### PR TITLE
Support creating missing keypairs via worklog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ _Unreleased_
   group can access it. To run the unit, both `TORUS_TOKEN_ID` and
   `TORUS_TOKEN_SECRE` must be set in `/etc/torus/token.environment`. See v0.17.0
   for the matching rpm change.
+- Teach `worklog` about missing user keypairs.
+- Unhide `worklog resolve`, as it can now be used to generate missing keypairs
+  for an org.
 
 **Fixes**
 

--- a/apitypes/worklog.go
+++ b/apitypes/worklog.go
@@ -14,7 +14,11 @@ type WorklogType byte
 // The enumberated byte types of WorklogItems
 const (
 	SecretRotateWorklogType WorklogType = 1 << iota
+	MissingKeypairsWorklogType
 )
+
+// WorklogResultType is the string type of worklog results
+type WorklogResultType string
 
 // WorklogResult result states.
 const (
@@ -74,6 +78,8 @@ func (t WorklogType) String() string {
 	switch t {
 	case SecretRotateWorklogType:
 		return "secret"
+	case MissingKeypairsWorklogType:
+		return "keypairs"
 	default:
 		return "n/a"
 	}

--- a/cmd/worklog.go
+++ b/cmd/worklog.go
@@ -48,7 +48,6 @@ func init() {
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
 					checkRequiredFlags, worklogResolve,
 				),
-				Hidden: true, // XXX nothing can be resolved automatically yet
 			},
 		},
 	}

--- a/daemon/routes/worklog.go
+++ b/daemon/routes/worklog.go
@@ -92,7 +92,14 @@ func worklogResolveRoute(engine *logic.Engine, o *observer.Observer) http.Handle
 			return
 		}
 
-		res, err := engine.Worklog.Resolve(ctx, &orgID, &ident)
+		n, err := o.Notifier(ctx, 1)
+		if err != nil {
+			log.Printf("Error creating Notifier: %s", err)
+			encodeResponseErr(w, err)
+			return
+		}
+
+		res, err := engine.Worklog.Resolve(ctx, n, &orgID, &ident)
 		if err != nil {
 			log.Printf("error resolving worklog item: %s", err)
 			encodeResponseErr(w, err)


### PR DESCRIPTION
```
$ ./torus worklog list --org badkeys
IDENTITY         TYPE      SUBJECT
0a74q6462ymxf5g  keypairs  badkeys
$ ./torus worklog resolve --org badkeys
✔  0a74q6462ymxf5g  Keypairs generated.
$ ./torus worklog list --org badkeys
IDENTITY  TYPE  SUBJECT
```