### PR TITLE
Add deb/apt releases

### DIFF
--- a/packaging/deb/Dockerfile
+++ b/packaging/deb/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.10
+
+RUN apt-get update && \
+	apt-get install -y reprepro && \
+	apt-get clean
+
+VOLUME torus

--- a/packaging/deb/control.in
+++ b/packaging/deb/control.in
@@ -1,0 +1,7 @@
+Package: torus
+Version: VERSION
+Maintainer: Manifold <hello@manifold.co>
+Section: devel
+Priority: optional
+Architecture: ARCH
+Description: Torus is a secure, shared workspace for secrets.

--- a/packaging/deb/distributions.debian
+++ b/packaging/deb/distributions.debian
@@ -1,0 +1,5 @@
+Origin: get.torus.sh
+Label: apt repository
+Architectures: amd64
+Components: main
+Codename: jessie

--- a/packaging/deb/distributions.ubuntu
+++ b/packaging/deb/distributions.ubuntu
@@ -1,0 +1,11 @@
+Origin: get.torus.sh
+Label: apt repository
+Architectures: amd64
+Components: main
+Codename: xenial
+
+Origin: get.torus.sh
+Label: apt repository
+Architectures: amd64
+Components: main
+Codename: trusty


### PR DESCRIPTION
The package is all the same, but releases are broken out for the most
recent debian release, and the last two ubuntu releases. This lets us
craft an apt sources.list line that is familiar to users (including the
distro code name), and provides a nice cut-point for supporting upstart
vs systemd, if we can't fit them both into a single deb.