### PR TITLE
Allow user to update their name or email

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -49,3 +49,15 @@ func (u *UsersClient) VerifyEmail(ctx context.Context, verifyCode string) error 
 
 	return nil
 }
+
+// Update performs a profile update to the user object
+func (u *UsersClient) Update(ctx context.Context, delta apitypes.ProfileUpdate) (*UserResult, error) {
+	req, _, err := u.client.NewRequest("PATCH", "/self", nil, &delta, false)
+	if err != nil {
+		return nil, err
+	}
+
+	user := UserResult{}
+	_, err = u.client.Do(ctx, req, &user, nil, nil)
+	return &user, err
+}

--- a/apitypes/apitypes.go
+++ b/apitypes/apitypes.go
@@ -201,6 +201,12 @@ type Signup struct {
 	OrgInvite  bool
 }
 
+// ProfileUpdate contains the fields a user can change on their user object
+type ProfileUpdate struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
 // OrgInvite contains information for sending an Org invite
 type OrgInvite struct {
 	ID      string               `json:"id"`

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -53,14 +53,18 @@ func profileView(ctx *cli.Context) error {
 	if err != nil {
 		return errs.NewErrorExitError("Error fetching user details", err)
 	}
-	if session.Type() == apitypes.MachineSession {
-		return errs.NewExitError("Machines do not have profiles")
-	}
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "Name:\t%s\n", session.Name())
-	fmt.Fprintf(w, "Email:\t%s\n", session.Email())
-	fmt.Fprintf(w, "Username:\t%s\n\n", session.Username())
+	if session.Type() == apitypes.MachineSession {
+		fmt.Fprintf(w, "Machine ID:\t%s\n", session.ID())
+		fmt.Fprintf(w, "Machine Token ID:\t%s\n", session.AuthID())
+		fmt.Fprintf(w, "Machine Name:\t%s\n\n", session.Username())
+	} else {
+		fmt.Fprintf(w, "Name:\t%s\n", session.Name())
+		fmt.Fprintf(w, "Email:\t%s\n", session.Email())
+		fmt.Fprintf(w, "Username:\t%s\n\n", session.Username())
+	}
+
 	w.Flush()
 
 	return nil
@@ -81,7 +85,7 @@ func profileEdit(ctx *cli.Context) error {
 		return errs.NewErrorExitError("Error fetching user details", err)
 	}
 	if session.Type() == apitypes.MachineSession {
-		return errs.NewExitError("Machines do not have profiles")
+		return errs.NewExitError("Machines cannot update profile")
 	}
 
 	ogName := session.Name()

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/manifoldco/torus-cli/api"
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/config"
+	"github.com/manifoldco/torus-cli/errs"
+
+	"github.com/urfave/cli"
+)
+
+func init() {
+	profile := cli.Command{
+		Name:     "profile",
+		Usage:    "Manage your Torus account",
+		Category: "ACCOUNT",
+		Subcommands: []cli.Command{
+			{
+				Name:  "view",
+				Usage: "View your profile",
+				Action: chain(
+					ensureDaemon, ensureSession, setUserEnv, profileView,
+				),
+			},
+			{
+				Name:  "update",
+				Usage: "Update your profile",
+				Action: chain(
+					ensureDaemon, ensureSession, setUserEnv, profileView,
+				),
+			},
+		},
+	}
+	Cmds = append(Cmds, profile)
+}
+
+// profileView is used to view your account profile
+func profileView(ctx *cli.Context) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(cfg)
+	c := context.Background()
+
+	session, err := client.Session.Who(c)
+	if err != nil {
+		return errs.NewErrorExitError("Error fetching user details", err)
+	}
+	if session.Type() == apitypes.MachineSession {
+		return errs.NewExitError("Machines do not have profiles")
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
+	fmt.Fprintf(w, "Name:\t%s\n", session.Name())
+	fmt.Fprintf(w, "Email:\t%s\n", session.Email())
+	fmt.Fprintf(w, "Username:\t%s\n\n", session.Username())
+	w.Flush()
+
+	return nil
+}
+
+// profileEdit is used to update name and email for an account
+func profileEdit(ctx *cli.Context) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(cfg)
+	c := context.Background()
+
+	session, err := client.Session.Who(c)
+	if err != nil {
+		return errs.NewErrorExitError("Error fetching user details", err)
+	}
+	if session.Type() == apitypes.MachineSession {
+		return errs.NewExitError("Machines do not have profiles")
+	}
+
+	ogName := session.Name()
+	name, err := FullNamePrompt(ogName)
+	if err != nil {
+		return err
+	}
+
+	ogEmail := session.Email()
+	email, err := EmailPrompt(ogEmail)
+	if err != nil {
+		return err
+	}
+
+	warning := "\nYou are about to update your profile to the values above."
+	if email != ogEmail {
+		warning = "\nYou will be required to re-verify your email address before taking any further actions within Torus."
+	}
+
+	if ogEmail == email && ogName == name {
+		fmt.Println("\nNo changes made :)")
+		return nil
+	}
+
+	err = ConfirmDialogue(ctx, nil, &warning)
+	if err != nil {
+		return err
+	}
+
+	delta := apitypes.ProfileUpdate{}
+	if ogEmail != email {
+		delta.Email = email
+	}
+	if ogName != name {
+		delta.Name = name
+	}
+
+	_, err = client.Users.Update(c, delta)
+	if err != nil {
+		return errs.NewErrorExitError("Failed to update profile.", err)
+	}
+	updatedSession, err := client.Session.Who(c)
+	if err != nil {
+		return errs.NewErrorExitError("Error fetching user details", err)
+	}
+
+	fmt.Println("")
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
+	fmt.Fprintf(w, "Name:\t%s\n", updatedSession.Name())
+	fmt.Fprintf(w, "Email:\t%s\n", updatedSession.Email())
+	fmt.Fprintf(w, "Username:\t%s\n\n", updatedSession.Username())
+	w.Flush()
+
+	return nil
+}

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -392,7 +392,7 @@ func EmailPrompt(defaultValue string) (string, error) {
 }
 
 // UsernamePrompt prompts the user to input a person's name
