### PR TITLE
typo fix for orgsRemoveFailed

### DIFF
--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -175,7 +175,7 @@ func orgsRemove(ctx *cli.Context) error {
 	c := context.Background()
 
 	const userNotFound = "User not found."
-	const orgsRemoveFailed = "Could remove user from the org."
+	const orgsRemoveFailed = "Could not remove user from the org."
 
 	org, err := client.Orgs.GetByName(c, ctx.String("org"))
 	if err != nil {


### PR DESCRIPTION
Summary of problem: Wrong message displayed when removing a user from an org fails.

What happened:

```
> torus orgs remove peterkaminski
Could remove user from the org. Please try again.
```

What I expected:

```
> torus orgs remove peterkaminski
Could not remove user from the org. Please try again.
```

Summary of fix: Added "not " to error message.

Since the change is trivial and I don't have a dev environment set up, I did not run through the QA checklist.  I hope the project maintainer can test, or, it's okay to bounce this PR, and get bug fixed another way.

I did not add `meta/in-progress` and `component/cli` labels because they were not available in the "Labels" dropdown in github.