### PR TITLE
Extend email in use error to include username

### DIFF
--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -104,7 +104,7 @@ func signup(ctx *cli.Context, subCommand bool) error {
 	user, err := client.Users.Signup(c, &signup, &progress)
 	if err != nil {
 		if strings.Contains(err.Error(), "resource exists") {
-			return errs.NewExitError("Email address in use.")
+			return errs.NewExitError("Username or email address in use.")
 		}
 		return errs.NewExitError("Signup failed, please try again.")
 	}


### PR DESCRIPTION
We should surface this context until we can update the server to provide more granularity.