### PR TITLE
Run all linters with gometalinter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,11 +125,6 @@ fmtcheck:
 
 METALINT=gometalinter --tests --disable-all --vendor --deadline=5m ./... --enable
 
-LINTERS=\
-	gosimple \
-	misspell \
-	ineffassign
-
 $(LINTERS):
 	$(METALINT) $@
 


### PR DESCRIPTION
Then we don't have to worry about identifying which files to run against.

I've also switched to using the `-s --skip` flag to skip over the `data` dir, so we don't have to care about go-bindata's output, removing the need for a fork.