### PR TITLE
Support logging in without logging out

### DIFF
--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -121,10 +121,6 @@ func (s *session) Set(sessionType string, identity, auth *envelope.Unsigned,
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if s.Type() != apitypes.NotLoggedIn {
-		return errors.New("Cannot overwrite existing session")
-	}
-
 	if identity == nil || auth == nil {
 		return errors.New("identity and auth cannot be null")
 	}


### PR DESCRIPTION
A change introduced in machine login prevented a user from logging in
without logging out again.

I've re-introduced this behaviour.