### PR TITLE
Machines Create

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -23,6 +23,7 @@ type Client struct {
 
 	Orgs         *OrgsClient
 	Users        *UsersClient
+	Machines     *MachinesClient
 	Profiles     *ProfilesClient
 	Teams        *TeamsClient
 	Memberships  *MembershipsClient
@@ -52,6 +53,7 @@ func NewClient(cfg *config.Config) *Client {
 
 	c.Orgs = &OrgsClient{client: c}
 	c.Users = &UsersClient{client: c}
+	c.Machines = &MachinesClient{client: c}
 	c.Profiles = &ProfilesClient{client: c}
 	c.Teams = &TeamsClient{client: c}
 	c.Memberships = &MembershipsClient{client: c}

--- a/api/machines.go
+++ b/api/machines.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/base64"
+	"github.com/manifoldco/torus-cli/identity"
+)
+
+const tokenSecretSize = 18
+
+// MachinesClient makes requests to the Daemon on behalf of the user to
+// manipualte Machine resources.
+type MachinesClient struct {
+	client *Client
+}
+
+// Create a new machine in the given org
+func (m *MachinesClient) Create(ctx context.Context, orgID, teamID *identity.ID,
+	name string, output *ProgressFunc) (*apitypes.MachineSegment, *base64.Value, error) {
+
+	secret, err := createTokenSecret()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mcr := apitypes.MachinesCreateRequest{
+		Name:   name,
+		OrgID:  orgID,
+		TeamID: teamID,
+		Secret: secret,
+	}
+
+	req, reqID, err := m.client.NewRequest("POST", "/machines", nil, &mcr, false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := &apitypes.MachineSegment{}
+	_, err = m.client.Do(ctx, req, result, &reqID, output)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result, secret, nil
+}
+
+func createTokenSecret() (*base64.Value, error) {
+	value := make([]byte, tokenSecretSize)
+	_, err := rand.Read(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return base64.NewValue(value), nil
+}

--- a/apitypes/claimtree.go
+++ b/apitypes/claimtree.go
@@ -1,0 +1,12 @@
+package apitypes
+
+import (
+	"github.com/manifoldco/torus-cli/envelope"
+)
+
+// PublicKeySegment represents a sub section of a claimtree targeting a
+// specific public key and it's claims.
+type PublicKeySegment struct {
+	Key    *envelope.Signed  `json:"public_key"`
+	Claims []envelope.Signed `json:"claims"`
+}

--- a/apitypes/machines.go
+++ b/apitypes/machines.go
@@ -1,0 +1,35 @@
+package apitypes
+
+import (
+	"github.com/manifoldco/torus-cli/base64"
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
+)
+
+// MachineSegment represents a machine, its tokens, and their connected keypairs
+type MachineSegment struct {
+	Machine *struct {
+		ID   *identity.ID       `json:"id"`
+		Body *primitive.Machine `json:"body"`
+	} `json:"machine"`
+	Memberships []*struct {
+		ID   *identity.ID          `json:"id"`
+		Body *primitive.Membership `json:"body"`
+	} `json:"memberships"`
+	Tokens []*struct {
+		Token *struct {
+			ID   *identity.ID            `json:"id"`
+			Body *primitive.MachineToken `json:"body"`
+		} `json:"token"`
+		Keypairs []PublicKeySegment `json:"keypairs"`
+	} `json:"tokens"`
+}
+
+// MachinesCreateRequest represents a request by a client to create a machine
+// for a specific org, team using the given name and secret.
+type MachinesCreateRequest struct {
+	Name   string        `json:"name"`
+	OrgID  *identity.ID  `json:"org_id"`
+	TeamID *identity.ID  `json:"team_id"`
+	Secret *base64.Value `json:"secret"`
+}

--- a/base64/base64.go
+++ b/base64/base64.go
@@ -24,6 +24,10 @@ func (bv *Value) MarshalJSON() ([]byte, error) {
 	return []byte("\"" + base64.RawURLEncoding.EncodeToString(*bv) + "\""), nil
 }
 
+func (bv *Value) String() string {
+	return base64.RawURLEncoding.EncodeToString(*bv)
+}
+
 // UnmarshalJSON sets bv to the bytes represented in the base64url encoding b.
 func (bv *Value) UnmarshalJSON(b []byte) error {
 	if len(b) < 2 || b[0] != byte('"') || b[len(b)-1] != byte('"') {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -58,6 +58,11 @@ func instanceFlag(usage string, required bool) cli.Flag {
 	return newPlaceholder("instance, i", "INSTANCE", usage, "1", "TORUS_INSTANCE", required)
 }
 
+// teamFlag creates a new --team cli.Flag with custom usage string.
+func teamFlag(usage string, required bool) cli.Flag {
+	return newPlaceholder("team, t", "TEAM", usage, "", "TORUS_TEAM", required)
+}
+
 // placeHolderStringSliceFlag is a StringSliceFlag that has been extended to use a
 // specific placedholder value in the usage, without parsing it out of the
 // usage string.

--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/torus-cli/api"
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/base32"
+	"github.com/manifoldco/torus-cli/base64"
+	"github.com/manifoldco/torus-cli/config"
+	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
+)
+
+const (
+	machineRandomIDLength = 5 // 8 characters in base32
+	machineCreateFailed   = "Could not create machine, please try again."
+)
+
+func init() {
+	machines := cli.Command{
+		Name:     "machines",
+		Usage:    "Manage machine for an organization",
+		Category: "ORGANIZATIONS",
+		Subcommands: []cli.Command{
+			{
+				Name:  "create",
+				Usage: "Create a machine for an organization",
+				Flags: []cli.Flag{
+					orgFlag("the org the machine will belong to", false),
+					teamFlag("the team the machine will belong to", false),
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					setUserEnv, checkRequiredFlags, createMachine,
+				),
+			},
+		},
+	}
+	Cmds = append(Cmds, machines)
+}
+
+func createMachine(ctx *cli.Context) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(cfg)
+	c := context.Background()
+
+	org, orgName, newOrg, err := SelectCreateOrg(c, client, ctx.String("org"))
+	if err != nil {
+		return handleSelectError(err, "Org selection failed.")
+	}
+
+	var orgID *identity.ID
+	if !newOrg {
+		if org == nil {
+			return errs.NewExitError("Org not found.")
+		}
+		orgID = org.ID
+	}
+
+	team, teamName, newTeam, err := SelectCreateTeam(
+		c, client, orgID, primitive.MachineTeam, ctx.String("team"))
+	if err != nil {
+		return handleSelectError(err, "Team selection failed.")
+	}
+
+	var teamID *identity.ID
+	if !newTeam {
+		if org == nil {
+			return errs.NewExitError("Team not found.")
+		}
+		teamID = team.ID
+	}
+
+	args := ctx.Args()
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+
+	name, err = promptForMachineName(name, teamName)
+	fmt.Println()
+	if err != nil {
+		return errs.NewErrorExitError(machineCreateFailed, err)
+	}
+
+	if newOrg {
+		org, err := client.Orgs.Create(c, orgName)
+		if err != nil {
+			return errs.NewErrorExitError("Could not create org", err)
+		}
+
+		orgID = org.ID
+		err = generateKeypairsForOrg(c, ctx, client, org.ID, false)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Org %s created.\n\n", orgName)
+	}
+
+	if newTeam {
+		team, err := client.Teams.Create(c, orgID, teamName, primitive.MachineTeam)
+		if err != nil {
+			return errs.NewErrorExitError("Could not create machine team", err)
+		}
+
+		teamID = team.ID
+		fmt.Printf("Machine team %s created for org %s.\n\n", teamName, orgName)
+	}
+
+	machine, tokenSecret, err := createMachineByName(c, client, orgID, teamID, name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print("\nYou will only be shown the secret once, please keep it safe.\n\n")
+
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
+
+	tokenID := machine.Tokens[0].Token.ID
+	fmt.Fprintf(w, "Machine ID:\t%s\n", machine.Machine.ID)
+	fmt.Fprintf(w, "Machine Token ID:\t%s\n", tokenID)
+	fmt.Fprintf(w, "Machine Token Secret:\t%s\n", tokenSecret)
+
+	w.Flush()
+	return err
+}
+
+func createMachineByName(c context.Context, client *api.Client,
+	orgID, teamID *identity.ID, name string) (*apitypes.MachineSegment, *base64.Value, error) {
+
+	machine, tokenSecret, err := client.Machines.Create(
+		c, orgID, teamID, name, &progress)
+	if err != nil {
+		if strings.Contains(err.Error(), "resource exists") {
+			return nil, nil, errs.NewExitError("Machine already exists")
+		}
+
+		return nil, nil, errs.NewErrorExitError(
+			"Could not create machine, please try again.", err)
+	}
+
+	return machine, tokenSecret, nil
+}
+
+func promptForMachineName(providedName, teamName string) (string, error) {
+	defaultName, err := deriveMachineName(teamName)
+	if err != nil {
+		return "", errs.NewErrorExitError("Could not derive machine name", err)
+	}
+
+	name := ""
+	if providedName == "" {
+		name = defaultName
+	} else {
+		name = providedName
+	}
+
+	label := "Enter machine name"
+	autoAccept := providedName != ""
+	return NamePrompt(&label, name, autoAccept)
+}
+
+func deriveMachineName(teamName string) (string, error) {
+	value := make([]byte, machineRandomIDLength)
+	_, err := rand.Read(value)
+	if err != nil {
+		return "", err
+	}
+
+	name := teamName + "-" + base32.EncodeToString(value)
+	return name, nil
+}

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -174,7 +174,8 @@ func handleSelectError(err error, generic string) error {
 	if err == promptui.ErrEOF || err == promptui.ErrInterrupt {
 		return err
 	}
-	return errs.NewExitError(generic)
+
+	return errs.NewErrorExitError(generic, err)
 }
 
 // SelectCreateProject prompts the user to select a project from at list of projects
@@ -193,7 +194,7 @@ func SelectCreateProject(c context.Context, client *api.Client, orgID *identity.
 		// Get the list of projects the user has access to in the specified org
 		projects, err = listProjects(&c, client, orgID, nil)
 		if err != nil {
-			return nil, "", false, errs.NewExitError("Error fetching projects list.")
+			return nil, "", false, err
 		}
 	}
 
@@ -239,7 +240,7 @@ func SelectCreateOrg(c context.Context, client *api.Client, name string) (*api.O
 	// Get the list of orgs the user has access to
 	orgs, err := client.Orgs.List(c)
 	if err != nil {
-		return nil, "", false, errs.NewExitError("Error fetching orgs list")
+		return nil, "", false, err
 	}
 
 	var idx int

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -337,7 +337,7 @@ func createTeamCmd(ctx *cli.Context) error {
 
 	// Create our new team
 	fmt.Println("")
-	err = client.Teams.Create(c, orgID, teamName)
+	_, err = client.Teams.Create(c, orgID, teamName, "")
 	if err != nil {
 		if strings.Contains(err.Error(), "resource exists") {
 			return errs.NewExitError("Team already exists")

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -158,16 +158,23 @@ func teamsListCmd(ctx *cli.Context) error {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
 	for _, t := range teams {
 		isMember := ""
-		teamType := ""
-		if t.Body.TeamType == primitive.SystemTeam {
-			teamType = "[system]"
+		displayTeamType := ""
+
+		switch teamType := t.Body.TeamType; teamType {
+		case primitive.SystemTeam:
+			displayTeamType = "[system]"
+			if t.Body.Name == "machine" {
+				displayTeamType += " (machine)"
+			}
+		case primitive.MachineTeam:
+			displayTeamType = "(machine)"
 		}
 
 		if _, ok := memberOf[*t.ID]; ok {
 			isMember = "*"
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\n", isMember, t.Body.Name, teamType)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", isMember, t.Body.Name, displayTeamType)
 	}
 
 	w.Flush()

--- a/daemon/logic/engine.go
+++ b/daemon/logic/engine.go
@@ -34,6 +34,7 @@ type Engine struct {
 	client  *registry.Client
 
 	Worklog Worklog
+	Machine Machine
 }
 
 // NewEngine returns a new Engine
@@ -47,6 +48,7 @@ func NewEngine(c *config.Config, s session.Session, db *db.DB, e *crypto.Engine,
 		client:  client,
 	}
 	engine.Worklog = Worklog{engine: engine}
+	engine.Machine = Machine{engine: engine}
 	return engine
 }
 
@@ -344,7 +346,7 @@ func (e *Engine) ApproveInvite(ctx context.Context, notifier *observer.Notifier,
 
 	n.Notify(observer.Progress, "Invite retrieved", true)
 
-	v1members, v2members, err := createKeyringMemberships(ctx, e.crypto, n,
+	v1members, v2members, err := createKeyringMemberships(ctx, e.crypto,
 		e.client, e.session, inviteBody.OrgID, inviteBody.InviteeID)
 	if err != nil {
 		return nil, err

--- a/daemon/logic/machine.go
+++ b/daemon/logic/machine.go
@@ -1,0 +1,197 @@
+package logic
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/base64"
+	"github.com/manifoldco/torus-cli/daemon/crypto"
+	"github.com/manifoldco/torus-cli/daemon/observer"
+	"github.com/manifoldco/torus-cli/daemon/registry"
+	"github.com/manifoldco/torus-cli/daemon/session"
+	"github.com/manifoldco/torus-cli/envelope"
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
+)
+
+// Machine represents the business logic for managing machines
+type Machine struct {
+	engine *Engine
+}
+
+// MachineTokenSegment represents a Token and it's associated Keypair
+type MachineTokenSegment struct {
+	Token   *envelope.Unsigned       `json:"token"`
+	Keypair *registry.ClaimedKeyPair `json:"keypair"`
+}
+
+// CreateToken generates a new machine token given a machine and a secret value.
+func (m *Machine) CreateToken(ctx context.Context, notifier *observer.Notifier,
+	machine *envelope.Unsigned, secret *base64.Value) (*registry.MachineTokenCreationSegment, error) {
+	n := notifier.Notifier(2)
+
+	n.Notify(observer.Progress, "Generating machine token", true)
+	salt, err := crypto.GenerateSalt(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	keypair, err := crypto.DeriveLoginKeypair(ctx, secret, salt)
+	if err != nil {
+		return nil, err
+	}
+
+	machineBody, ok := machine.Body.(*primitive.Machine)
+	if !ok {
+		return nil, &apitypes.Error{
+			Type: apitypes.InternalServerError,
+			Err:  []string{"Could not cast to Machine"},
+		}
+	}
+	orgID := machineBody.OrgID
+
+	masterKey, err := crypto.CreateMasterKeyObject(ctx, secret.String())
+	if err != nil {
+		return nil, err
+	}
+
+	tokenBody := &primitive.MachineToken{
+		OrgID:     orgID,
+		MachineID: machine.ID,
+		PublicKey: &primitive.MachineTokenPublicKey{
+			Salt:  keypair.Salt(),
+			Value: keypair.PublicKey(),
+			Alg:   crypto.EdDSA,
+		},
+		Master:      masterKey,
+		CreatedBy:   m.engine.session.ID(),
+		Created:     time.Now().UTC(),
+		DestroyedBy: nil,
+		Destroyed:   nil,
+		State:       primitive.MachineTokenActiveState,
+	}
+	tokenID, err := identity.NewMutable(tokenBody)
+	if err != nil {
+		return nil, err
+	}
+
+	token := &envelope.Unsigned{
+		ID:      &tokenID,
+		Version: 1,
+		Body:    tokenBody,
+	}
+
+	// Create an "empty" machine session in order to create a Crypto engine on
+	// behalf of the machine for deriving and uploading these keys.
+	sess := session.NewSession()
+	err = sess.Set(session.MachineSession, machine, token, secret.String(), "asdfsdf")
+	if err != nil {
+		return nil, err
+	}
+	c := crypto.NewEngine(sess)
+
+	n.Notify(observer.Progress, "Generating token keypairs", true)
+	kp, err := c.GenerateKeyPairs(ctx)
+	if err != nil {
+		log.Printf("Error generating machine keypairs: %s", err)
+		return nil, err
+	}
+
+	authID := sess.AuthID()
+	keypairs, err := generateKeypairs(ctx, c, orgID, authID, kp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &registry.MachineTokenCreationSegment{
+		Token:    token,
+		Keypairs: keypairs,
+	}, nil
+}
+
+// EncodeToken creates KeyringMemberships for the provided Machine Token. Used
+// during the machine creation process
+func (m *Machine) EncodeToken(ctx context.Context, notifier *observer.Notifier,
+	token *envelope.Unsigned) error {
+
+	n := notifier.Notifier(2)
+
+	n.Notify(observer.Progress, "Creating keyring memberships for token", true)
+
+	tokenBody, ok := token.Body.(*primitive.MachineToken)
+	if !ok {
+		return errors.New("Could not cast token to MachineToken")
+	}
+
+	v1members, v2members, err := createKeyringMemberships(ctx, m.engine.crypto,
+		m.engine.client, m.engine.session, tokenBody.OrgID, token.ID)
+	if err != nil {
+		return err
+	}
+
+	n.Notify(observer.Progress, "Uploading keyring memberships", true)
+
+	if len(v1members) != 0 {
+		_, err = m.engine.client.KeyringMember.Post(ctx, v1members)
+		if err != nil {
+			log.Printf("error uploading memberships: %s", err)
+			return err
+		}
+	}
+
+	for _, member := range v2members {
+		err = m.engine.client.Keyring.Members.Post(ctx, member)
+		if err != nil {
+			log.Printf("error uploading memberships: %s", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func generateKeypairs(ctx context.Context, c *crypto.Engine, orgID, authID *identity.ID,
+	kp *crypto.KeyPairs) ([]*registry.ClaimedKeyPair, error) {
+
+	pubsig, privsig, err := packageSigningKeypair(ctx, c, authID, orgID, kp)
+	if err != nil {
+		log.Printf("Error packaging machine signing keypair: %s", err)
+		return nil, err
+	}
+
+	rawsigClaim := primitive.NewClaim(orgID, authID, pubsig.ID, pubsig.ID, primitive.SignatureClaimType)
+	sigclaim, err := c.SignedEnvelope(ctx, rawsigClaim, pubsig.ID, &kp.Signature)
+	if err != nil {
+		log.Printf("Error generating signature claim: %s", err)
+		return nil, err
+	}
+
+	pubenc, privenc, err := packageEncryptionKeypair(ctx, c, authID, orgID, kp, pubsig)
+	if err != nil {
+		log.Printf("Error packaging machine encryption keypair: %s", err)
+		return nil, err
+	}
+
+	rawencClaim := primitive.NewClaim(orgID, authID, pubenc.ID, pubenc.ID, primitive.SignatureClaimType)
+	encclaim, err := c.SignedEnvelope(ctx, rawencClaim, pubsig.ID, &kp.Signature)
+	if err != nil {
+		log.Printf("Error generating encryption claim: %s", err)
+		return nil, err
+	}
+
+	return []*registry.ClaimedKeyPair{
+		{
+			PublicKey:  pubsig,
+			PrivateKey: privsig,
+			Claims:     []envelope.Signed{*sigclaim},
+		},
+		{
+			PublicKey:  pubenc,
+			PrivateKey: privenc,
+			Claims:     []envelope.Signed{*encclaim},
+		},
+	}, nil
+}

--- a/daemon/logic/utils.go
+++ b/daemon/logic/utils.go
@@ -17,7 +17,6 @@ import (
 	"github.com/manifoldco/torus-cli/primitive"
 
 	"github.com/manifoldco/torus-cli/daemon/crypto"
-	"github.com/manifoldco/torus-cli/daemon/observer"
 	"github.com/manifoldco/torus-cli/daemon/registry"
 	"github.com/manifoldco/torus-cli/daemon/session"
 )
@@ -219,11 +218,8 @@ func newV2KeyringMember(ctx context.Context, engine *crypto.Engine,
 	}, nil
 }
 
-func createKeyringMemberships(ctx context.Context, c *crypto.Engine, notifier *observer.Notifier,
-	client *registry.Client, s session.Session, orgID, ownerID *identity.ID) (
-	[]envelope.Signed, []registry.KeyringMember, error) {
-
-	n := notifier.Notifier(3)
+func createKeyringMemberships(ctx context.Context, c *crypto.Engine, client *registry.Client,
+	s session.Session, orgID, ownerID *identity.ID) ([]envelope.Signed, []registry.KeyringMember, error) {
 
 	// Get this users keypairs
 	sigID, encID, kp, err := fetchKeyPairs(ctx, client, orgID)
@@ -231,8 +227,6 @@ func createKeyringMemberships(ctx context.Context, c *crypto.Engine, notifier *o
 		log.Printf("could not fetch keypairs for org: %s", err)
 		return nil, nil, err
 	}
-
-	n.Notify(observer.Progress, "Keypairs retrieved", true)
 
 	claimTrees, err := client.ClaimTree.List(ctx, orgID, nil)
 	if err != nil {
@@ -249,8 +243,6 @@ func createKeyringMemberships(ctx context.Context, c *crypto.Engine, notifier *o
 			},
 		}
 	}
-
-	n.Notify(observer.Progress, "Claims retrieved", true)
 
 	// Get all the keyrings and memberships for the current user. This way we
 	// can decrypt the MEK for each and then create a new KeyringMember for
@@ -296,8 +288,6 @@ func createKeyringMemberships(ctx context.Context, c *crypto.Engine, notifier *o
 	if err != nil {
 		return nil, nil, err
 	}
-
-	n.Notify(observer.Progress, "Keyrings retrieved", true)
 
 	v1members := []envelope.Signed{}
 	v2members := []registry.KeyringMember{}

--- a/daemon/logic/worklog.go
+++ b/daemon/logic/worklog.go
@@ -39,7 +39,7 @@ func (w *Worklog) List(ctx context.Context, orgID *identity.ID) ([]apitypes.Work
 	for _, project := range projects {
 		projName := project.Body.(*primitive.Project).Name
 		graphs, err := w.engine.client.CredentialGraph.Search(ctx,
-			"/"+orgName+"/"+projName+"/*/*/*/*", w.engine.session.ID())
+			"/"+orgName+"/"+projName+"/*/*/*/*", w.engine.session.AuthID())
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/registry/claimtree.go
+++ b/daemon/registry/claimtree.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 
+	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/envelope"
 	"github.com/manifoldco/torus-cli/identity"
 )
@@ -18,15 +19,8 @@ type ClaimTreeClient struct {
 // ClaimTree represents an organizations claim tree which contains public
 // signing and encryption keys for every member.
 type ClaimTree struct {
-	Org        *envelope.Unsigned `json:"org"`
-	PublicKeys []PublicKeySegment `json:"public_keys"`
-}
-
-// PublicKeySegment represents a sub section of a claimtree targeting a
-// specific public key and it's claims.
-type PublicKeySegment struct {
-	Key    *envelope.Signed  `json:"public_key"`
-	Claims []envelope.Signed `json:"claims"`
+	Org        *envelope.Unsigned          `json:"org"`
+	PublicKeys []apitypes.PublicKeySegment `json:"public_keys"`
 }
 
 // List returns a list of all claimtrees for a given orgID. If no orgID is

--- a/daemon/registry/client.go
+++ b/daemon/registry/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	KeyringMember   *KeyringMemberClientV1
 	ClaimTree       *ClaimTreeClient
 	CredentialGraph *CredentialGraphClient
+	Machines        *MachinesClient
 }
 
 // NewClient returns a new Client.
@@ -62,6 +63,7 @@ func NewClient(prefix string, apiVersion string, version string, sess session.Se
 	c.Keyring.Members = &KeyringMembersClient{client: c}
 	c.KeyringMember = &KeyringMemberClientV1{client: c}
 	c.CredentialGraph = &CredentialGraphClient{client: c}
+	c.Machines = &MachinesClient{client: c}
 
 	return c
 }

--- a/daemon/registry/machines.go
+++ b/daemon/registry/machines.go
@@ -1,0 +1,59 @@
+package registry
+
+import (
+	"context"
+	"log"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/envelope"
+)
+
+// MachinesClient represents the `/machines` registry endpoint, used for
+// creating, listing, authorizing, and destroying machines and their tokens.
+type MachinesClient struct {
+	client *Client
+}
+
+// MachineCreationSegment represents the request sent to create the registry to
+// create a machine and it's first token
+type MachineCreationSegment struct {
+	Machine     *envelope.Unsigned            `json:"machine"`
+	Memberships []envelope.Unsigned           `json:"memberships"`
+	Tokens      []MachineTokenCreationSegment `json:"tokens"`
+}
+
+// MachineTokenCreationSegment represents the request send to the registry to
+// create a Machine Token
+type MachineTokenCreationSegment struct {
+	Token    *envelope.Unsigned `json:"token"`
+	Keypairs []*ClaimedKeyPair  `json:"keypairs"`
+}
+
+// Create requests the registry to create a MachineSegment.
+//
+// The MachineSegment includes the Machine, it's Memberships, and authorization
+// tokens.
+func (m *MachinesClient) Create(ctx context.Context, machine *envelope.Unsigned,
+	memberships []envelope.Unsigned, token *MachineTokenCreationSegment) (*apitypes.MachineSegment, error) {
+
+	segment := MachineCreationSegment{
+		Machine:     machine,
+		Memberships: memberships,
+		Tokens:      []MachineTokenCreationSegment{*token},
+	}
+
+	req, err := m.client.NewRequest("POST", "/machines", nil, &segment)
+	if err != nil {
+		log.Printf("Error building POST Machines Request: %s", err)
+		return nil, err
+	}
+
+	resp := &apitypes.MachineSegment{}
+	_, err = m.client.Do(ctx, req, resp)
+	if err != nil {
+		log.Printf("Failed to create machine: %s", err)
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/daemon/registry/users.go
+++ b/daemon/registry/users.go
@@ -122,7 +122,7 @@ type SignupBody struct {
 	Email    string `json:"email"`
 	// State is not a field because the server determines it, client cannot
 	Password *primitive.UserPassword `json:"password"`
-	Master   *primitive.UserMaster   `json:"master"`
+	Master   *primitive.MasterKey    `json:"master"`
 }
 
 // Version returns the object version

--- a/daemon/routes/machines.go
+++ b/daemon/routes/machines.go
@@ -1,0 +1,136 @@
+package routes
+
+// This file contains routes related to keypairs
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/daemon/logic"
+	"github.com/manifoldco/torus-cli/daemon/observer"
+	"github.com/manifoldco/torus-cli/daemon/registry"
+	"github.com/manifoldco/torus-cli/daemon/session"
+	"github.com/manifoldco/torus-cli/envelope"
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
+)
+
+func machinesCreateRoute(client *registry.Client, session session.Session,
+	engine *logic.Engine, o *observer.Observer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		dec := json.NewDecoder(r.Body)
+		req := apitypes.MachinesCreateRequest{}
+		err := dec.Decode(&req)
+		if err != nil {
+			log.Printf("Error decoding request: %s", err)
+			encodeResponseErr(w, err)
+			return
+		}
+
+		n, err := o.Notifier(ctx, 3)
+		if err != nil {
+			log.Printf("Error creating Notifier: %s", err)
+			encodeResponseErr(w, err)
+			return
+		}
+
+		msg := fmt.Sprintf("Creating machine \"%s\"", req.Name)
+		n.Notify(observer.Progress, msg, true)
+
+		machine, memberships, err := createMachine(req.OrgID, req.TeamID, session.ID(), req.Name)
+		if err != nil {
+			log.Printf("Error creating machine %s: %s", req.Name, err)
+			encodeResponseErr(w, err)
+			return
+		}
+
+		token, err := engine.Machine.CreateToken(ctx, n, machine, req.Secret)
+		if err != nil {
+			log.Printf("Error creating machine token: %s", err)
+			encodeResponseErr(w, err)
+			return
+		}
+
+		n.Notify(observer.Progress, "Uploading token keypairs", true)
+
+		segment, err := client.Machines.Create(ctx, machine, memberships, token)
+		if err != nil {
+			log.Printf("Error creating machine with registry: %s", err)
+			encodeResponseErr(w, err)
+			return
+		}
+
+		err = engine.Machine.EncodeToken(ctx, n, token.Token)
+		if err != nil {
+			log.Printf("Error encoding token into keyrings: %s", err)
+			encodeResponseErr(w, err)
+			return
+		}
+
+		n.Notify(observer.Finished, "Machine created", true)
+
+		enc := json.NewEncoder(w)
+		err = enc.Encode(segment)
+		if err != nil {
+			log.Printf("Error encoding MachineSegment: %s", err)
+			encodeResponseErr(w, err)
+			return
+		}
+	}
+}
+
+// createMachine generates a Machine object and associated Membership objects
+// to be uploaded to the registry in the future.
+func createMachine(orgID, teamID, creatorID *identity.ID, name string) (
+	*envelope.Unsigned, []envelope.Unsigned, error) {
+
+	machineBody := &primitive.Machine{
+		Name:        name,
+		OrgID:       orgID,
+		CreatedBy:   creatorID,
+		Created:     time.Now().UTC(),
+		DestroyedBy: nil,
+		Destroyed:   nil,
+		State:       primitive.MachineActiveState,
+	}
+	machineID, err := identity.NewMutable(machineBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	machine := envelope.Unsigned{
+		ID:      &machineID,
+		Version: 1,
+		Body:    machineBody,
+	}
+
+	machineTeamID := identity.DeriveMutable(&primitive.Team{}, orgID, primitive.DerivableMachineTeamSymbol)
+	teamIDList := []*identity.ID{&machineTeamID, teamID}
+	memberships := []envelope.Unsigned{}
+	for _, curTeamID := range teamIDList {
+		body := primitive.Membership{
+			OwnerID: &machineID,
+			OrgID:   orgID,
+			TeamID:  curTeamID,
+		}
+
+		ID, err := identity.NewMutable(&body)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		membership := envelope.Unsigned{
+			ID:      &ID,
+			Version: 1,
+			Body:    &body,
+		}
+		memberships = append(memberships, membership)
+	}
+
+	return &machine, memberships, nil
+}

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -36,6 +36,7 @@ func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
 	mux.PostFunc("/logout", logoutRoute(client, s))
 	mux.GetFunc("/session", sessionRoute(s))
 
+	mux.PostFunc("/machines", machinesCreateRoute(client, s, lEngine, o))
 	mux.PostFunc("/keypairs/generate", keypairsGenerateRoute(lEngine, o))
 
 	mux.GetFunc("/credentials", credentialsGetRoute(lEngine, o))

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -22,7 +22,7 @@ import (
 func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
 	t *http.Transport, o *observer.Observer) *bone.Mux {
 
-	cryptoEngine := crypto.NewEngine(s, db)
+	cryptoEngine := crypto.NewEngine(s)
 	client := registry.NewClient(c.RegistryURI.String(), c.APIVersion,
 		c.Version, s, t)
 	lEngine := logic.NewEngine(c, s, db, cryptoEngine, client)

--- a/daemon/routes/session.go
+++ b/daemon/routes/session.go
@@ -163,8 +163,8 @@ func signupRoute(client *registry.Client, s session.Session, db *db.DB) http.Han
 			Username: signup.Username,
 			Name:     signup.Name,
 			Email:    signup.Email,
-			Password: &passwordObj,
-			Master:   &masterObj,
+			Password: passwordObj,
+			Master:   masterObj,
 		}
 
 		ID, err := identity.NewMutable(&userBody)

--- a/daemon/routes/session.go
+++ b/daemon/routes/session.go
@@ -73,8 +73,7 @@ func attemptLogin(ctx context.Context, client *registry.Client, s session.Sessio
 	}
 
 	db.Set(self)
-	s.Set(self.ID, creds.Passphrase, authToken)
-	return nil
+	return s.Set("user", self, self, creds.Passphrase, authToken)
 }
 
 func logoutRoute(client *registry.Client, s session.Session) http.HandlerFunc {
@@ -102,11 +101,23 @@ func logoutRoute(client *registry.Client, s session.Session) http.HandlerFunc {
 				// In any case, the daemon has gotten out of sync with the
 				// server. Remove our local copy of the auth token.
 				log.Printf("Got 4XX removing auth token. Treating as success")
-				s.Logout()
+				logoutErr := s.Logout()
+				if logoutErr != nil {
+					log.Printf("Error while attempting to destroy session: %s", logoutErr)
+					encodeResponseErr(w, logoutErr)
+					break
+				}
+
 				w.WriteHeader(http.StatusNoContent)
 			}
 		case nil:
-			s.Logout()
+			logoutErr := s.Logout()
+			if logoutErr != nil {
+				log.Printf("Error while attempting to destroy session: %s", logoutErr)
+				encodeResponseErr(w, logoutErr)
+				break
+			}
+
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			encodeResponseErr(w, err)

--- a/daemon/routes/types.go
+++ b/daemon/routes/types.go
@@ -11,6 +11,11 @@ type keyPairGenerate struct {
 	OrgID *identity.ID `json:"org_id"`
 }
 
+type machineCreate struct {
+	Name  string       `json:"name"`
+	OrgID *identity.ID `json:"org_id"`
+}
+
 type errorMsg struct {
 	Type  apitypes.ErrorType `json:"type"`
 	Error []string           `json:"error"`

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -6,44 +6,154 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/base64"
+	"github.com/manifoldco/torus-cli/envelope"
 	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
 )
 
-type memorySession struct {
-	id *identity.ID
+// A session can represent either a machine or a user
+const (
+	MachineSession = "machine"
+	UserSession    = "user"
+	NotLoggedIn    = "no_session"
+)
+
+const notLoggedInError = "Please login to perform that command"
+
+type session struct {
+	mutex       *sync.Mutex
+	sessionType string
+	identity    *envelope.Unsigned
+	auth        *envelope.Unsigned
 
 	// sensitive values
 	token      string
 	passphrase string
-	mutex      *sync.Mutex
 }
 
 // Session is the interface for access to secure session details.
 type Session interface {
-	Set(*identity.ID, string, string) error
+	Type() string
+	Set(string, *envelope.Unsigned, *envelope.Unsigned, string, string) error
 	ID() *identity.ID
+	AuthID() *identity.ID
 	Token() string
 	Passphrase() string
+	MasterKey() (*base64.Value, error)
 	HasToken() bool
 	HasPassphrase() bool
-	Logout()
+	Logout() error
 	String() string
 }
 
-// NewSession returns the default implementation of the Session interface.
+// NewSession returns the default implementation of the Session interface
+// for a user or machine depending on the passed type.
 func NewSession() Session {
-	return &memorySession{mutex: &sync.Mutex{}}
+	return &session{mutex: &sync.Mutex{}, sessionType: NotLoggedIn}
+}
+
+// Type returns the type of identity this session represents (e.g. user or
+// machine)
+func (s *session) Type() string {
+	return s.sessionType
+}
+
+// ID returns the ID representing the Identity providing object (e.g. user or
+// machine)
+func (s *session) ID() *identity.ID {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.identity == nil {
+		return nil
+	}
+
+	return s.identity.ID
+}
+
+// AuthID returns the ID representing the object used for authorization (e.g.
+// user or machine token).
+func (s *session) AuthID() *identity.ID {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.auth == nil {
+		return nil
+	}
+
+	return s.auth.ID
+}
+
+// Token returns the auth token stored in this session.
+func (s *session) Token() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.token
+}
+
+// Passphrase returns the user's passphrase.
+func (s *session) Passphrase() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.passphrase
+}
+
+func (s *session) HasToken() bool {
+	return (len(s.token) > 0)
+}
+
+func (s *session) HasPassphrase() bool {
+	return (len(s.passphrase) > 0)
+}
+
+// String implements the fmt.Stringer interface.
+func (s *session) String() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return fmt.Sprintf("Session{type:%s,token:%t,passphrase:%t}",
+		s.Type(), s.HasToken(), s.HasPassphrase())
 }
 
 // Set atomically sets all relevant session details.
 //
 // It returns an error if any values are empty.
-func (s *memorySession) Set(id *identity.ID, passphrase, token string) error {
+func (s *session) Set(sessionType string, identity, auth *envelope.Unsigned,
+	passphrase, token string) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if len(id) == 0 {
-		return errors.New("ID must not be empty")
+	if s.Type() != NotLoggedIn {
+		return errors.New("Cannot overwrite existing session")
+	}
+
+	if identity == nil || auth == nil {
+		return errors.New("identity and auth cannot be null")
+	}
+
+	switch sessionType {
+	case UserSession:
+		if _, ok := identity.Body.(*primitive.User); !ok {
+			return errors.New("Identity must be a user object")
+		}
+
+		if _, ok := auth.Body.(*primitive.User); !ok {
+			return errors.New("Auth must be a user object")
+		}
+	case MachineSession:
+		if _, ok := identity.Body.(*primitive.Machine); !ok {
+			return errors.New("Identity must be machine object")
+		}
+
+		if _, ok := auth.Body.(*primitive.MachineToken); !ok {
+			return errors.New("Auth must be a machine token object")
+		}
+	default:
+		panic("did not recognize session type")
 	}
 
 	if len(passphrase) == 0 {
@@ -54,59 +164,51 @@ func (s *memorySession) Set(id *identity.ID, passphrase, token string) error {
 		return errors.New("Token must not be empty")
 	}
 
-	s.id = id
+	s.sessionType = sessionType
 	s.passphrase = passphrase
 	s.token = token
+	s.identity = identity
+	s.auth = auth
 
 	return nil
 }
 
-func (s *memorySession) ID() *identity.ID {
+func createNotLoggedInError() error {
+	return &apitypes.Error{
+		Type: apitypes.UnauthorizedError,
+		Err:  []string{notLoggedInError},
+	}
+}
+
+// Returns the base64 representation of the identities encrypted master key
+func (s *session) MasterKey() (*base64.Value, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	return s.id
+	if s.Type() == NotLoggedIn {
+		return nil, createNotLoggedInError()
+	}
+
+	if s.Type() == UserSession {
+		return s.auth.Body.(*primitive.User).Master.Value, nil
+	}
+
+	return s.auth.Body.(*primitive.MachineToken).Master.Value, nil
 }
 
-// Token returns the auth token stored in this session.
-func (s *memorySession) Token() string {
+// Logout resets all values to the logged out state
+func (s *session) Logout() error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	return s.token
-}
+	if s.Type() == NotLoggedIn {
+		return createNotLoggedInError()
+	}
 
-// Passphrase returns the user's passphrase.
-func (s *memorySession) Passphrase() string {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	return s.passphrase
-}
-
-func (s *memorySession) HasToken() bool {
-	return (len(s.token) > 0)
-}
-
-func (s *memorySession) HasPassphrase() bool {
-	return (len(s.passphrase) > 0)
-}
-
-// Logout clears all details from the session.
-func (s *memorySession) Logout() {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	s.id = nil
+	s.sessionType = NotLoggedIn
+	s.identity = nil
+	s.auth = nil
 	s.token = ""
 	s.passphrase = ""
-}
-
-// String implements the fmt.Stringer interface.
-func (s *memorySession) String() string {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	return fmt.Sprintf(
-		"memorySession{token:%t,passphrase:%t}", s.HasToken(), s.HasPassphrase())
+	return nil
 }

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -100,6 +100,16 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 - [ ]   `torus ls "/*/*/*"` lists all services
 - [ ]   `torus ls "/$org/$proj/*/*"` lists all secrets for `/$org/$proj/*/*/*`
 
+### Machines
+
+- [ ] `torus teams list` displays the "machines" team for the org
+- [ ] `torus teams list` displays the "machine" teams in the org
+- [ ] Only admins and owners can create machines
+- [ ] `torus machines create` works with context
+- [ ] `torus machines create` supports flags (e.g. `-o, -t` etc)
+- [ ] `torus machines create` allows you to select an existing org and team
+- [ ] `torus machines create` allows you to create a new machine team
+
 ### Critical Path
 
 - [ ]   `torus orgs create [name]` prompts you to confirm the org name, and creates it

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -55,6 +55,14 @@ func NewMutable(body Mutable) (ID, error) {
 	return id, nil
 }
 
+// DeriveMutable returns a ID for a mutable object based on another ID.
+func DeriveMutable(body Mutable, base *ID, derivableType byte) ID {
+	id := ID{idVersion, body.Type(), derivableType}
+	copy(id[3:], base[2:17])
+
+	return id
+}
+
 // NewImmutable returns a new signed ID for an immutable object.
 //
 // sig should be a registry.Signature type

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -507,11 +507,17 @@ type Environment struct { // type: 0x05
 	ProjectID *identity.ID `json:"project_id"`
 }
 
-// There are two types of teams: system and user. System teams are
-// managed by the Torus registry.
+// There are three types of teams: system, machine and user. System teams are
+// managed by the Torus registry while Machine teams contain only machines.
 const (
-	SystemTeam = "system"
-	UserTeam   = "user"
+	SystemTeam  = "system"
+	UserTeam    = "user"
+	MachineTeam = "machine"
+)
+
+// Team IDs for certain system teams can be derived based on their OrgID.
+const (
+	DerivableMachineTeamSymbol = 0x04
 )
 
 // Team is an entity that represents a group of users

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -48,11 +48,11 @@ type User struct { // type: 0x01
 	Email    string        `json:"email"`
 	State    string        `json:"state"`
 	Password *UserPassword `json:"password"`
-	Master   *UserMaster   `json:"master"`
+	Master   *MasterKey    `json:"master"`
 }
 
-// UserMaster is the body.master object for a user
-type UserMaster struct {
+// MasterKey is the body.master object for a user and machine token
+type MasterKey struct {
 	Value *base64.Value `json:"value"`
 	Alg   string        `json:"alg"`
 }
@@ -324,6 +324,54 @@ type OrgInvite struct { // type: 0x13
 	Created      *time.Time    `json:"created_at"`
 	Accepted     *time.Time    `json:"accepted_at"`
 	Approved     *time.Time    `json:"approved_at"`
+}
+
+// Machines can be in one of two states: active or destroyed
+const (
+	MachineActiveState    = "active"
+	MachineDestroyedState = "destroyed"
+)
+
+// Machine is an entity that represents a machine object
+type Machine struct { // type: 0x17
+	v1Schema
+	mutable
+	Name        string       `json:"name"`
+	OrgID       *identity.ID `json:"org_id"`
+	CreatedBy   *identity.ID `json:"created_by"`
+	Created     time.Time    `json:"created_at"`
+	DestroyedBy *identity.ID `json:"destroyed_by"`
+	Destroyed   *time.Time   `json:"destroyed_at"`
+	State       string       `json:"state"`
+}
+
+// MachineTokens can be in one of two states: active or destroyed
+const (
+	MachineTokenActiveState    = "active"
+	MachineTokenDestroyedState = "destroyed"
+)
+
+// MachineToken is an portion of the MachineSegment object
+type MachineToken struct { // type: 0x18
+	v1Schema
+	mutable
+	OrgID       *identity.ID           `json:"org_id"`
+	MachineID   *identity.ID           `json:"machine_id"`
+	PublicKey   *MachineTokenPublicKey `json:"public_key"`
+	Master      *MasterKey             `json:"master"`
+	CreatedBy   *identity.ID           `json:"created_by"`
+	Created     time.Time              `json:"created_at"`
+	DestroyedBy *identity.ID           `json:"destroyed_by"`
+	Destroyed   *time.Time             `json:"destroyed_at"`
+	State       string                 `json:"state"`
+}
+
+// MachineTokenPublicKey represents a public used by a machine to authenticate
+// against the registry
+type MachineTokenPublicKey struct {
+	Alg   string        `json:"alg"`
+	Salt  *base64.Value `json:"salt"`
+	Value *base64.Value `json:"value"`
 }
 
 // Project is an entity that represents a group of services

--- a/promptui/select.go
+++ b/promptui/select.go
@@ -178,7 +178,7 @@ func (sa *SelectWithAdd) Run() (int, string, error) {
 	}
 
 	p := Prompt{
-		Label:    sa.Label,
+		Label:    sa.AddLabel,
 		Validate: sa.Validate,
 	}
 	value, err := p.Run()


### PR DESCRIPTION
Introducing the ability to create a machine!

**UI**

``` bash
Ians-MacBook-Pro-2:torus-cli ianlivingstone$ ./torus machines create --help
NAME:
   torus machines create - Create a machine for an organization

USAGE:
   torus machines create [command options]

OPTIONS:
   --org ORG, -o ORG     the org the machine will belong too
   --team TEAM, -t TEAM  the team the machine will belong too

Ians-MacBook-Pro-2:torus-cli ianlivingstone$ ./torus machines create
✔ Org name: test
✔ Select Machine Team: api
✔ Enter machine name: api-98g4vw63

Creating machine "api-98g4vw63"
Generating machine token
Generating token keypairs
Uploading token keypairs
Creating keyring memberships for token
Uploading keyring memberships
Machine created

You will only be shown the secret once, please keep it safe.

Machine ID:           04bm8jj0dbxbbtgn7dey2b7tewt82
Machine Token ID:     04c5e58npy50g8meprw5etk514ha2
Machine Token Secret: TlxwEbG3Ol7K9PLSUCSVtAHk
```

**Changes**

I've tried to break the commits down as much as possible to be incremental and atomic for readability. I recommend reviewing by walking through each commit in linear order.

Each commit generally encapsulates the reasoning for the change, however, I'll cover the big changes here:
- `Session` now supports the concept of `identity` and `auth` objects in order to support machines which identify using the Machine object but authorize using a Machine Token object.
- I've fixed a few bugs with prompts (labelling, and not hiding errors) while also introducing a new prompt for selecting or creating teams.
- I've removed the dependency on the DB from the Crypto Engine. Instead, it uses the Session object for pulling the Master Key value from the User (or Machine) object. This was required to support machine creation where we now generate and encrypt keys on the behalf of another entity (machine creating a machine, or user creating a machine)
- I've add beginnings of support for Passphrase-Derived Public Key Authentication which will be used when we implement `machines login`.