-func UsernamePrompt() (string, error) {
+func UsernamePrompt(un string) (string, error) {
 	prompt := promptui.Prompt{
 		Label: "Username",
 		Validate: func(input string) error {
@@ -402,12 +402,15 @@ func UsernamePrompt() (string, error) {
 			return promptui.NewValidationError("Please enter a valid username")
 		},
 	}
+	if un != "" {
+		prompt.Default = un
+	}
 
 	return prompt.Run()
 }
 
 // FullNamePrompt prompts the user to input a person's name
-func FullNamePrompt() (string, error) {
+func FullNamePrompt(name string) (string, error) {
 	prompt := promptui.Prompt{
 		Label: "Name",
 		Validate: func(input string) error {
@@ -416,6 +419,9 @@ func FullNamePrompt() (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid name")
 		},
+	}
+	if name != "" {
+		prompt.Default = name
 	}
 
 	return prompt.Run()

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -46,12 +46,12 @@ func signup(ctx *cli.Context, subCommand bool) error {
 	fmt.Println("By completing sign up, you agree to our terms of use (found at https://torus.sh/terms)\nand our privacy policy (found at https://torus.sh/privacy)")
 	fmt.Println("")
 
-	name, err := FullNamePrompt()
+	name, err := FullNamePrompt("")
 	if err != nil {
 		return err
 	}
 
-	username, err := UsernamePrompt()
+	username, err := UsernamePrompt("")
 	if err != nil {
 		return err
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -8,7 +8,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/manifoldco/torus-cli/api"
-	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
 	"github.com/manifoldco/torus-cli/prefs"
@@ -75,18 +74,6 @@ func statusCmd(ctx *cli.Context) error {
 		return errs.NewErrorExitError("Error fetching user details", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
-	if session.Type() == apitypes.MachineSession {
-		fmt.Fprintf(w, "Machine ID:\t%s\n", session.ID())
-		fmt.Fprintf(w, "Machine Token ID:\t%s\n", session.AuthID())
-		fmt.Fprintf(w, "Machine Name:\t%s\n\n", session.Username())
-	} else {
-		fmt.Fprintf(w, "Identity:\t%s <%s>\n", session.Name(), session.Email())
-		fmt.Fprintf(w, "Username:\t%s\n\n", session.Username())
-	}
-
-	w.Flush()
-
 	err = checkRequiredFlags(ctx)
 	if err != nil {
 		fmt.Printf("You are not inside a linked working directory. "+
@@ -100,6 +87,7 @@ func statusCmd(ctx *cli.Context) error {
 	service := ctx.String("service")
 	instance := ctx.String("instance")
 
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "Org:\t%s\n", org)
 	fmt.Fprintf(w, "Project:\t%s\n", project)
 	fmt.Fprintf(w, "Environment:\t%s\n", env)

--- a/daemon/registry/users.go
+++ b/daemon/registry/users.go
@@ -53,6 +53,30 @@ func (u *Users) Create(ctx context.Context, userObj Signup, signup apitypes.Sign
 	return &user, nil
 }
 
+// Update patches the user object with whitelisted fields
+func (u *Users) Update(ctx context.Context, userObj interface{}) (*envelope.Unsigned, error) {
+	req, err := u.client.NewRequest("PATCH", "/users/self", nil, userObj)
+	if err != nil {
+		log.Printf("Error making api request: %s", err)
+		return nil, err
+	}
+
+	user := envelope.Unsigned{}
+	_, err = u.client.Do(ctx, req, &user)
+	if err != nil {
+		log.Printf("Error making api request: %s", err)
+		return nil, err
+	}
+
+	err = validateSelf(&user)
+	if err != nil {
+		log.Printf("Invalid user object: %s", err)
+		return nil, err
+	}
+
+	return &user, nil
+}
+
 func validateSelf(s *envelope.Unsigned) error {
 	if s.Version != 1 {
 		return errors.New("version must be 1")

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -30,6 +30,7 @@ func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
 	mux.PostFunc("/logout", logoutRoute(lEngine))
 	mux.GetFunc("/session", sessionRoute(s))
 	mux.GetFunc("/self", selfRoute(s))
+	mux.PatchFunc("/self", updateSelfRoute(client, s))
 
 	mux.PostFunc("/machines", machinesCreateRoute(client, s, lEngine, o))
 	mux.PostFunc("/keypairs/generate", keypairsGenerateRoute(lEngine, o))


### PR DESCRIPTION
- `torus profile update`
- Depends on a new route in the registry
- Allows user to update name or email address
  - Email will require re-verification on change