### PR TITLE
Machines list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _YYYY-MM-DD_
 **Notable Changes**
 
 - Added contributor guide, CLA and Code of Conduct
+- Introduced concept of machines (with commands create, list)
 
 ## v0.14.0
 

--- a/api/machines.go
+++ b/api/machines.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/rand"
+	"net/url"
 
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/base64"
@@ -55,4 +56,50 @@ func createTokenSecret() (*base64.Value, error) {
 	}
 
 	return base64.NewValue(value), nil
+}
+
+// List machines in the given org and state
+func (m *MachinesClient) List(ctx context.Context, orgID *identity.ID, state *string, name *string, teamID *identity.ID) ([]*apitypes.MachineSegment, error) {
+	v := &url.Values{}
+	if orgID != nil {
+		v.Add("org_id", (*orgID).String())
+	}
+	if state != nil {
+		v.Add("state", *state)
+	}
+	if teamID != nil {
+		v.Add("team_id", (*teamID).String())
+	}
+	if name != nil {
+		v.Add("name", *name)
+	}
+
+	req, reqID, err := m.client.NewRequest("GET", "/machines", v, nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*apitypes.MachineSegment
+	_, err = m.client.Do(ctx, req, &results, &reqID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// Get machine by ID
+func (m *MachinesClient) Get(ctx context.Context, machineID *identity.ID) (*apitypes.MachineSegment, error) {
+	req, reqID, err := m.client.NewRequest("GET", "/machines/"+machineID.String(), nil, nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &apitypes.MachineSegment{}
+	_, err = m.client.Do(ctx, req, result, &reqID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -63,6 +63,14 @@ func teamFlag(usage string, required bool) cli.Flag {
 	return newPlaceholder("team, t", "TEAM", usage, "", "TORUS_TEAM", required)
 }
 
+// destroyedFlag creates a new --destroyed cli.Flag with custom usage string.
+func destroyedFlag() cli.Flag {
+	return cli.BoolFlag{
+		Name:  "destroyed, d",
+		Usage: "Display only destroyed",
+	}
+}
+
 // placeHolderStringSliceFlag is a StringSliceFlag that has been extended to use a
 // specific placedholder value in the usage, without parsing it out of the
 // usage string.

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -109,6 +109,10 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 - [ ] `torus machines create` supports flags (e.g. `-o, -t` etc)
 - [ ] `torus machines create` allows you to select an existing org and team
 - [ ] `torus machines create` allows you to create a new machine team
+- [ ] `torus machines list` displays all machines
+- [ ] `torus machines list --destroyed` shows only destroyed machines
+- [ ] `torus machines list --team [team]` shows machines belonging to that team
+- [ ] `torus machines list --team [team] --destroyed` shows destroyed machines belonging to that team
 
 ### Critical Path
 


### PR DESCRIPTION
Branched from https://github.com/manifoldco/torus-cli/pull/6

Will continue to update this as code review happens for machines create.

Sample output:

```
> torus machines list --help
NAME:
   torus machines list - List machines for an organization

USAGE:
   torus machines list [command options]

OPTIONS:
   --org ORG, -o ORG     Org to the machine belongs to
   --team TEAM, -t TEAM  Team the machine belongs to
   --destroyed, -d       Display only destroyed
```

```
> torus machines list

ID                                   NAME                              STATE         TEAM                     CREATION DATE

04buv5v36xecb5r390btvevkh0k10        api-test-machines-00cjftz6        active        api-test-machines        2016-10-30T12:56:21Z
04bh45uqk811xqzr81jb6naw5mt02        api-test-machines-b5hryd28        active        api-test-machines        2016-10-30T12:56:35Z
04bhu01f40b94k8vw7drh0gr294xy        ok-8u6j7cwv                       active        ok                       2016-10-30T19:56:21Z
```

```
> torus machines list --destroyed

ID                                   NAME                              STATE            TEAM                     CREATION DATE

04bx7jwzw9c8wd6t0n7mqpxerqncu        api-test-machines-2apzzf71        destroyed        api-test-machines        2016-10-30T12:56:41Z

```

```
> torus machines list --team ok

ID                                   NAME               STATE         TEAM        CREATION DATE

04bhu01f40b94k8vw7drh0gr294xy        ok-8u6j7cwv        active        ok          2016-10-30T19:56:21Z
```
