### PR TITLE
Add systemd machine setup for deb packaging, too!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # CHANGELOG
 
+## v0.18.0
 _Unreleased_
 
 **Notable Changes**
 
 - Re-organization of commands and editing of help output.
-
-## v0.18.0
+- Include a systemd service unit with deb packaging, to run the torus daemon in
+  a system wide machine mode. When the unit is running, users in the `torus`
+  group can access it. To run the unit, both `TORUS_TOKEN_ID` and
+  `TORUS_TOKEN_SECRE` must be set in `/etc/torus/token.environment`. See v0.17.0
+  for the matching rpm change.
 
 **Fixes**
 
-- Fixed "unauthorized" error which occurred while updating email and password at same time.
+- Fixed "unauthorized" error which occurred while updating email and password at
+  same time.
 
 ## v0.17.0
 

--- a/Makefile
+++ b/Makefile
@@ -233,10 +233,18 @@ $(addprefix deb-,$(LINUX)): deb-%: binary-% builds/deb deb-container
 	docker run -v $(PWD):/torus manifoldco/torus-deb /bin/bash -c " \
 		mkdir -p deb-tmp/torus/DEBIAN && \
 		mkdir -p deb-tmp/torus/usr/bin && \
+		mkdir -p deb-tmp/torus/etc/torus && \
+		mkdir -p deb-tmp/torus/lib/systemd/system && \
 		cp /torus/builds/bin/$(VERSION)/$(OS)/$(ARCH)/torus \
 			deb-tmp/torus/usr/bin/ && \
+		cp /torus/contrib/systemd/torus.service \
+			deb-tmp/torus/lib/systemd/system && \
+		cp /torus/contrib/systemd/token.environment \
+			deb-tmp/torus/etc/torus && \
 		sed 's/VERSION/$(VERSION)/' < /torus/packaging/deb/control.in | \
 			sed 's/ARCH/$(ARCH)/' > deb-tmp/torus/DEBIAN/control && \
+		cp /torus/packaging/deb/postinst \
+			deb-tmp/torus/DEBIAN/postinst && \
 		cd deb-tmp && \
 		dpkg-deb -b torus && \
 		cp torus.deb /torus/builds/deb/torus_$(VERSION)_$(ARCH).deb \

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+addgroup --quiet --system torus
+adduser --quiet --system --group --no-create-home --home /etc/torus \
+	--gecos "Torus daemon user" torus
+
+if [ "$1" = "configure" ]; then
+	chown torus:torus /etc/torus
+	chmod 700 /etc/torus
+	chmod 600 /etc/torus/token.environment
+	mkdir -p -m 770 /var/run/torus
+	chown torus:torus /var/run/torus
+fi


### PR DESCRIPTION
All of the deb based distros we support use systemd, so we don't need an
upstart configuration.

Closes #74