### PR TITLE
Filter sensitive env vars on run and daemon start

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"path"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
@@ -132,13 +131,7 @@ func spawnDaemon() error {
 
 	// Clone the current env, removing email and password if they exist.
 	// no need to keep those hanging around in a long lived-process!
-	cmd.Env = []string{}
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "TORUS_EMAIL=") || strings.HasPrefix(e, "TORUS_PASSWORD=") {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
+	cmd.Env = filterEnv()
 
 	err = cmd.Start()
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -53,15 +53,7 @@ func runCmd(ctx *cli.Context) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	cmd.Env = []string{}
-	// Clone the existing environment, without sensitve TORUS values.
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "TORUS_EMAIL=") || strings.HasPrefix(e, "TORUS_PASSWORD=") {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
+	cmd.Env = filterEnv()
 
 	// Add the secrets into the env
 	for _, secret := range secrets {
@@ -103,4 +95,17 @@ func runCmd(ctx *cli.Context) error {
 	}
 
 	return nil
+}
+
+func filterEnv() []string {
+	env := []string{}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "TORUS_EMAIL=") || strings.HasPrefix(e, "TORUS_PASSWORD=") ||
+			strings.HasPrefix(e, "TORUS_TOKEN_ID=") || strings.HasPrefix(e, "TORUS_TOKEN_SECRET=") {
+			continue
+		}
+		env = append(env, e)
+	}
+
+	return env
 }


### PR DESCRIPTION
Now that we've introduced `TORUS_TOKEN_ID` and `TORUS_TOKEN_SECRET` we
need to ensure we don't pass these on to downstream processes.

At the same time, I've consolidated the filtering logic!