### PR TITLE
Add confirm dialogue for destructive commands

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -11,13 +11,22 @@ import (
 
 // Standard flags for path expression parts.
 var (
-	stdOrgFlag      = orgFlag("Use this organization.", true)
-	stdProjectFlag  = projectFlag("Use this project.", true)
-	stdEnvFlag      = envFlag("Use this environment.", true)
-	stdServiceFlag  = serviceFlag("Use this service.", "", true)
-	stdUserFlag     = userFlag("Use this user.", true)
-	stdInstanceFlag = instanceFlag("Use this instance.", true)
+	stdOrgFlag        = orgFlag("Use this organization.", true)
+	stdProjectFlag    = projectFlag("Use this project.", true)
+	stdEnvFlag        = envFlag("Use this environment.", true)
+	stdServiceFlag    = serviceFlag("Use this service.", "", true)
+	stdUserFlag       = userFlag("Use this user.", true)
+	stdInstanceFlag   = instanceFlag("Use this instance.", true)
+	stdAutoAcceptFlag = autoAcceptFlag()
 )
+
+// autoAcceptFlag creates a new --yes cli.BoolFlag
+func autoAcceptFlag() cli.Flag {
+	return cli.BoolFlag{
+		Name:  "yes, y",
+		Usage: "Automatically accept confirmation dialogues.",
+	}
+}
 
 // orgFlag creates a new --org cli.Flag with custom usage string.
 func orgFlag(usage string, required bool) cli.Flag {

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/urfave/cli"
 
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/errs"
 	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/prefs"
 	"github.com/manifoldco/torus-cli/promptui"
 )
 
@@ -34,6 +36,36 @@ func validateInviteCode(input string) error {
 		return nil
 	}
 	return promptui.NewValidationError("Please enter a valid invite code")
+}
+
+// ConfirmDialogue prompts the user to confirm their action
+func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string) error {
+	preferences, err := prefs.NewPreferences(true)
+	if err != nil {
+		return err
+	}
+	if ctx.Bool("yes") || preferences.Core.AutoConfirm {
+		return nil
+	}
+
+	label := "Do you wish to continue"
+	if labelOverride != nil {
+		label = *labelOverride
+	}
+
+	warning := "The action you are about to perform cannot be undone."
+	if warningOverride != nil {
+		warning = *warningOverride
+	}
+
+	prompt := promptui.Prompt{
+		Label:     label,
+		IsConfirm: true,
+		Preamble:  &warning,
+	}
+
+	_, err = prompt.Run()
+	return err
 }
 
 // NamePrompt prompts the user to input a person's name

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -47,6 +47,7 @@ type Core struct {
 	CABundleFile  string `ini:"ca_bundle_file,omitempty"`
 	RegistryURI   string `ini:"registry_uri,omitempty"`
 	Context       bool   `ini:"context,omitempty"`
+	AutoConfirm   bool   `ini:"auto_confirm,omitempty"`
 }
 
 // Defaults contains default values for use in command argument flags

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -80,8 +80,17 @@ func (prefs Preferences) SetValue(key string, value string) (Preferences, error)
 		return prefs, errs.NewExitError("error: unknown property `" + key + "`")
 	}
 
-	// Set the string value
-	field.SetString(value)
+	switch field.Type() {
+	case reflect.TypeOf(true):
+		v := true
+		if value != "true" && value != "1" {
+			v = false
+		}
+		field.SetBool(v)
+	default:
+		field.SetString(value)
+	}
+
 	return prefs, nil
 }
 

--- a/promptui/promptui.go
+++ b/promptui/promptui.go
@@ -10,6 +10,9 @@ var ErrEOF = errors.New("^D")
 // encountered.
 var ErrInterrupt = errors.New("^C")
 
+// ErrAbort is returned when confirm prompts are supplied "n"
+var ErrAbort = errors.New("")
+
 // ValidateFunc validates the given input. It should return a ValidationError
 // if the input is not valid.
 type ValidateFunc func(string) error


### PR DESCRIPTION
This prevents users from accidentally destroying something unintended.

Right now our only destructive command is `unset`

### Basic usage:

```
> torus unset testunset
You are about to unset "/jeff/all-projects/dev-jeff/default/*/*". This cannot be undone.
✗ Do you wish to continue? [Y/n] n

> torus unset testunset
You are about to unset "/jeff/all-projects/dev-jeff/default/*/*". This cannot be undone.
✔ Do you wish to continue? [Y/n] Y
Credentials retrieved
Keypairs retrieved
Encrypting key retrieved
Credential encrypted
Completed Operation

Credential testunset has been unset at /jeff/all-projects/dev-jeff/default/*/*/testunset.
```
### Yes flag
```
> torus set testunset 1234 -y
Credentials retrieved
Keypairs retrieved
Encrypting key retrieved
Credential encrypted
Completed Operation

Credential testunset has been set at /jeff/all-projects/dev-jeff/default/*/*/testunset
```
### Auto confirm pref
```
> torus prefs set core.auto_confirm true
Preferences updated.

> torus set testunset 1234
Credentials retrieved
Keypairs retrieved
Encrypting key retrieved
Credential encrypted
Completed Operation

Credential testunset has been set at /jeff/all-projects/dev-jeff/default/*/*/testunset
```