### PR TITLE
Move Login and Logout flow into LogicEngine

### DIFF
--- a/daemon/logic/engine.go
+++ b/daemon/logic/engine.go
@@ -35,6 +35,7 @@ type Engine struct {
 
 	Worklog Worklog
 	Machine Machine
+	Session Session
 }
 
 // NewEngine returns a new Engine
@@ -49,6 +50,7 @@ func NewEngine(c *config.Config, s session.Session, db *db.DB, e *crypto.Engine,
 	}
 	engine.Worklog = Worklog{engine: engine}
 	engine.Machine = Machine{engine: engine}
+	engine.Session = Session{engine: engine}
 	return engine
 }
 

--- a/daemon/logic/session.go
+++ b/daemon/logic/session.go
@@ -1,0 +1,131 @@
+package logic
+
+import (
+	"context"
+	"log"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/base64"
+	"github.com/manifoldco/torus-cli/daemon/crypto"
+	"github.com/manifoldco/torus-cli/daemon/registry"
+	"github.com/manifoldco/torus-cli/daemon/session"
+)
+
+// Session represents the business logic for creating and managing tokens (and
+// their underlying effects on the current session)
+type Session struct {
+	engine *Engine
+}
+
+// Login attempts to create a valid auth token to authorize http requests made
+// against the registry.
+func (s *Session) Login(ctx context.Context, creds apitypes.LoginCredential) error {
+	if !creds.Valid() {
+		return &apitypes.Error{
+			Type: apitypes.BadRequestError,
+			Err:  []string{"invalid login credentials provided"},
+		}
+	}
+
+	var authToken string
+	var err error
+	switch creds.Type() {
+	case apitypes.UserSession:
+		authToken, err = attemptHMACLogin(ctx, s.engine.client, s.engine.session, creds)
+	case apitypes.MachineSession:
+		authToken, err = attemptPDPKALogin(ctx, s.engine.client, s.engine.session, creds)
+	}
+
+	self, err := s.engine.client.Self.Get(ctx, authToken)
+	if err != nil {
+		return err
+	}
+
+	s.engine.db.Set(self.Identity)
+	if self.Type == apitypes.UserSession {
+		s.engine.db.Set(self.Auth)
+	}
+
+	return s.engine.session.Set(self.Type, self.Identity, self.Auth, creds.Passphrase(), authToken)
+}
+
+// Logout destroys the current session if it exists, otherwise, it returns an
+// error that the request could not be completed.
+func (s *Session) Logout(ctx context.Context) error {
+	tok := s.engine.session.Token()
+
+	if tok == "" {
+		return &apitypes.Error{
+			Type: apitypes.UnauthorizedError,
+			Err:  []string{"You must be logged in, to logout!"},
+		}
+	}
+
+	err := s.engine.client.Tokens.Delete(ctx, tok)
+	switch err := err.(type) {
+	case *apitypes.Error:
+		switch {
+		case err.StatusCode >= 500:
+			// On a 5XX response, we don't know for sure that the server
+			// has successfully removed the auth token. Keep the copy in
+			// the daemon, so the user may try again.
+			return err
+		case err.StatusCode >= 400:
+			// A 4XX error indicates either the token isn't found, or we're
+			// not allowed to remove it (or the server is a teapot).
+			//
+			// In any case, the daemon has gotten out of sync with the
+			// server. Remove our local copy of the auth token.
+			log.Printf("Got 4XX removing auth token. Treating as success")
+			logoutErr := s.engine.session.Logout()
+			if logoutErr != nil {
+				return logoutErr
+			}
+
+			return nil
+		}
+	case nil:
+		logoutErr := s.engine.session.Logout()
+		if logoutErr != nil {
+			return logoutErr
+		}
+
+		return nil
+	default:
+		return err
+	}
+
+	return nil
+}
+
+func attemptPDPKALogin(ctx context.Context, client *registry.Client, s session.Session, creds apitypes.LoginCredential) (string, error) {
+	salt, loginToken, err := client.Tokens.PostLogin(ctx, creds)
+	if err != nil {
+		return "", err
+	}
+
+	pw := base64.NewValue([]byte(creds.Passphrase()))
+	log.Print(pw, salt)
+	keypair, err := crypto.DeriveLoginKeypair(ctx, pw, salt)
+	if err != nil {
+		return "", err
+	}
+
+	log.Printf("Public Key %s", keypair.PublicKey())
+	loginTokenSig := keypair.Sign([]byte(loginToken))
+	return client.Tokens.PostPDPKAuth(ctx, loginToken, loginTokenSig)
+}
+
+func attemptHMACLogin(ctx context.Context, client *registry.Client, s session.Session, creds apitypes.LoginCredential) (string, error) {
+	salt, loginToken, err := client.Tokens.PostLogin(ctx, creds)
+	if err != nil {
+		return "", err
+	}
+
+	hmac, err := crypto.DeriveLoginHMAC(ctx, creds.Passphrase(), salt.String(), loginToken)
+	if err != nil {
+		return "", err
+	}
+
+	return client.Tokens.PostAuth(ctx, loginToken, hmac)
+}

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 
-	"github.com/manifoldco/torus-cli/daemon/crypto"
 	"github.com/manifoldco/torus-cli/daemon/db"
 	"github.com/manifoldco/torus-cli/daemon/logic"
 	"github.com/manifoldco/torus-cli/daemon/observer"
