### PR TITLE
Support --user and --machine flags for set, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNPUBLISHED
+
+_Unpublished_
+
+**Notable Changes**
+
+- Introduced `--user, -u` and `--machine, -m` flags to `torus set`, `torus
+  unset`, `torus view`, `torus run`, and `torus ls` for specifying machine or
+  user identity
+
 ## v0.15.0
 
 _2016-11-01_

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -27,6 +27,8 @@ func init() {
 				"default", "TORUS_SERVICE", false),
 			newSlicePlaceholder("user, u", "USER", "Use this user (identity).",
 				"*", "TORUS_USER", false),
+			newSlicePlaceholder("machine, m", "MACHINE", "Use this machine.",
+				"*", "TORUS_MACHINE", false),
 			newSlicePlaceholder("instance, i", "INSTANCE", "Use this instance.",
 				"*", "TORUS_INSTANCE", false),
 		},
@@ -52,6 +54,11 @@ func listObjects(ctx *cli.Context) error {
 	var cpathObj *pathexp.PathExp
 	var count int
 	var err error
+
+	identitySlice, err := deriveIdentitySlice(ctx)
+	if err != nil {
+		return err
+	}
 
 	hasPath := len(args) > 0
 	emptyOrg := ctx.String("org") == ""
@@ -82,7 +89,7 @@ func listObjects(ctx *cli.Context) error {
 		// Construct the target path through flags
 		obj, _, err := pathexp.NewPartial(ctx.String("org"), ctx.String("project"),
 			ctx.StringSlice("environment"), ctx.StringSlice("service"),
-			ctx.StringSlice("user"), ctx.StringSlice("instance"),
+			identitySlice, ctx.StringSlice("instance"),
 		)
 		cpathObj = obj
 		count = 6

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,6 +22,8 @@ func init() {
 			stdOrgFlag,
 			stdProjectFlag,
 			stdEnvFlag,
+			stdUserFlag,
+			stdMachineFlag,
 			serviceFlag("Use this service.", "default", true),
 			stdInstanceFlag,
 		},


### PR DESCRIPTION
Introduce flags for specifying user or machine identities through
commands that manipulate secrets (set, unset, run, view, etc).

The machine flag automatically prepends `machine-`, ensuring users don't
have to worry about the complexities of the credential path.

Stringing together multiple `--user` and `--machine` flags will turn
them into an OR expression (e.g. `[ian|machine-api-staging-1231fd]`).