### PR TITLE
Create cmdlint for linting our commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LINTERS=\
 	ineffassign
 
 all: binary
-ci: binary $(LINTERS) test
+ci: binary $(LINTERS) cmdlint test
 
 .PHONY: all ci
 
@@ -112,7 +112,13 @@ METALINT=gometalinter --tests --disable-all --vendor --deadline=5m -s data \
 $(LINTERS):
 	$(METALINT) $@
 
-.PHONY: $(LINTERS) test
+$(TOOLS)/cmdlint: $(wildcard tools/cmdlint/*.go) $(wildcard cmd/*.go)
+	$(GO_BUILD) -o $@ ./tools/cmdlint
+
+cmdlint: $(TOOLS)/cmdlint
+	$(TOOLS)/cmdlint
+
+.PHONY: $(LINTERS) $(TOOLS)/cmdlint test
 
 #################################################
 # Docker targets

--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -46,18 +46,6 @@ func init() {
 				),
 			},
 			{
-				Name:      "view",
-				Usage:     "Show the details of a machine",
-				ArgsUsage: "<id|name>",
-				Flags: []cli.Flag{
-					orgFlag("Org the machine will belongs to", true),
-				},
-				Action: chain(
-					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					checkRequiredFlags, viewMachineCmd,
-				),
-			},
-			{
 				Name:  "list",
 				Usage: "List machines for an organization",
 				Flags: []cli.Flag{
@@ -68,6 +56,18 @@ func init() {
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
 					checkRequiredFlags, listMachinesCmd,
+				),
+			},
+			{
+				Name:      "view",
+				Usage:     "Show the details of a machine",
+				ArgsUsage: "<id|name>",
+				Flags: []cli.Flag{
+					orgFlag("Org the machine will belongs to", true),
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					checkRequiredFlags, viewMachineCmd,
 				),
 			},
 			{

--- a/tools/cmdlint/main.go
+++ b/tools/cmdlint/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/torus-cli/cmd"
+)
+
+func lintCmd(c cli.Command) error {
+	var err error
+	order := []string{"create", "list", "view", "delete"}
+	var neworder []string
+
+orderLoop:
+	for _, o := range order {
+		for _, s := range c.Subcommands {
+			if s.Names()[0] == o {
+				neworder = append(neworder, o)
+				continue orderLoop
+			}
+		}
+	}
+
+	for _, s := range c.Subcommands {
+		name := s.Names()[0]
+		if len(neworder) == 0 {
+			break
+		}
+		if neworder[0] == name {
+			neworder = neworder[1:]
+		}
+
+		for _, o := range neworder {
+			if o == name {
+				fmt.Printf("Error: %s standard subcommand '%s' out of order\n",
+					c.FullName(), name)
+				err = errors.New("subcommand out of order")
+			}
+		}
+	}
+
+	for _, s := range c.Subcommands {
+		newerr := lintCmd(s)
+		if newerr != nil {
+			err = newerr
+		}
+	}
+
+	return err
+}
+
+func main() {
+	var err error
+	for _, c := range cmd.Cmds {
+		newerr := lintCmd(c)
+		if newerr != nil {
+			err = newerr
+		}
+	}
+
+	if err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
For starters it enforces ordering of standard subcommand names.