@@ -20,12 +19,7 @@ import (
 // NewRouteMux returns a *bone.Mux responsible for handling the cli to daemon
 // http api.
 func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
-	t *http.Transport, o *observer.Observer) *bone.Mux {
-
-	cryptoEngine := crypto.NewEngine(s)
-	client := registry.NewClient(c.RegistryURI.String(), c.APIVersion,
-		c.Version, s, t)
-	lEngine := logic.NewEngine(c, s, db, cryptoEngine, client)
+	t *http.Transport, o *observer.Observer, client *registry.Client, lEngine *logic.Engine) *bone.Mux {
 
 	mux := bone.New()
 

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -32,8 +32,8 @@ func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
 	mux.Get("/observe", o)
 
 	mux.PostFunc("/signup", signupRoute(client, s, db))
-	mux.PostFunc("/login", loginRoute(client, s, db))
-	mux.PostFunc("/logout", logoutRoute(client, s))
+	mux.PostFunc("/login", loginRoute(lEngine))
+	mux.PostFunc("/logout", logoutRoute(lEngine))
 	mux.GetFunc("/session", sessionRoute(s))
 	mux.GetFunc("/self", selfRoute(s))
 

--- a/daemon/routes/session.go
+++ b/daemon/routes/session.go
@@ -3,24 +3,21 @@ package routes
 // This file contains routes related to the user's session
 
 import (
-	"context"
 	"encoding/json"
 	"log"
 	"net/http"
 
 	"github.com/manifoldco/torus-cli/apitypes"
-	"github.com/manifoldco/torus-cli/base64"
 	"github.com/manifoldco/torus-cli/identity"
 
 	"github.com/manifoldco/torus-cli/daemon/crypto"
 	"github.com/manifoldco/torus-cli/daemon/db"
+	"github.com/manifoldco/torus-cli/daemon/logic"
 	"github.com/manifoldco/torus-cli/daemon/registry"
 	"github.com/manifoldco/torus-cli/daemon/session"
 )
 
-func loginRoute(client *registry.Client, s session.Session,
-	db *db.DB) http.HandlerFunc {
-
+func loginRoute(engine *logic.Engine) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		dec := json.NewDecoder(r.Body)
@@ -52,36 +49,9 @@ func loginRoute(client *registry.Client, s session.Session,
 			return
 		}
 
-		if !creds.Valid() {
-			encodeResponseErr(w, &apitypes.Error{
-				Type: apitypes.BadRequestError,
-				Err:  []string{"invalid login credentials provided"},
-			})
-			return
-		}
-
-		var authToken string
-		switch creds.Type() {
-		case apitypes.UserSession:
-			authToken, err = attemptHMACLogin(ctx, client, s, db, creds)
-		case apitypes.MachineSession:
-			authToken, err = attemptPDPKALogin(ctx, client, s, db, creds)
-		}
-
-		self, err := client.Self.Get(ctx, authToken)
+		err = engine.Session.Login(ctx, creds)
 		if err != nil {
-			log.Printf("Could not retrieve self: %s", err)
-			encodeResponseErr(w, err)
-			return
-		}
-
-		db.Set(self.Identity)
-		if self.Type == apitypes.UserSession {
-			db.Set(self.Auth)
-		}
-
-		err = s.Set(self.Type, self.Identity, self.Auth, creds.Passphrase(), authToken)
-		if err != nil {
+			log.Printf("Could not complete login: %s", err)
 			encodeResponseErr(w, err)
 			return
 		}
@@ -90,84 +60,17 @@ func loginRoute(client *registry.Client, s session.Session,
 	}
 }
 
-func attemptPDPKALogin(ctx context.Context, client *registry.Client, s session.Session, db *db.DB, creds apitypes.LoginCredential) (string, error) {
-	salt, loginToken, err := client.Tokens.PostLogin(ctx, creds)
-	if err != nil {
-		return "", err
-	}
-
-	pw := base64.NewValue([]byte(creds.Passphrase()))
-	log.Print(pw, salt)
-	keypair, err := crypto.DeriveLoginKeypair(ctx, pw, salt)
-	if err != nil {
-		return "", err
-	}
-
-	log.Printf("Public Key %s", keypair.PublicKey())
-	loginTokenSig := keypair.Sign([]byte(loginToken))
-	return client.Tokens.PostPDPKAuth(ctx, loginToken, loginTokenSig)
-}
-
-func attemptHMACLogin(ctx context.Context, client *registry.Client, s session.Session, db *db.DB, creds apitypes.LoginCredential) (string, error) {
-	salt, loginToken, err := client.Tokens.PostLogin(ctx, creds)
-	if err != nil {
-		return "", err
-	}
-
-	hmac, err := crypto.DeriveLoginHMAC(ctx, creds.Passphrase(), salt.String(), loginToken)
-	if err != nil {
-		return "", err
-	}
-
-	return client.Tokens.PostAuth(ctx, loginToken, hmac)
-}
-
-func logoutRoute(client *registry.Client, s session.Session) http.HandlerFunc {
+func logoutRoute(engine *logic.Engine) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		tok := s.Token()
 
-		if tok == "" {
-			encodeResponseErr(w, notFoundError)
-			return
-		}
-
-		err := client.Tokens.Delete(r.Context(), tok)
-		switch err := err.(type) {
-		case *apitypes.Error:
-			switch {
-			case err.StatusCode >= 500:
-				// On a 5XX response, we don't know for sure that the server
-				// has successfully removed the auth token. Keep the copy in
-				// the daemon, so the user may try again.
-				encodeResponseErr(w, err)
-			case err.StatusCode >= 400:
-				// A 4XX error indicates either the token isn't found, or we're
-				// not allowed to remove it (or the server is a teapot).
-				//
-				// In any case, the daemon has gotten out of sync with the
-				// server. Remove our local copy of the auth token.
-				log.Printf("Got 4XX removing auth token. Treating as success")
-				logoutErr := s.Logout()
-				if logoutErr != nil {
-					log.Printf("Error while attempting to destroy session: %s", logoutErr)
-					encodeResponseErr(w, logoutErr)
-					break
-				}
-
-				w.WriteHeader(http.StatusNoContent)
-			}
-		case nil:
-			logoutErr := s.Logout()
-			if logoutErr != nil {
-				log.Printf("Error while attempting to destroy session: %s", logoutErr)
-				encodeResponseErr(w, logoutErr)
-				break
-			}
-
-			w.WriteHeader(http.StatusNoContent)
-		default:
+		ctx := r.Context()
+		err := engine.Session.Logout(ctx)
+		if err != nil {
+			log.Printf("Could not complete logout: %s", err)
 			encodeResponseErr(w, err)
 		}
+
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 


### PR DESCRIPTION
In preparation for supporting machine and user login by running the
daemon as a service, I've moved the login/logout flow into the logic
engine.

The daemon will then construct the logic engine at startup and pass it
into the router for future use.