### PR TITLE
Teach brew install to bypass go check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,9 @@ endif
 
 gocheck:
 ifeq (,$(findstring $(GO_REQUIRED_VERSION),$(shell go version)))
+ifeq (,$(BYPASS_GO_CHECK))
 	$(error "Go Version $(GO_REQUIRED_VERSION) is required.")
+endif
 endif
 
 OS=$(word 1, $(subst -, ,$*))
@@ -201,7 +203,7 @@ $(addprefix binary-,$(TARGETS)): binary-%: gocheck generated vendor
 	GOOS=$(OS) GOARCH=$(ARCH) $(GO_BUILD) $(BINARY) \
 		-ldflags='$(STATIC_FLAGS)' ${PKG}
 
-builds/dist/$(VERSION) builds/dist/rpm builds/dist/brew builds/dist/npm:
+builds/dist/$(VERSION) builds/dist/rpm builds/dist/brew/$(VERSION) builds/dist/npm/$(VERSION):
 	@mkdir -p $@
 
 $(addprefix zip-,$(TARGETS)): zip-%: binary-% builds/dist/$(VERSION)
@@ -235,8 +237,8 @@ builds/torus-$(VERSION).rb: packaging/homebrew/torus.rb.in
 
 release-homebrew: envcheck tagcheck release-homebrew-$(RELEASE_ENV)
 
-release-homebrew-stage: builds/torus-$(VERSION).rb builds/dist/brew
-	cp $< builds/dist/brew/
+release-homebrew-stage: builds/torus-$(VERSION).rb builds/dist/brew/$(VERSION)
+	cp $< builds/dist/brew/$(VERSION)/torus.rb
 
 builds/homebrew-git:
 	git clone --depth=1 git@github.com:manifoldco/homebrew-brew.git \
@@ -253,8 +255,8 @@ release-homebrew-prod: builds/torus-$(VERSION).rb homebrew-git
 
 release-npm: envcheck tagcheck release-npm-$(RELEASE_ENV)
 
-release-npm-stage: builds/torus-npm-$(VERSION).tar.gz builds/dist/npm
-	cp $< builds/dist/npm/
+release-npm-stage: builds/torus-npm-$(VERSION).tar.gz builds/dist/npm/$(VERSION)
+	cp $< builds/dist/npm/$(VERSION)/torus.tar.gz
 
 release-npm-prod: builds/torus-npm-$(VERSION).tar.gz
 	npm publish $<

--- a/packaging/homebrew/torus.rb.in
+++ b/packaging/homebrew/torus.rb.in
@@ -31,7 +31,7 @@ class Torus < Formula
     cd toruspath do
       arch = MacOS.prefer_64_bit? ? "amd64" : "386"
       ENV.deparallelize do
-        system "make", "binary-darwin-#{arch}", "VERSION={{VERSION}}"
+        system "make", "binary-darwin-#{arch}", "VERSION={{VERSION}}", "BYPASS_GO_CHECK=yes"
       end
 
       bin.install "builds/bin/VERSION/darwin/#{arch}/torus"


### PR DESCRIPTION
We can't pick a specific go version for the brew build, so bypass the
check.

For staging prerelease builds, put the formula under a version dir, so
the name matches the class contained within.