### PR TITLE
Expose Machine Teams as Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ _Unpublished_
 - Introduced `--user, -u` and `--machine, -m` flags to `torus set`, `torus
   unset`, `torus view`, `torus run`, and `torus ls` for specifying machine or
   user identity
+- Introduce `machines roles list` and `machines roles create` commands for
+  viewing and creating machine roles.
+- Machine teams no longer appear under `teams list` nor can you view machine
+  teams through `teams members`.
+- The `machines` command now appears under the `ORGANIZATIONS` category when
+  listing commands with `torus help`.
+
+**Fixes**
+
+- Listing teams no longer results in a panic when an unknown org is specified.
 
 ## v0.15.0
 

--- a/cmd/allow.go
+++ b/cmd/allow.go
@@ -20,8 +20,8 @@ import (
 func init() {
 	allow := cli.Command{
 		Name:      "allow",
-		Usage:     "Grant a team permission to access specific resources",
-		ArgsUsage: "<crudl> <path> <team>",
+		Usage:     "Grant a team or machine role permission to access specific resources",
+		ArgsUsage: "<crudl> <path> <team|machine-role>",
 		Category:  "ACCESS CONTROL",
 		Action:    chain(ensureDaemon, ensureSession, allowCmd),
 	}

--- a/cmd/deny.go
+++ b/cmd/deny.go
@@ -9,8 +9,8 @@ import (
 func init() {
 	deny := cli.Command{
 		Name:      "deny",
-		Usage:     "Deny a team permission to access specific resources",
-		ArgsUsage: "<crudl> <path> <team>",
+		Usage:     "Deny a team or machine role permission to access specific resources",
+		ArgsUsage: "<crudl> <path> <team|machine-role>",
 		Category:  "ACCESS CONTROL",
 		Action:    chain(ensureDaemon, ensureSession, denyCmd),
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -71,6 +71,11 @@ func teamFlag(usage string, required bool) cli.Flag {
 	return newPlaceholder("team, t", "TEAM", usage, "", "TORUS_TEAM", required)
 }
 
+// roleFlag creates a new --role cli.Flag with custom usage string.
+func roleFlag(usage string, required bool) cli.Flag {
+	return newPlaceholder("role, r", "ROLE", usage, "", "TORUS_ROLE", required)
+}
+
 // destroyedFlag creates a new --destroyed cli.Flag with custom usage string.
 func destroyedFlag() cli.Flag {
 	return cli.BoolFlag{

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -49,8 +49,8 @@ func init() {
 
 			{
 				Name:      "detach",
-				Usage:     "Detach a policy from a team, does not delete the policy",
-				ArgsUsage: "<name> <team>",
+				Usage:     "Detach a policy from a team or machine role, does not delete the policy",
+				ArgsUsage: "<name> <team|role>",
 				Flags: []cli.Flag{
 					orgFlag("org to detach policy from", true),
 				},

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -273,29 +273,22 @@ func SelectCreateOrg(c context.Context, client *api.Client, name string) (*api.O
 	return &orgs[idx], name, false, nil
 }
 
-// SelectCreateTeam prompts the user to select a team from a list of teams for
-// the given org.
+// SelectCreateRole prompts the user to select a machine team from a list of
+// teams for the given org.
 //
 // The user may select to create a new team, or they may may preselect a team via
 // a non-empty name parameter.
 //
-// The type of team can be specified, if no team type is provided then all
-// teams excluding machine teams are listed.
-//
 // It returns the object of the selected team, the name of the selected team,
 // and a boolean indicating if a new team should be created.
-func SelectCreateTeam(c context.Context, client *api.Client, orgID *identity.ID, teamType, name string) (*api.TeamResult, string, bool, error) {
+func SelectCreateRole(c context.Context, client *api.Client, orgID *identity.ID, name string) (*api.TeamResult, string, bool, error) {
 
-	teams, err := client.Teams.List(c, orgID, "", teamType)
+	teams, err := client.Teams.List(c, orgID, "", primitive.MachineTeam)
 	if err != nil {
 		return nil, "", false, err
 	}
 
-	label := ""
-	if teamType == primitive.MachineTeam {
-		label = "Select Machine Team"
-	}
-
+	label := "Select Machine Role"
 	var idx int
 	if name == "" {
 		idx, name, err = SelectTeamPrompt(teams, label)
@@ -313,10 +306,10 @@ func SelectCreateTeam(c context.Context, client *api.Client, orgID *identity.ID,
 		}
 
 		if !found {
-			fmt.Println(promptui.FailedValue("Team name", name))
-			return nil, "", false, errs.NewExitError("Team not found")
+			fmt.Println(promptui.FailedValue("Machine Role", name))
+			return nil, "", false, errs.NewExitError("Role not found")
 		}
-		fmt.Println(promptui.SuccessfulValue("Team name", name))
+		fmt.Println(promptui.SuccessfulValue("Machine Role", name))
 	}
 
 	if idx == promptui.SelectedAdd {

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -120,13 +120,14 @@ func teamsListCmd(ctx *cli.Context) error {
 
 	go func() {
 		org, oErr = client.Orgs.GetByName(c, orgName)
-		getMemberships.Done()
-
 		if org == nil {
 			oErr = errs.NewExitError("Org not found.")
+			getMemberships.Done()
 			display.Done()
 			return
 		}
+
+		getMemberships.Done()
 
 		teams, tErr = client.Teams.GetByOrg(c, org.ID)
 		display.Done()

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -158,17 +158,16 @@ func teamsListCmd(ctx *cli.Context) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
 	for _, t := range teams {
+		if isMachineTeam(t.Body) {
+			continue
+		}
+
 		isMember := ""
 		displayTeamType := ""
 
 		switch teamType := t.Body.TeamType; teamType {
 		case primitive.SystemTeam:
 			displayTeamType = "[system]"
-			if t.Body.Name == "machine" {
-				displayTeamType += " (machine)"
-			}
-		case primitive.MachineTeam:
-			displayTeamType = "(machine)"
 		}
 
 		if _, ok := memberOf[*t.ID]; ok {
@@ -223,6 +222,14 @@ func teamMembersListCmd(ctx *cli.Context) error {
 			return
 		}
 		team = teams[0]
+
+		// Hide machine teams from the teams list; as we use them to represent
+		// machine roles in the system.
+		if isMachineTeam(team.Body) {
+			tErr = errs.NewExitError("Team not found.")
+			getMembers.Done()
+			return
+		}
 
 		// Pull all memberships for supplied org/team
 		memberships, mErr = client.Memberships.List(c, org.ID, nil, team.ID)
@@ -551,4 +558,10 @@ func teamsAddCmd(ctx *cli.Context) error {
 
 	fmt.Println(username + " has been added to the " + teamName + " team.")
 	return nil
+}
+
+// isMachineTeam returns whether or not the given team represents a machine
+// role (which uses the Team primitive)
+func isMachineTeam(team *primitive.Team) bool {
+	return team.TeamType == primitive.MachineTeam || (team.TeamType == primitive.SystemTeam && team.Name == primitive.MachineTeamName)
 }

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -119,6 +119,8 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 - [ ] `torus machines destroy [identity]` destroys a machine by id after confirming
 - [ ] `torus machines destroy [name]` destroys a machine by name after confirming
 - [ ] `torus machines list --destroyed` shows only destroyed machines
+- [ ] `torus machines roles create` creates a machine role
+- [ ] `torus machines roles lists` lists all machine roles (including the machine team)
 
 ### Critical Path
 

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -563,6 +563,15 @@ const (
 	MachineTeam = "machine"
 )
 
+// Teams are used to represent a group of identities and their associated
+// access control policies
+const (
+	AdminTeamName   = "admin"
+	OwnerTeamName   = "owner"
+	MemberTeamName  = "member"
+	MachineTeamName = "machine"
+)
+
 // Team IDs for certain system teams can be derived based on their OrgID.
 const (
 	DerivableMachineTeamSymbol = 0x04


### PR DESCRIPTION
This pull request introduces the concept of "machine roles" to the CLI which are powered using the "team" primitive.

The fundamental difference between a user and a machine is that a machine can only belong to *one* team other than the main `machines` system team which is the team that defines the role of the machine.

Included in this request:

- Bug fix to prevent a panic occurring when listing teams with an unknown org
- Remove capability to list machines through `torus teams list` or `torus teams members`
- Introduce the `torus machines roles` and `torus machines create-role` commands for listing and creating machine roles.

**UI**

```
Ians-MacBook-Pro-2:torus-cli ianlivingstone$ ./torus machines roles
machine             [system]
hellomachines
joe
axe
fdf

All machines belong to the "machine" role.
Ians-MacBook-Pro-2:torus-cli ianlivingstone$ ./torus machines create-role api
✔ Org name: ian
✔ Role name: api

Role api created.
```