### PR TITLE
Re-organization of commands, in preparation for docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+_Unreleased_
+
+**Notable Changes**
+
+- Re-organization of commands and editing of help output.
+
 ## v0.18.0
 
 **Fixes**

--- a/cmd/allow.go
+++ b/cmd/allow.go
@@ -20,7 +20,7 @@ import (
 func init() {
 	allow := cli.Command{
 		Name:      "allow",
-		Usage:     "Grant a team or machine role permission to access specific resources",
+		Usage:     "Increase access given to a team or role by creating and attaching a new policy",
 		ArgsUsage: "<crudl> <path> <team|machine-role>",
 		Category:  "ACCESS CONTROL",
 		Action:    chain(ensureDaemon, ensureSession, allowCmd),

--- a/cmd/deny.go
+++ b/cmd/deny.go
@@ -9,7 +9,7 @@ import (
 func init() {
 	deny := cli.Command{
 		Name:      "deny",
-		Usage:     "Deny a team or machine role permission to access specific resources",
+		Usage:     "Decrease access given to a team or role by creating and attaching a new policy",
 		ArgsUsage: "<crudl> <path> <team|machine-role>",
 		Category:  "ACCESS CONTROL",
 		Action:    chain(ensureDaemon, ensureSession, denyCmd),

--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -18,8 +18,8 @@ import (
 func init() {
 	envs := cli.Command{
 		Name:     "envs",
-		Usage:    "View and manipulate environments within an organization",
-		Category: "ORGANIZATIONS",
+		Usage:    "Manage environments within an organization",
+		Category: "PROJECT STRUCTURE",
 		Subcommands: []cli.Command{
 			{
 				Name:  "create",

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -21,7 +21,7 @@ func init() {
 	link := cli.Command{
 		Name:     "link",
 		Usage:    "Link your current directory to Torus",
-		Category: "CONTEXT",
+		Category: "PROJECT STRUCTURE",
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "force, f",

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	login := cli.Command{
 		Name:     "login",
-		Usage:    "Log in to your Torus account",
+		Usage:    "Log in to a user account, authenticating the CLI",
 		Category: "ACCOUNT",
 		Action:   chain(ensureDaemon, login),
 	}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	logout := cli.Command{
 		Name:     "logout",
-		Usage:    "Log out of your Torus account",
+		Usage:    "Destroy the current active session, unauthenticating the CLI",
 		Category: "ACCOUNT",
 		Action:   chain(ensureDaemon, logoutCmd),
 	}

--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -58,19 +58,6 @@ func init() {
 				),
 			},
 			{
-				Name:      "destroy",
-				Usage:     "Destroy a machine in the specified organization",
-				ArgsUsage: "<id|name>",
-				Flags: []cli.Flag{
-					orgFlag("Org the machine will belongs to", true),
-					stdAutoAcceptFlag,
-				},
-				Action: chain(
-					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					checkRequiredFlags, destroyMachineCmd,
-				),
-			},
-			{
 				Name:  "list",
 				Usage: "List machines for an organization",
 				Flags: []cli.Flag{
@@ -84,21 +71,23 @@ func init() {
 				),
 			},
 			{
+				Name:      "destroy",
+				Usage:     "Destroy a machine in the specified organization",
+				ArgsUsage: "<id|name>",
+				Flags: []cli.Flag{
+					orgFlag("Org the machine will belongs to", true),
+					stdAutoAcceptFlag,
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					checkRequiredFlags, destroyMachineCmd,
+				),
+			},
+			{
 				Name:      "roles",
 				Usage:     "Lists and create machine roles for an organization",
 				ArgsUsage: "<machine-role>",
 				Subcommands: []cli.Command{
-					{
-						Name:  "list",
-						Usage: "List all machine roles for an organization",
-						Flags: []cli.Flag{
-							orgFlag("Org the machine roles belongs to", true),
-						},
-						Action: chain(
-							ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-							checkRequiredFlags, listMachineRoles,
-						),
-					},
 					{
 						Name:      "create",
 						Usage:     "Create a machine role for an organization",
@@ -109,6 +98,17 @@ func init() {
 						Action: chain(
 							ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
 							checkRequiredFlags, createMachineRole,
+						),
+					},
+					{
+						Name:  "list",
+						Usage: "List all machine roles for an organization",
+						Flags: []cli.Flag{
+							orgFlag("Org the machine roles belongs to", true),
+						},
+						Action: chain(
+							ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+							checkRequiredFlags, listMachineRoles,
 						),
 					},
 				},

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -20,7 +20,7 @@ import (
 func init() {
 	policies := cli.Command{
 		Name:     "policies",
-		Usage:    "View and manipulate access control list policies",
+		Usage:    "Manage which resources machines and users can access",
 		Category: "ACCESS CONTROL",
 		Subcommands: []cli.Command{
 			{
@@ -36,7 +36,7 @@ func init() {
 			},
 			{
 				Name:      "view",
-				Usage:     "Display the contents of an ACL policy",
+				Usage:     "Display the contents of a policy",
 				ArgsUsage: "<policy>",
 				Flags: []cli.Flag{
 					orgFlag("org to show policies for", true),
@@ -49,7 +49,7 @@ func init() {
 
 			{
 				Name:      "detach",
-				Usage:     "Detach a policy from a team or machine role, does not delete the policy",
+				Usage:     "Detach (but not delete) a policy from a team or role",
 				ArgsUsage: "<name> <team|role>",
 				Flags: []cli.Flag{
 					orgFlag("org to detach policy from", true),

--- a/cmd/prefs.go
+++ b/cmd/prefs.go
@@ -17,8 +17,8 @@ import (
 func init() {
 	prefs := cli.Command{
 		Name:     "prefs",
-		Usage:    "View and set preferences",
-		Category: "ACCOUNT",
+		Usage:    "Manage tool preferences",
+		Category: "SYSTEM",
 		Subcommands: []cli.Command{
 			{
 				Name:      "set",

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -18,20 +18,9 @@ import (
 func init() {
 	projects := cli.Command{
 		Name:     "projects",
-		Usage:    "View and manipulate projects within an organization",
-		Category: "ORGANIZATIONS",
+		Usage:    "Manage projects within an organization",
+		Category: "PROJECT STRUCTURE",
 		Subcommands: []cli.Command{
-			{
-				Name:  "list",
-				Usage: "List services for an organization",
-				Flags: []cli.Flag{
-					orgFlag("List projects in an organization", true),
-				},
-				Action: chain(
-					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, listProjectsCmd,
-				),
-			},
 			{
 				Name:      "create",
 				Usage:     "Create a project in an organization",
@@ -42,6 +31,17 @@ func init() {
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
 					createProjectCmd,
+				),
+			},
+			{
+				Name:  "list",
+				Usage: "List services for an organization",
+				Flags: []cli.Flag{
+					orgFlag("List projects in an organization", true),
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					setUserEnv, checkRequiredFlags, listProjectsCmd,
 				),
 			},
 		},

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -18,9 +18,22 @@ import (
 func init() {
 	services := cli.Command{
 		Name:     "services",
-		Usage:    "View and manipulate services within an organization",
-		Category: "ORGANIZATIONS",
+		Usage:    "Manage services within an organization",
+		Category: "PROJECT STRUCTURE",
 		Subcommands: []cli.Command{
+			{
+				Name:      "create",
+				Usage:     "Create a service in an organization",
+				ArgsUsage: "[name]",
+				Flags: []cli.Flag{
+					orgFlag("Create the project in this org", false),
+					projectFlag("project to create services for", false),
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					createServiceCmd,
+				),
+			},
 			{
 				Name:  "list",
 				Usage: "List services for an organization",
@@ -35,19 +48,6 @@ func init() {
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
 					setUserEnv, checkRequiredFlags, listServicesCmd,
-				),
-			},
-			{
-				Name:      "create",
-				Usage:     "Create a service in an organization",
-				ArgsUsage: "[name]",
-				Flags: []cli.Flag{
-					orgFlag("Create the project in this org", false),
-					projectFlag("project to create services for", false),
-				},
-				Action: chain(
-					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					createServiceCmd,
 				),
 			},
 		},

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -15,11 +15,10 @@ import (
 
 func init() {
 	signup := cli.Command{
-		Name:      "signup",
-		Usage:     "Create a new Torus account",
-		ArgsUsage: "[email] [code]",
-		Category:  "ACCOUNT",
-		Action:    chain(ensureDaemon, signupCmd),
+		Name:     "signup",
+		Usage:    "Create a new Torus account",
+		Category: "ACCOUNT",
+		Action:   chain(ensureDaemon, signupCmd),
 	}
 	Cmds = append(Cmds, signup)
 }
@@ -33,7 +32,8 @@ func signupCmd(ctx *cli.Context) error {
 // and not as a generic signup
 func signup(ctx *cli.Context, subCommand bool) error {
 	args := ctx.Args()
-	if len(args) > 0 && len(args) != 2 {
+	// Arguments are only used as a subcommand
+	if subCommand && (len(args) > 0 && len(args) != 2) {
 		var text string
 		if len(args) > 2 {
 			text = "Too many arguments supplied."

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -19,7 +19,7 @@ func init() {
 	status := cli.Command{
 		Name:     "status",
 		Usage:    "Show the current Torus status associated with your account and project",
-		Category: "CONTEXT",
+		Category: "PROJECT STRUCTURE",
 		Flags: []cli.Flag{
 			stdEnvFlag,
 			serviceFlag("Use this service.", "default", true),

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -23,19 +23,19 @@ import (
 func init() {
 	teams := cli.Command{
 		Name:     "teams",
-		Usage:    "View and manipulate teams within an organization",
-		Category: "ORGANIZATIONS",
+		Usage:    "Manage teams and their members",
+		Category: "ACCESS CONTROL",
 		Subcommands: []cli.Command{
 			{
-				Name:      "members",
-				Usage:     "List members of a particular team in and organization",
-				ArgsUsage: "<team>",
+				Name:      "create",
+				Usage:     "Create a team in an organization",
+				ArgsUsage: "[name]",
 				Flags: []cli.Flag{
-					stdOrgFlag,
+					orgFlag("Create the team in this org", false),
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, teamMembersListCmd,
+					createTeamCmd,
 				),
 			},
 			{
@@ -50,27 +50,15 @@ func init() {
 				),
 			},
 			{
-				Name:      "create",
-				Usage:     "Create a team in an organization",
-				ArgsUsage: "[name]",
-				Flags: []cli.Flag{
-					orgFlag("Create the team in this org", false),
-				},
-				Action: chain(
-					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					createTeamCmd,
-				),
-			},
-			{
-				Name:      "remove",
-				Usage:     "Remove user from a specified team in an organization you administer",
-				ArgsUsage: "<username> <team>",
+				Name:      "members",
+				Usage:     "List members of a particular team in and organization",
+				ArgsUsage: "<team>",
 				Flags: []cli.Flag{
 					stdOrgFlag,
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, teamsRemoveCmd,
+					setUserEnv, checkRequiredFlags, teamMembersListCmd,
 				),
 			},
 			{
@@ -83,6 +71,18 @@ func init() {
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
 					setUserEnv, checkRequiredFlags, teamsAddCmd,
+				),
+			},
+			{
+				Name:      "remove",
+				Usage:     "Remove user from a specified team in an organization you administer",
+				ArgsUsage: "<username> <team>",
+				Flags: []cli.Flag{
+					stdOrgFlag,
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					setUserEnv, checkRequiredFlags, teamsRemoveCmd,
 				),
 			},
 		},

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -15,7 +15,7 @@ func init() {
 	unlink := cli.Command{
 		Name:     "unlink",
 		Usage:    "Remove the link between this project and Torus",
-		Category: "CONTEXT",
+		Category: "PROJECT STRUCTURE",
 		Action:   unlinkCmd,
 	}
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -16,7 +16,7 @@ func init() {
 	version := cli.Command{
 		Name:      "verify",
 		ArgsUsage: "<code>",
-		Usage:     "Verify the email address for your account",
+		Usage:     "Verify an email address for your account",
 		Category:  "ACCOUNT",
 		Action: chain(
 			ensureDaemon, ensureSession, verifyEmailCmd,


### PR DESCRIPTION
```
NAME:
   torus - A secure, shared workspace for secrets

USAGE:
   torus [global options] command [command options] [arguments...]

VERSION:
   0.17.0

COMMANDS:
     help, h  Shows a list of commands or help for one command

   ACCESS CONTROL:
     allow     Increase access given to a team or role by creating and attaching a new policy
     deny      Decrease access given to a team or role by creating and attaching a new policy
     policies  Manage which resources machines and users can access
     teams     Manage teams and their members

   ACCOUNT:
     login    Log in to a user account, authenticating the CLI
     logout   Destroy the current active session, unauthenticating the CLI
     profile  Manage your Torus account
     signup   Create a new Torus account
     verify   Verify an email address for your account

   ORGANIZATIONS:
     invites   View and accept organization invites
     keypairs  View and generate organization keypairs
     machines  View and create machines within an organization
     orgs      View and create organizations
     worklog   View and perform maintenance tasks

   PROJECT STRUCTURE:
     envs      Manage environments within an organization
     link      Link your current directory to Torus
     projects  Manage projects within an organization
     services  Manage services within an organization
     status    Show the current Torus status associated with your account and project
     unlink    Remove the link between this project and Torus

   SECRETS:
     ls     Explore all objects your account has access to
     run    Run a process and inject secrets into its environment
     set    Set a secret for a service and environment
     unset  Remove a secret from a service and environment
     view   View secrets for the current service and environment

   SYSTEM:
     daemon   Manage the session daemon
     prefs    Manage tool preferences
     version  Display versions of utility components

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version

```