### PR TITLE
Fix build times with gosimple

### DIFF
--- a/api/invites.go
+++ b/api/invites.go
@@ -91,11 +91,7 @@ func (i *InvitesClient) Accept(ctx context.Context, org, email, code string) err
 	}
 
 	_, err = i.client.Do(ctx, req, nil, &reqID, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Associate executes the associate invite request
@@ -125,9 +121,5 @@ func (i *InvitesClient) Approve(ctx context.Context, inviteID identity.ID, outpu
 	}
 
 	_, err = i.client.Do(ctx, req, nil, &reqID, output)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/api/memberships.go
+++ b/api/memberships.go
@@ -91,9 +91,5 @@ func (m *MembershipsClient) Delete(ctx context.Context, membership *identity.ID)
 	}
 
 	_, err = m.client.Do(ctx, req, nil, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/api/policies.go
+++ b/api/policies.go
@@ -106,11 +106,7 @@ func (p *PoliciesClient) Detach(ctx context.Context, attachmentID *identity.ID) 
 		return err
 	}
 	_, err = p.client.Do(ctx, req, nil, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // AttachmentsList retrieves all policy attachments for an org

--- a/api/session.go
+++ b/api/session.go
@@ -183,11 +183,7 @@ func performLogin(ctx context.Context, s *SessionClient, loginType string, rawLo
 	}
 
 	_, err = s.client.Do(ctx, req, nil, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Logout logs the user out of their session
@@ -198,9 +194,5 @@ func (s *SessionClient) Logout(ctx context.Context) error {
 	}
 
 	_, err = s.client.Do(ctx, req, nil, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/api/users.go
+++ b/api/users.go
@@ -43,11 +43,7 @@ func (u *UsersClient) VerifyEmail(ctx context.Context, verifyCode string) error 
 	}
 
 	_, err = u.client.Do(ctx, req, nil, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Update performs a profile update to the user object

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -40,12 +40,7 @@ func login(ctx *cli.Context) error {
 	client := api.NewClient(cfg)
 
 	c := context.Background()
-	err = performLogin(c, client, email, password, true)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return performLogin(c, client, email, password, true)
 }
 
 func performLogin(c context.Context, client *api.Client, email, password string, shouldPrint bool) error {


### PR DESCRIPTION
Use it via gometalinter now, so imports are all correct.

Fix the identified issues, and use a temporary fork of go-bindata so it
won't generate un-simple files.