### PR TITLE
Status command not display identity properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _Unpublished_
 **Fixes**
 
 - Listing teams no longer results in a panic when an unknown org is specified.
+- `torus status` properly displays the identity segment for a machine in the credential path.
 - Various typo fixes.
 
 ## v0.15.0

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/urfave/cli"
 
+	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/errs"
 )
 
@@ -195,6 +196,35 @@ func identityString(identityType, identity string) (string, error) {
 	}
 
 	return "machine-" + identity, nil
+}
+
+func deriveIdentity(ctx *cli.Context, session *api.Session) (string, error) {
+	if ctx.String("user") != "" && ctx.String("machine") != "" {
+		return "", errs.NewExitError(
+			"You can only supply --user or --machine, not both.")
+	}
+
+	identity := ""
+	if ctx.String("user") != "" {
+		identity = ctx.String("user")
+	}
+
+	var err error
+	if ctx.String("machine") != "" {
+		identity, err = identityString("machine", ctx.String("machine"))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if identity == "" {
+		identity, err = identityString(session.Type(), session.Username())
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return identity, nil
 }
 
 // Derives a slice of identity segments for us in building a PathExp object.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -107,7 +107,12 @@ func statusCmd(ctx *cli.Context) error {
 	fmt.Fprintf(w, "Instance:\t%s\n", instance)
 	w.Flush()
 
-	parts := []string{"", org, project, env, service, session.Username(), instance}
+	identity, err := deriveIdentity(ctx, session)
+	if err != nil {
+		return err
+	}
+
+	parts := []string{"", org, project, env, service, identity, instance}
 	credPath := strings.Join(parts, "/")
 	fmt.Printf("\nCredential path: %s\n", credPath)
 


### PR DESCRIPTION
The status command's "credential path" was not displaying properly for
machines (it was not prepending "machine-").