### PR TITLE
Display correct error when lookup fails by name during machines view

### DIFF
--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -179,7 +179,7 @@ func viewMachineCmd(ctx *cli.Context) error {
 		name := args[0]
 		machines, lErr := client.Machines.List(c, org.ID, nil, &name, nil)
 		if lErr != nil {
-			return errs.NewErrorExitError("Failed to retrieve machine", err)
+			return errs.NewErrorExitError("Failed to retrieve machine", lErr)
 		}
 		if len(machines) < 1 {
 			return errs.NewExitError("Machine not found")


### PR DESCRIPTION
It was showing the error from the failed machine ID parse (when a name is supplied), rather than showing the "machine not supported" error returned from the lookup.

```
> torus machines view api-g98fnb9z
Failed to retrieve machine.
Unauthorized: Feature not supported by Machines
```