### PR TITLE
Introduce torus template command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## v0.18.0
+
 _Unreleased_
 
 **Notable Changes**
@@ -11,6 +12,10 @@ _Unreleased_
   group can access it. To run the unit, both `TORUS_TOKEN_ID` and
   `TORUS_TOKEN_SECRE` must be set in `/etc/torus/token.environment`. See v0.17.0
   for the matching rpm change.
+- Introduced `torus template [flags] <template-file> [output-file]` for
+  generating a configuration file from a template. The underlying templating
+  engine is [handlebars](https://github.com/aymerick/raymond) allowing Torus to
+  be used in any file based configuration flow.
 
 **Fixes**
 

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aymerick/raymond"
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/errs"
+)
+
+func init() {
+	template := cli.Command{
+		Name:      "template",
+		Usage:     "Generate a config file from a template using secrets stored inside torus",
+		ArgsUsage: "<template-file> [output-file]",
+		Category:  "SECRETS",
+		Flags: []cli.Flag{
+			stdOrgFlag,
+			stdProjectFlag,
+			stdEnvFlag,
+			serviceFlag("Use this service.", "default", true),
+			userFlag("Use this user.", false),
+			machineFlag("Use this machine.", false),
+			stdInstanceFlag,
+		},
+		Action: chain(
+			ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+			setUserEnv, checkRequiredFlags, templateCmd,
+		),
+	}
+
+	Cmds = append(Cmds, template)
+}
+
+func templateCmd(ctx *cli.Context) error {
+
+	outputPath := ""
+	args := ctx.Args()
+
+	if len(args) == 0 {
+		return errs.NewUsageExitError("A template-file must be provided", ctx)
+	} else if len(args) > 2 {
+		return errs.NewUsageExitError("Too many arguments provided", ctx)
+	}
+
+	templatePath, err := filepath.Abs(args[0])
+	if err != nil {
+		return errs.NewErrorExitError("Invalid template file path", err)
+	}
+	if len(args) == 2 {
+		outputPath, err = filepath.Abs(args[1])
+		if err != nil {
+			return errs.NewErrorExitError("Invalid output file path", err)
+		}
+	}
+
+	template, err := loadTemplateFile(templatePath)
+	if err != nil {
+		return err
+	}
+
+	secrets, _, err := getSecrets(ctx)
+	if err != nil {
+		return err
+	}
+
+	output, err := deriveTemplateOutput(template, secrets)
+	if err != nil {
+		return err
+	}
+
+	if outputPath != "" {
+		return writeOutputFile(outputPath, output)
+	}
+
+	fmt.Printf("%s", output)
+	return nil
+}
+
+func loadTemplateFile(templatePath string) (string, error) {
+	buf, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("Could not open template file: %s", templatePath)
+		}
+
+		return "", err
+	}
+
+	return string(buf), nil
+}
+
+// We expose the variables in two ways to the template:
+//
+//  1) Through a _config variable which has a Name and Value property for iterating
+//  2) Directly through the {{ slug }} and {{ Upper(slug) }} for straight referencing
+func deriveTemplateOutput(template string, secrets []apitypes.CredentialEnvelope) (string, error) {
+	variables := make(map[string]interface{})
+	configItems := make([]map[string]string, len(secrets))
+
+	for i, secret := range secrets {
+		value := (*secret.Body).GetValue().String()
+		name := (*secret.Body).GetName()
+		configItems[i] = map[string]string{
+			"name":  name,
+			"value": value,
+		}
+
+		variables[name] = value
+		variables[strings.ToUpper(name)] = value
+	}
+
+	// Export the config inside the template under `_config` without colliding
+	// with the variable namespace
+	variables["_config"] = configItems
+
+	result, err := raymond.Render(template, variables)
+	if err != nil {
+		return "", errs.NewErrorExitError("Could not generate template", err)
+	}
+
+	return result, nil
+}
+
+func writeOutputFile(outputPath, output string) error {
+	err := ioutil.WriteFile(outputPath, []byte(output), 0600)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("File already exists at output path: %s", outputPath)
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -132,3 +132,4 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 - [ ]   `torus run <command> —service [service]` will inject secrets and execute the command
 - [ ]   `torus run <command>` without a service defaults to "default" service
 - [ ]   `torus unset [key] —service [service]` will unset the variable
+- [ ] `torus template` can be used to derive a configuration file

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9ad7d18509e0cfcbf8512a207250a813d46712390483a4f264b6f20aaa3c55af
-updated: 2016-11-18T15:41:29.109385779-04:00
+hash: f6a73b329a544f8270e519a8a0fd9752cba4ae22c7b29cddccff12adcacfb0f7
+updated: 2016-11-25T15:30:52.489196-04:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 0969b5d51be9af32da3f79fbbc4a638d79dc24bf551063399fddf2221aff9e24
-updated: 2016-10-26T21:11:14.319350703-03:00
+hash: 9ad7d18509e0cfcbf8512a207250a813d46712390483a4f264b6f20aaa3c55af
+updated: 2016-11-18T15:41:29.109385779-04:00
 imports:
 - name: github.com/asaskevich/govalidator
-  version: 593d64559f7600f29581a3ee42177f5dbded27a9
+  version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/aws/aws-sdk-go
-  version: 45d21707a58c6bfdf7cf12197d054769d88f7d13
+  version: 96b4ffc754cd7047fb910d74ef9f951cbcb09b4d
   subpackages:
   - aws
   - aws/awserr
@@ -31,12 +31,16 @@ imports:
   - private/waiter
   - service/s3
   - service/sts
+- name: github.com/aymerick/raymond
+  version: a2232af10b53ef1ae5a767f5178db3a6c1dab655
+  subpackages:
+  - ast
+  - lexer
+  - parser
 - name: github.com/boltdb/bolt
-  version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
-- name: github.com/BurntSushi/toml
-  version: 99064174e013895bbd9b025c31100bd1d9b590ca
+  version: 315c65d4cf4f5278c73477a35fb1f9b08365d340
 - name: github.com/chzyer/readline
-  version: bc5c91eb5bc99e662b22bfaa6b84ddc56b70eccc
+  version: c914be64f07d9998f52bf0d598ec26d457168c0f
 - name: github.com/dchest/blake2b
   version: 3c8c640cd7bea3ca78209d812b5854442ab92fed
 - name: github.com/donovanhide/eventsource
@@ -48,66 +52,45 @@ imports:
 - name: github.com/facebookgo/stats
   version: 1b76add642e42c6ffba7211ad7b3939ce654526e
 - name: github.com/go-ini/ini
-  version: 3e15c6754352225de49767249c3680a2fa2201f5
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/go-zoo/bone
-  version: 0237f0c5455f175a6513e21afe050e128902dc7f
-- name: github.com/gorilla/context
-  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
-- name: github.com/gorilla/mux
-  version: cf79e51a62d8219d52060dfc1b4e810414ba2d15
-- name: github.com/julienschmidt/httprouter
-  version: d8ff598a019f2c7bad0980917a588193cf26666e
+  version: 34232a072007f7a1d1e7b5a286cc559ed6a29964
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/kardianos/osext
   version: c2c54e542fb797ad986b31721e1baedf214ca413
 - name: github.com/keybase/go-triplesec
   version: b360b8252869a5ac88df3ed7897bc3b6d1e55dd2
   subpackages:
   - sha3
-- name: github.com/kr/pty
-  version: ce7fa45920dc37a92de8377972e52bc55ffa8d57
 - name: github.com/kr/text
   version: 7cafcd837844e784b526369c9bce262804aebc60
 - name: github.com/natefinch/lumberjack
-  version: e21e5cbec0cd0861b9dc302736ad5666c529d93f
-- name: github.com/nbutton23/zxcvbn-go
-  version: a22cb81b2ecdde8b68e9ffb8824731cbf88e1de4
-  subpackages:
-  - matching
-  - scoring
-  - utils/math
-  - data
-  - match
+  version: dd45e6a67c53f673bb49ca8a001fd3a63ceb640e
 - name: github.com/nightlyone/lockfile
-  version: 3d299f51e376213fcdcfd213a76afce6b290bf9d
+  version: 1d49c987357a327b5b03aa84cbddd582c328615d
 - name: github.com/satori/go.uuid
-  version: 0aa62d5ddceb50dbcb909d790b5345affd3669b6
+  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/urfave/cli
-  version: 207bb6185291cfced4895a7768cad642e08a68d8
+  version: b4f4786f378c0c1d3336b5bb798094b166edf5a9
 - name: golang.org/x/crypto
-  version: b35ccbc95a0eaae49fb65c5d627cb7149ed8d1ab
+  version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
   subpackages:
-  - acme/internal/acme
-  - blowfish
+  - curve25519
+  - ed25519
   - ed25519/internal/edwards25519
+  - nacl/box
   - nacl/secretbox
-  - salsa20/salsa
+  - pbkdf2
   - poly1305
-  - openpgp/armor
-  - openpgp/errors
-  - openpgp/packet
-  - openpgp/s2k
-  - pkcs12/internal/rc2
-- name: golang.org/x/net
-  version: 7394c112eae4dba7e96bfcfe738e6373d61772b4
-  subpackages:
-  - context
-  - context/ctxhttp
+  - salsa20
+  - salsa20/salsa
+  - scrypt
+  - twofish
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: b699b7032584f0953262cb2788a0ca19bb494703
   subpackages:
   - unix
 - name: gopkg.in/oleiade/reflections.v1
   version: 2b6ec3da648e3e834dc41bad8d9ed7f2dc6a9496
-- name: gopkg.in/yaml.v2
-  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,4 +19,3 @@ import:
 - package: gopkg.in/oleiade/reflections.v1
 - package: github.com/donovanhide/eventsource
 - package: github.com/aws/aws-sdk-go
-- package: github.com/aymerick/raymond

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,3 +19,4 @@ import:
 - package: gopkg.in/oleiade/reflections.v1
 - package: github.com/donovanhide/eventsource
 - package: github.com/aws/aws-sdk-go
+- package: github.com/aymerick/raymond

--- a/promptui/select.go
+++ b/promptui/select.go
@@ -25,7 +25,7 @@ func (s *Select) Run() (int, string, error) {
 }
 
 func (s *Select) innerRun(starting int, top rune) (int, string, error) {
-	stdin := readline.NewCancelableStdin()
+	stdin := readline.NewCancelableStdin(os.Stdin)
 	c := &readline.Config{}
 	err := c.Init()
 	if err != nil {


### PR DESCRIPTION
The `torus template` command allows a user to inject secrets stored in
torus as they derive a configuration file from a template.

The current templating engine is the [raymond
handlebars](https://github.com/aymerick/raymond) engine for Go
which supports v3 of the handlebars spec.

### Example Usage

Simple variable replacement example with a json file:

```bash
$ cat test.json.template
{
    "message": "{{ message }}",
    "port": {{ port }}
}
$ ./torus template test.json.template
{
    "message": "this value was set using ag",
    "port": 34234
}
```

Outputting to a file instead of stdout using the optional output parameter:

```bash
$ ./torus template test.json.template config.json
$ cat config.json
{
    "message": "this value was set using ag",
    "port": 34234
}
```

Iterating over the special `_config` variable:

```bash
$ cat test.json.template
{
    "message": "{{ message }}",
    "port": {{ port }},
    "config": {
    {{#each _config}}
        "{{ name }}": "{{ value }}"{{#unless @last}},{{/unless}}
    {{/each}}
    }
}
$ ./torus template test.json.template
{
    "message": "this value was set using ag",
    "port": 4432,
    "config": {
        "message": "this value was set using ag",
        "port": "4432",
        "test_db": "testdburl"
    }
}
```

Closes manifoldco/torus-cli#51