### PR TITLE
Generate static directory listings for get.torus.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,14 +325,19 @@ release-npm-stage: builds/torus-npm-$(VERSION).tar.gz builds/dist/npm/$(VERSION)
 release-npm-prod: builds/torus-npm-$(VERSION).tar.gz
 	npm publish $<
 
+CDN_INDEXER=tools/cdn-indexer
+$(TOOLS)/cdn-indexer: $(wildcard $(CDN_INDEXER)/*.go) $(wildcard $(CDN_INDEXER)/*.tmpl)
+	$(GO_BUILD) -o $@ ./$(CDN_INDEXER)
+
 RELEASE_TARGETS=\
 	release-binary \
 	release-npm \
 	release-homebrew \
 	apt-repo \
 	$(addprefix yum-,$(LINUX))
-release-all: envcheck tagcheck $(RELEASE_TARGETS)
+release-all: envcheck tagcheck $(RELEASE_TARGETS) $(TOOLS)/cdn-indexer
 	pushd builds/dist && aws s3 cp --recursive . $(TORUS_S3_BUCKET)
+	$(TOOLS)/cdn-indexer -bucket $(TORUS_S3_BUCKET)
 
 .PHONY: envcheck tagcheck gocheck release-all release-binary
 .PHONY: $(addprefix binary-,$(TARGETS)) $(addprefix zip-,$(TARGETS))

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -232,7 +232,7 @@ func deriveIdentitySlice(ctx *cli.Context) ([]string, error) {
 	users := ctx.StringSlice("user")
 	machines := ctx.StringSlice("machine")
 
-	identities := make([]string, 0)
+	var identities []string
 	for _, u := range users {
 		identity, err := identityString("user", u)
 		if err != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -3,6 +3,34 @@ updated: 2016-10-26T21:11:14.319350703-03:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 593d64559f7600f29581a3ee42177f5dbded27a9
+- name: github.com/aws/aws-sdk-go
+  version: 45d21707a58c6bfdf7cf12197d054769d88f7d13
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - private/endpoints
+  - private/protocol
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/s3
+  - service/sts
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
 - name: github.com/BurntSushi/toml

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,3 +18,4 @@ import:
 - package: github.com/kr/text
 - package: gopkg.in/oleiade/reflections.v1
 - package: github.com/donovanhide/eventsource
+- package: github.com/aws/aws-sdk-go

--- a/tools/cdn-indexer/index.html.tmpl
+++ b/tools/cdn-indexer/index.html.tmpl
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>get.torus.sh directory listing</title>
+        <style>
+            .listing {
+                min-height: calc(100vh - 7em);
+            }
+            .footer {
+                margin: 1em 0 0 0;
+                padding: 2em 1em 1em 1em;
+                background-color: #f7f7f8;
+            }
+            .footer .copyright {
+                float: right;
+            }
+
+        </style>
+    </head>
+    <body>
+        <div class="listing">
+        <h4>{{ .Dir }}</h4>
+        <table>
+            {{ if ne .Dir "/" }}
+            <tr class="parent directory">
+                <td><a href="../">parent directory</a></td>
+                <td></td>
+                <td></td>
+            </tr>
+            {{ end }}
+            {{ range .Files }}
+            <tr class="{{ .Type }}">
+                <td class="name"><a href="{{ .Name }}">{{ .Name }}</a></td>
+                <td class="size">{{ if ne .Size 0 }}{{ .Size }}{{ end }}</td>
+                <td class="modified">{{ .Modified }}</td>
+            </tr>
+            {{ end }}
+        </table>
+        </div>
+        <div class="footer">
+            <span class="copyright">© 2016 Manifold</span>
+            <span class="timestamp">Index generated at {{ .Timestamp }}</span>
+        </div>
+    </body>
+</html>

--- a/tools/cdn-indexer/main.go
+++ b/tools/cdn-indexer/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+var t *template.Template
+
+var (
+	bucket    string
+	rawBucket = flag.String("bucket", "", "generate for this bucket")
+)
+
+func init() {
+	flag.Parse()
+
+	bucket = *rawBucket
+	if len(bucket) > 4 && bucket[:5] == "s3://" {
+		bucket = bucket[5:]
+	}
+
+	prefix := "tools/cdn-indexer/"
+	name := filepath.Join(prefix, "index.html.tmpl")
+	t = template.Must(template.ParseFiles(name))
+}
+
+type fileType string
+
+const (
+	directoryType fileType = "directory"
+	genericType            = "generic"
+)
+
+type cdnFile struct {
+	Name     string
+	Type     fileType
+	Size     int64
+	Modified time.Time
+}
+
+// Listings are sorted lexicographically, with directories coming before
+// files.
+type sortCDNFile []cdnFile
+
+func (d sortCDNFile) Len() int      { return len(d) }
+func (d sortCDNFile) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d sortCDNFile) Less(i, j int) bool {
+	if d[i].Type != d[j].Type {
+		return d[i].Type == directoryType
+	}
+
+	return strings.Compare(d[i].Name, d[j].Name) < 0
+}
+
+func main() {
+	sess, err := session.NewSession()
+	if err != nil {
+		log.Println("failed to create session,", err)
+		return
+	}
+
+	svc := s3.New(sess)
+
+	params := &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket), // Required
+	}
+
+	listings := make(map[string][]cdnFile)
+
+	err = svc.ListObjectsV2Pages(params, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+		for _, o := range page.Contents {
+			f := cdnFile{
+				Name:     filepath.Base(*o.Key),
+				Type:     genericType,
+				Size:     *o.Size,
+				Modified: *o.LastModified,
+			}
+
+			// index pages shouldn't list themselves.
+			if f.Name == "index.html" {
+				continue
+			}
+
+			dir := filepath.Dir(*o.Key)
+			listings[dir] = append(listings[dir], f)
+		}
+		return true
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add dirs into their parent listings
+	for dir := range listings {
+		for {
+			f := cdnFile{
+				Name: filepath.Base(dir),
+				Type: directoryType,
+			}
+			if f.Name == "." {
+				break
+			}
+
+			dir = filepath.Dir(dir)
+
+			found := false
+			for _, o := range listings[dir] {
+				if o.Name == f.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				listings[dir] = append(listings[dir], f)
+			}
+		}
+	}
+
+	now := time.Now()
+	for dir, listing := range listings {
+		if dir == "." {
+			dir = "/"
+		}
+
+		sort.Sort(sortCDNFile(listing))
+
+		buf := &bytes.Buffer{}
+		err = t.Execute(buf, struct {
+			Dir       string
+			Files     []cdnFile
+			Timestamp time.Time
+		}{Dir: dir, Files: listing, Timestamp: now})
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		dirPath := dir
+
+		params := &s3.PutObjectInput{
+			Bucket:       aws.String(bucket),
+			Key:          aws.String(filepath.Join(dirPath, "index.html")),
+			Body:         bytes.NewReader(buf.Bytes()),
+			ContentType:  aws.String("text/html"),
+			CacheControl: aws.String("public, max-age=300"),
+		}
+		_, err := svc.PutObject(params)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Printf("Wrote /%s\n", filepath.Join(dirPath, "index.html"))
+	}
+}


### PR DESCRIPTION
tools/cdn-indexer reads the existing files from s3 and generates a
templated index file, then writes it back to s3. It is run during the
`release-all` Makefile target.

This is on top of #50. I'll rebase after that's merged.
