### PR TITLE
Include a systemd service with our rpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ _Unpublished_
 
 - Introduced `--format, -f` to `torus view` for specifying the format of out the output (env, json, verbose).
 - Updated the `--verbose, -v` option for `torus view` to be a shortcut to `--format verbose`.
+- Include a systemd service unit with the rpm packaging, to run the torus daemon
+  in a system wide machine mode. When the unit is running, users in the `torus`
+  group can access it. To run the unit, both `TORUS_TOKEN_ID` and
+  `TORUS_TOKEN_SECRE` must be set in `/etc/torus/token.environment`.
 
 ## v0.16.0
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -167,7 +167,7 @@ func startDaemon(ctx *cli.Context) error {
 		return errs.NewErrorExitError("Failed to load config.", err)
 	}
 
-	daemon, err := daemon.New(cfg)
+	daemon, err := daemon.New(cfg, noPermissionCheck)
 	if err != nil {
 		return errs.NewErrorExitError("Failed to create daemon.", err)
 	}

--- a/contrib/systemd/token.environment
+++ b/contrib/systemd/token.environment
@@ -1,0 +1,2 @@
+TORUS_TOKEN_ID=fill_me_in
+TORUS_TOKEN_SECRET=fill_me_in

--- a/contrib/systemd/torus.service
+++ b/contrib/systemd/torus.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Torus daemon
+Documentation=https://www.torus.sh/docs/
+After=network.target
+
+[Service]
+Type=simple
+User=torus
+Environment="TORUS_ROOT=/var/run/torus"
+EnvironmentFile=/etc/torus/token.environment
+ExecStart=/usr/bin/torus daemon start --foreground --no-permission-check
+
+[Install]
+WantedBy=multi-user.target

--- a/daemon/socket/proxy.go
+++ b/daemon/socket/proxy.go
@@ -48,6 +48,11 @@ type AuthProxy struct {
 
 // NewAuthProxy returns a new AuthProxy. It will return an error if creation
 // of the domain socket fails, or the upstream registry URL is misconfigured.
+//
+// If groupShared is true, the domain socket will be readable and writable by
+// both the user and the user's group (so daemon can be accessed by multiple
+// users). If false, the socket will only be readable and writable by the user
+// running the daemon.
 func NewAuthProxy(c *config.Config, sess session.Session, db *db.DB, t *http.Transport,
 	client *registry.Client, logic *logic.Engine, groupShared bool) (*AuthProxy, error) {
 

--- a/daemon/socket/proxy.go
+++ b/daemon/socket/proxy.go
@@ -48,10 +48,10 @@ type AuthProxy struct {
 
 // NewAuthProxy returns a new AuthProxy. It will return an error if creation
 // of the domain socket fails, or the upstream registry URL is misconfigured.
-func NewAuthProxy(c *config.Config, sess session.Session, db *db.DB,
-	t *http.Transport, client *registry.Client, logic *logic.Engine) (*AuthProxy, error) {
+func NewAuthProxy(c *config.Config, sess session.Session, db *db.DB, t *http.Transport,
+	client *registry.Client, logic *logic.Engine, groupShared bool) (*AuthProxy, error) {
 
-	l, err := makeSocket(c.SocketPath)
+	l, err := makeSocket(c.SocketPath, groupShared)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func requestIDHandler(next http.Handler) http.Handler {
 	})
 }
 
-func makeSocket(socketPath string) (net.Listener, error) {
+func makeSocket(socketPath string, groupShared bool) (net.Listener, error) {
 	absPath, err := filepath.Abs(socketPath)
 	if err != nil {
 		return nil, err
@@ -162,9 +162,14 @@ func makeSocket(socketPath string) (net.Listener, error) {
 		return nil, err
 	}
 
+	mode := os.FileMode(0700)
+	if groupShared {
+		mode = 0760
+	}
+
 	// Does not guarantee security; BSD ignores file permissions for sockets
 	// see https://github.com/manifoldco/torus-cli/issues/76 for details
-	if err = os.Chmod(socketPath, 0700); err != nil {
+	if err = os.Chmod(socketPath, mode); err != nil {
 		return nil, err
 	}
 

--- a/packaging/rpm/torus.spec
+++ b/packaging/rpm/torus.spec
@@ -7,19 +7,41 @@ License: BSD
 URL:     https://www.torus.sh
 Source:  builds/bin/%{VERSION}/linux/%{ARCH}/torus
 
+Requires(pre): shadow-utils
 
 %description
 Torus is a secure, shared workspace for secrets.
 
 %install
 rm -rf $RPM_BUILD_ROOT
+
 mkdir -p $RPM_BUILD_ROOT%{_bindir}
 cp %{_sourcedir}/builds/bin/%{REAL_VERSION}/linux/%{ARCH}/torus $RPM_BUILD_ROOT%{_bindir}
 
+mkdir -p $RPM_BUILD_ROOT%{_usr}/lib/systemd/system
+cp %{_sourcedir}/contrib/systemd/torus.service $RPM_BUILD_ROOT%{_usr}/lib/systemd/system/
+
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/torus
+cp %{_sourcedir}/contrib/systemd/token.environment $RPM_BUILD_ROOT%{_sysconfdir}/torus/
+
+mkdir -p $RPM_BUILD_ROOT%{_var}/run/torus
+
+%pre
+getent group torus >/dev/null || groupadd -r torus
+getent passwd torus >/dev/null || \
+    useradd -r -g torus -d /etc/torus -s /sbin/nologin \
+    -c "Torus daemon" torus
+exit 0
 
 %files
 %doc
 %{_bindir}/torus
+%{_usr}/lib/systemd/system/torus.service
+
+%attr(700, torus, torus) %{_sysconfdir}/torus
+%config(noreplace) %attr(600, root, root) %{_sysconfdir}/torus/token.environment
+
+%attr(770, torus, torus) %{_var}/run/torus
 
 
 %changelog


### PR DESCRIPTION
The service can be configured with machine token credentials in
/etc/torus/token.environment, for use in production environments.

Other processes running on the system can access secrets from torus by:
- running as a user in the `torus` group
- setting the TORUS_ROOT environment variable to /var/run/torus

While there is a torus user, this user should *not* be used for running
processes that need access to secrets. It is an isolated sandbox that
has access to the machine's token credentials.