### PR TITLE
Add --format option to view (json, env, verbose)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unpublished
+
+_Unpublished_
+
+**Notable Changes**
+
+- Introduced `--format, -f` to `torus view` for specifying the format of out the output (env, json, verbose).
+- Updated the `--verbose, -v` option for `torus view` to be a shortcut to `--format verbose`.
+
 ## v0.16.0
 
 _2016-11-09_

--- a/apitypes/credential.go
+++ b/apitypes/credential.go
@@ -130,6 +130,15 @@ type credentialImpl struct {
 	} `json:"body"`
 }
 
+// Raw returns the underlying typed value for this Credential.
+func (c *CredentialValue) Raw() (interface{}, error) {
+	if c.IsUnset() {
+		return nil, errors.New("Cannot return raw value of an unset Credential")
+	}
+
+	return c.raw, nil
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (c *CredentialValue) MarshalJSON() ([]byte, error) {
 	impl := credentialImpl{Version: 1}

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +15,9 @@ import (
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
 )
+
+var formatFlag = newPlaceholder("format, f", "FORMAT", "Format used to display data (json, env, verbose)",
+	"env", "TORUS_FORMAT", false)
 
 func init() {
 	view := cli.Command{
@@ -28,9 +32,10 @@ func init() {
 			userFlag("Use this user.", false),
 			machineFlag("Use this machine.", false),
 			stdInstanceFlag,
+			formatFlag,
 			cli.BoolFlag{
 				Name:  "verbose, v",
-				Usage: "list the sources of the values",
+				Usage: "Lists the sources of the secrets (shortcut for --format verbose)",
 			},
 		},
 		Action: chain(
@@ -48,24 +53,79 @@ func viewCmd(ctx *cli.Context) error {
 		return err
 	}
 
-	verbose := ctx.Bool("verbose")
-	if verbose {
-		fmt.Printf("Credential path: %s\n\n", path)
+	if ctx.Bool("verbose") && ctx.IsSet("format") {
+		return errs.NewUsageExitError(
+			"Cannot specify --format and --verbose at the same time", ctx)
 	}
+
+	format := ctx.String("format")
+	if ctx.Bool("verbose") {
+		format = "verbose"
+	}
+
+	switch format {
+	case "env":
+		return printEnvFormat(secrets, path)
+	case "verbose":
+		return printVerboseFormat(secrets, path)
+	case "json":
+		return printJSONFormat(secrets, path)
+	default:
+		return errs.NewUsageExitError("Unknown format: "+format, ctx)
+	}
+}
+
+func printEnvFormat(secrets []apitypes.CredentialEnvelope, path string) error {
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+
+	for _, secret := range secrets {
+		value := (*secret.Body).GetValue()
+		name := (*secret.Body).GetName()
+		key := strings.ToUpper(name)
+		fmt.Fprintf(w, "%s=%s\n", key, value.String())
+	}
+	w.Flush()
+
+	return nil
+}
+
+func printVerboseFormat(secrets []apitypes.CredentialEnvelope, path string) error {
+	fmt.Printf("Credential path: %s\n\n", path)
+
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	for _, secret := range secrets {
 		value := (*secret.Body).GetValue()
 		name := (*secret.Body).GetName()
 		key := strings.ToUpper(name)
-		if verbose {
-			spath := (*secret.Body).GetPathExp().String() + "/" + name
-			fmt.Fprintf(w, "%s=%s\t%s\n", key, value.String(), spath)
-		} else {
-			fmt.Fprintf(w, "%s=%s\n", key, value.String())
-
-		}
+		spath := (*secret.Body).GetPathExp().String() + "/" + name
+		fmt.Fprintf(w, "%s=%s\t%s\n", key, value.String(), spath)
 	}
 	w.Flush()
+
+	return nil
+
+}
+
+func printJSONFormat(secrets []apitypes.CredentialEnvelope, path string) error {
+	keyMap := make(map[string]interface{})
+
+	for _, secret := range secrets {
+		value := (*secret.Body).GetValue()
+		name := (*secret.Body).GetName()
+		v, err := value.Raw()
+		if err != nil {
+			return err
+		}
+
+		keyMap[name] = v
+	}
+
+	str, err := json.MarshalIndent(keyMap, "", "  ")
+	if err != nil {
+		return errs.NewErrorExitError("Could not marshal to json", err)
+	}
+
+	fmt.Printf("%s\n", str)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Implement `--format` supporting `env, json, and verbose` for displaying
secrets with the default being (env).

## Example Usage

```
$ torus help view
NAME:
   torus view - View secrets for the current service and environment

USAGE:
   torus view [command options]

CATEGORY:
   SECRETS

OPTIONS:
   --org ORG, -o ORG                 Use this organization.
   --project PROJECT, -p PROJECT     Use this project.
   --environment ENV, -e ENV         Use this environment.
   --service SERVICE, -s SERVICE     Use this service. (default: default)
   --user USER, -u USER              Use this user.
   --machine MACHINE, -m MACHINE     Use this machine.
   --instance INSTANCE, -i INSTANCE  Use this instance. (default: 1)
   --format FORMAT, -f FORMAT        Format used to display data (json, env, verbose) (default: env)
   --verbose, -v                     Lists the sources of the secrets (shortcut for --format verbose)
$ torus view
SECRETSRUS=sdfsf
$ torus view --format verbose
Credential path: /iantestagained/jackandjill/dev-ian/default/ian/1

SECRETSRUS=sdfsf  /iantestagained/jackandjill/[dev-ian|production]/default/*/*/secretsrus
$ torus view --format json -v
Credential path: /iantestagained/jackandjill/dev-ian/default/ian/1

SECRETSRUS=sdfsf  /iantestagained/jackandjill/[dev-ian|production]/default/*/*/secretsrus
$ torus view --format json
{
  "secretsrus": "sdfsf"
}
$ torus view --format jsfsd
Unknown format: jsfsd.
Usage:
    torus view [command options]
```

Related manifoldco/torus-cli#51