### PR TITLE
Allow bypassing torus root permission checks

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -48,6 +48,11 @@ func init() {
 						Usage:  "Run as a background session daemon",
 						Hidden: true, // not displayed in help; used internally
 					},
+					cli.BoolFlag{
+						Name:   "no-permission-check",
+						Usage:  "Skip Torus root dir permission checks",
+						Hidden: true, // Just for system daemon use
+					},
 				},
 				Action: func(ctx *cli.Context) error {
 					if ctx.Bool("foreground") {
@@ -142,7 +147,8 @@ func spawnDaemon() error {
 }
 
 func startDaemon(ctx *cli.Context) error {
-	torusRoot, err := config.CreateTorusRoot()
+	noPermissionCheck := ctx.Bool("no-permission-check")
+	torusRoot, err := config.CreateTorusRoot(!noPermissionCheck)
 	if err != nil {
 		return errs.NewErrorExitError("Failed to initialize Torus root dir.", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -86,7 +86,7 @@ func torusRootPath() string {
 }
 
 // CreateTorusRoot creates the root directory for the Torus daemon.
-func CreateTorusRoot() (string, error) {
+func CreateTorusRoot(checkPermissions bool) (string, error) {
 	torusRoot := torusRootPath()
 	src, err := os.Stat(torusRoot)
 	if err != nil && !os.IsNotExist(err) {
@@ -110,7 +110,7 @@ func CreateTorusRoot() (string, error) {
 	}
 
 	fMode := src.Mode()
-	if fMode.Perm() != requiredPermissions {
+	if checkPermissions && fMode.Perm() != requiredPermissions {
 		return "", fmt.Errorf("%s has permissions %d requires %d",
 			torusRoot, fMode.Perm(), requiredPermissions)
 	}


### PR DESCRIPTION
For the system wide daemon machine case, we want to have looser
permissions on the torus root dir.

Introduce a hidden flag to bypass permission checks on the torus root
dir, so we can allow the system install to take care of permissions
instead.