### PR TITLE
Prevent hiding of errors, add context to Unauthorized errors

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -195,7 +195,7 @@ func checkResponseCode(r *http.Response) error {
 			return errors.New("Malformed error response from daemon.")
 		}
 
-		return rErr
+		return apitypes.FormatError(rErr)
 	}
 
 	return errors.New("Error from daemon. Check status code.")

--- a/cmd/allow.go
+++ b/cmd/allow.go
@@ -81,7 +81,7 @@ func doCrudl(ctx *cli.Context, effect primitive.PolicyEffect, extra primitive.Po
 
 	org, err := client.Orgs.GetByName(c, pe.Org())
 	if err != nil {
-		return errs.NewExitError("Unable to lookup org. Please try again.")
+		return errs.NewErrorExitError("Unable to lookup org.", err)
 	}
 	if org == nil {
 		return errs.NewExitError("Org not found")
@@ -89,7 +89,7 @@ func doCrudl(ctx *cli.Context, effect primitive.PolicyEffect, extra primitive.Po
 
 	teams, err := client.Teams.GetByName(c, org.ID, args[2])
 	if err != nil {
-		return errs.NewExitError("Unable to lookup team. Please try again.")
+		return errs.NewErrorExitError("Unable to lookup team.", err)
 	}
 	if len(teams) < 1 {
 		return errs.NewExitError("Team not found.")

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,7 +51,7 @@ func login(ctx *cli.Context) error {
 func performLogin(c context.Context, client *api.Client, email, password string) error {
 	err := client.Session.UserLogin(context.Background(), email, password)
 	if err != nil {
-		return errs.NewExitError("Login failed. Please try again.")
+		return errs.NewErrorExitError("Login failed.", err)
 	}
 
 	fmt.Println("You are now authenticated.")

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -38,7 +38,7 @@ func logoutCmd(ctx *cli.Context) error {
 				return nil
 			}
 		}
-		return errs.NewExitError("Logout failed. Please try again.")
+		return errs.NewErrorExitError("Logout failed.", err)
 	}
 
 	fmt.Println("You have successfully logged out. o/")

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -48,7 +48,7 @@ func init() {
 	Cmds = append(Cmds, orgs)
 }
 
-const orgCreateFailed = "Org creation failed, please try again."
+const orgCreateFailed = "Org creation failed."
 
 func orgsCreate(ctx *cli.Context) error {
 	args := ctx.Args()
@@ -74,7 +74,7 @@ func orgsCreate(ctx *cli.Context) error {
 
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		return errs.NewExitError(orgCreateFailed)
+		return errs.NewErrorExitError(orgCreateFailed, err)
 	}
 
 	client := api.NewClient(cfg)
@@ -86,7 +86,7 @@ func orgsCreate(ctx *cli.Context) error {
 func createOrgByName(c context.Context, ctx *cli.Context, client *api.Client, name string) (*api.OrgResult, error) {
 	org, err := client.Orgs.Create(c, name)
 	if err != nil {
-		return nil, errs.NewExitError(orgCreateFailed)
+		return nil, errs.NewErrorExitError(orgCreateFailed, err)
 	}
 
 	err = generateKeypairsForOrg(c, ctx, client, org.ID, false)
@@ -175,11 +175,11 @@ func orgsRemove(ctx *cli.Context) error {
 	c := context.Background()
 
 	const userNotFound = "User not found."
-	const orgsRemoveFailed = "Could remove user from the org. Please try again."
+	const orgsRemoveFailed = "Could remove user from the org."
 
 	org, err := client.Orgs.GetByName(c, ctx.String("org"))
 	if err != nil {
-		return errs.NewExitError(orgsRemoveFailed)
+		return errs.NewErrorExitError(orgsRemoveFailed, err)
 	}
 	if org == nil {
 		return errs.NewExitError("Org not found.")
@@ -190,7 +190,7 @@ func orgsRemove(ctx *cli.Context) error {
 		return errs.NewExitError(userNotFound)
 	}
 	if err != nil {
-		return errs.NewExitError(orgsRemoveFailed)
+		return errs.NewErrorExitError(orgsRemoveFailed, err)
 	}
 	if profile == nil {
 		return errs.NewExitError(userNotFound)
@@ -202,7 +202,7 @@ func orgsRemove(ctx *cli.Context) error {
 		return nil
 	}
 	if err != nil {
-		return errs.NewExitError(orgsRemoveFailed)
+		return errs.NewErrorExitError(orgsRemoveFailed, err)
 	}
 
 	fmt.Println("User has been removed from the org.")
@@ -212,7 +212,7 @@ func orgsRemove(ctx *cli.Context) error {
 func getOrg(ctx context.Context, client *api.Client, name string) (*api.OrgResult, error) {
 	org, err := client.Orgs.GetByName(ctx, name)
 	if err != nil {
-		return nil, errs.NewExitError("Unable to lookup org. Please try again.")
+		return nil, errs.NewErrorExitError("Unable to lookup org.", err)
 	}
 	if org == nil {
 		return nil, errs.NewExitError("Org not found.")
@@ -224,7 +224,7 @@ func getOrg(ctx context.Context, client *api.Client, name string) (*api.OrgResul
 func getOrgTree(c context.Context, client *api.Client, orgID identity.ID) ([]api.OrgTreeSegment, error) {
 	orgTree, err := client.Orgs.GetTree(c, orgID)
 	if err != nil {
-		return nil, errs.NewExitError("Unable to lookup org tree. Please try again.")
+		return nil, errs.NewErrorExitError("Unable to lookup org tree.", err)
 	}
 	if orgTree == nil {
 		return nil, errs.NewExitError("Org tree not found.")

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -64,7 +64,7 @@ func init() {
 	Cmds = append(Cmds, policies)
 }
 
-const policyDetachFailed = "Could not detach policy, please try again."
+const policyDetachFailed = "Could not detach policy."
 
 func detachPolicies(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
@@ -90,7 +90,7 @@ func detachPolicies(ctx *cli.Context) error {
 	var org *api.OrgResult
 	org, err = client.Orgs.GetByName(c, ctx.String("org"))
 	if err != nil {
-		return errs.NewExitError(projectListFailed)
+		return errs.NewErrorExitError(policyDetachFailed, err)
 	}
 	if org == nil {
 		return errs.NewExitError("Org not found")
@@ -141,7 +141,7 @@ func detachPolicies(ctx *cli.Context) error {
 
 	attachments, err := client.Policies.AttachmentsList(c, org.ID, team.ID, policy.ID)
 	if err != nil {
-		return errs.NewExitError(policyDetachFailed)
+		return errs.NewErrorExitError(policyDetachFailed, err)
 	}
 	if len(attachments) < 1 {
 		return errs.NewExitError(policyName + " policy is not currently attached to " + teamName)
@@ -152,14 +152,14 @@ func detachPolicies(ctx *cli.Context) error {
 		if strings.Contains(err.Error(), "system team") {
 			return errs.NewExitError("Cannot delete system team attachment")
 		}
-		return errs.NewExitError(policyDetachFailed)
+		return errs.NewErrorExitError(policyDetachFailed, err)
 	}
 
 	fmt.Println("Policy " + policyName + " has been detached from team " + teamName)
 	return nil
 }
 
-const policyListFailed = "Could not list policies, please try again."
+const policyListFailed = "Could not list policies."
 
 func listPolicies(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
@@ -174,7 +174,7 @@ func listPolicies(ctx *cli.Context) error {
 	var org *api.OrgResult
 	org, err = client.Orgs.GetByName(c, ctx.String("org"))
 	if err != nil {
-		return errs.NewExitError(policyListFailed)
+		return errs.NewErrorExitError(policyListFailed, err)
 	}
 	if org == nil {
 		return errs.NewExitError("Org not found.")
@@ -276,7 +276,7 @@ func viewPolicyCmd(ctx *cli.Context) error {
 
 	org, err := client.Orgs.GetByName(c, ctx.String("org"))
 	if err != nil {
-		return errs.NewExitError("Unable to lookup org. Please try again.")
+		return errs.NewErrorExitError("Unable to lookup org.", err)
 	}
 	if org == nil {
 		return errs.NewExitError("Org not found.")
@@ -284,7 +284,7 @@ func viewPolicyCmd(ctx *cli.Context) error {
 
 	policies, err := client.Policies.List(c, org.ID, args[0])
 	if err != nil {
-		return errs.NewExitError("Unable to list policies. Please try again.")
+		return errs.NewExitError("Unable to list policies.")
 	}
 
 	if len(policies) < 1 {

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -125,7 +125,7 @@ func listProjectsByOrgName(ctx *context.Context, client *api.Client, orgName str
 	return projects, nil
 }
 
-const projectCreateFailed = "Could not create project. Please try again."
+const projectCreateFailed = "Could not create project."
 
 func createProjectCmd(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
@@ -138,7 +138,7 @@ func createProjectCmd(ctx *cli.Context) error {
 
 	org, orgName, newOrg, err := SelectCreateOrg(c, client, ctx.String("org"))
 	if err != nil {
-		return errs.NewExitError(projectCreateFailed)
+		return errs.NewErrorExitError(projectCreateFailed, err)
 	}
 
 	var orgID *identity.ID

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -55,7 +55,7 @@ func init() {
 	Cmds = append(Cmds, services)
 }
 
-const serviceListFailed = "Could not list services, please try again."
+const serviceListFailed = "Could not list services."
 
 func listServicesCmd(ctx *cli.Context) error {
 	if !ctx.Bool("all") {
@@ -80,7 +80,7 @@ func listServicesCmd(ctx *cli.Context) error {
 	var org *api.OrgResult
 	org, err = client.Orgs.GetByName(c, ctx.String("org"))
 	if err != nil {
-		return errs.NewExitError(serviceListFailed)
+		return errs.NewErrorExitError(serviceListFailed, err)
 	}
 	if org == nil {
 		return errs.NewExitError("Org not found")
@@ -93,7 +93,7 @@ func listServicesCmd(ctx *cli.Context) error {
 		// Pull all projects for the given orgID
 		projects, err = listProjects(&c, client, org.ID, nil)
 		if err != nil {
-			return errs.NewExitError(serviceListFailed)
+			return errs.NewErrorExitError(serviceListFailed, err)
 		}
 
 	} else {
@@ -101,7 +101,7 @@ func listServicesCmd(ctx *cli.Context) error {
 		projectName := ctx.String("project")
 		projects, err = listProjects(&c, client, org.ID, &projectName)
 		if err != nil {
-			return errs.NewExitError(serviceListFailed)
+			return errs.NewErrorExitError(serviceListFailed, err)
 		}
 		if len(projects) == 1 {
 			projectID = *projects[0].ID
@@ -113,7 +113,7 @@ func listServicesCmd(ctx *cli.Context) error {
 	// Retrieve services for targeted org and project
 	services, err := listServices(&c, client, org.ID, &projectID, nil)
 	if err != nil {
-		return errs.NewExitError(serviceListFailed)
+		return errs.NewErrorExitError(serviceListFailed, err)
 	}
 
 	// Build map of services to project
@@ -175,7 +175,7 @@ func listServicesByProjectID(ctx *context.Context, client *api.Client, projectID
 	return client.Services.List(c, nil, &projectIDs, nil)
 }
 
-const serviceCreateFailed = "Could not create service. Please try again."
+const serviceCreateFailed = "Could not create service."
 
 func createServiceCmd(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -289,12 +289,12 @@ func teamMembersListCmd(ctx *cli.Context) error {
 	return nil
 }
 
-const teamCreateFailed = "Could not create team. Please try again."
+const teamCreateFailed = "Could not create team."
 
 func createTeamCmd(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		return errs.NewExitError(teamCreateFailed)
+		return errs.NewErrorExitError(teamCreateFailed, err)
 	}
 
 	args := ctx.Args()
@@ -356,7 +356,7 @@ func createTeamCmd(ctx *cli.Context) error {
 	return nil
 }
 
-const teamRemoveFailed = "Failed to remove team member, please try again"
+const teamRemoveFailed = "Failed to remove team member."
 
 func teamsRemoveCmd(ctx *cli.Context) error {
 	args := ctx.Args()

--- a/cmd/worklog.go
+++ b/cmd/worklog.go
@@ -178,7 +178,7 @@ func worklogResolve(ctx *cli.Context) error {
 	for _, item := range toResolve {
 		res, err := client.Worklog.Resolve(c, org.ID, item.ID)
 		if err != nil {
-			return errs.NewExitError("Error resolving worklog item. Please try again.")
+			return errs.NewErrorExitError("Error resolving worklog item.", err)
 		}
 
 		var icon string


### PR DESCRIPTION
Related to https://github.com/manifoldco/torus-cli/issues/25

We've had a number of users in unverified states end up confused about why commands are failing because we weren't surfacing enough context. This adds more context to Unauthorized error situations, and updates a lot of cases where we were eating the error in favour of a generic.

```
> torus link
✔ Select organization: unverifieduser
Project selection failed.
Unauthorized: Your account has not yet been verified.

Please check your email for your verification code and follow the enclosed instructions.
Once you have verified your account you may retry this operation.
```