### PR TITLE
Add prefs for core.hints and core.progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.19.0
+
+_Unreleased_
+
+**Notable Changes**
+
+- Add preferences for `core.disable_progress` and `core.disable_hints` to control levels of output
+  in preparation for additional onboarding output.
+
 ## v0.18.0
 
 _2016-11-30_

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,12 +3,12 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/urfave/cli"
 
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/config"
+	"github.com/manifoldco/torus-cli/ui"
 )
 
 // Cmds is the list of all cli commands
@@ -16,7 +16,7 @@ var Cmds []cli.Command
 
 var progress api.ProgressFunc = func(evt *api.Event, err error) {
 	if evt != nil {
-		fmt.Println(evt.Message)
+		ui.Progress(evt.Message)
 	}
 }
 

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -90,7 +90,7 @@ func debugInfoCmd(ctx *cli.Context) error {
 
 	// Which registry
 	var registryURI string
-	preferences, err := prefs.NewPreferences(true)
+	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		registryURI = "Failed to load prefs"
 	} else {

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func linkCmd(ctx *cli.Context) error {
-	preferences, err := prefs.NewPreferences(true)
+	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return err
 	}

--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -160,7 +160,7 @@ func ensureSession(ctx *cli.Context) error {
 
 // loadDirPrefs loads argument values from the .torus.json file
 func loadDirPrefs(ctx *cli.Context) error {
-	p, err := prefs.NewPreferences(true)
+	p, err := prefs.NewPreferences()
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func loadDirPrefs(ctx *cli.Context) error {
 // loadPrefDefaults loads default argument values from the .torusrc
 // preferences file defaults section, inserting them into any unset flag values
 func loadPrefDefaults(ctx *cli.Context) error {
-	p, err := prefs.NewPreferences(true)
+	p, err := prefs.NewPreferences()
 	if err != nil {
 		return err
 	}

--- a/cmd/prefs.go
+++ b/cmd/prefs.go
@@ -42,7 +42,7 @@ func init() {
 
 func listPref(ctx *cli.Context) error {
 	const loadErr = "Failed to load prefs."
-	preferences, err := prefs.NewPreferences(false)
+	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return errs.NewErrorExitError(loadErr, err)
 	}
@@ -83,7 +83,7 @@ func listPref(ctx *cli.Context) error {
 }
 
 func setPref(ctx *cli.Context) error {
-	preferencess, err := prefs.NewPreferences(false)
+	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return errs.NewErrorExitError("Failed to load prefs.", err)
 	}
@@ -113,7 +113,7 @@ func setPref(ctx *cli.Context) error {
 	}
 
 	// Set value inside prefs struct
-	result, err := preferencess.SetValue(key, value)
+	result, err := preferences.SetValue(key, value)
 	if err != nil {
 		return err
 	}

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -52,7 +52,7 @@ func AskPerform(label string) error {
 
 // ConfirmDialogue prompts the user to confirm their action
 func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string, allowSkip bool) error {
-	preferences, err := prefs.NewPreferences(true)
+	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return err
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -51,7 +51,7 @@ func init() {
 }
 
 func statusCmd(ctx *cli.Context) error {
-	preferences, err := prefs.NewPreferences(true)
+	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 
 // NewConfig returns a new Config, with loaded user preferences.
 func NewConfig(torusRoot string) (*Config, error) {
-	preferences, err := prefs.NewPreferences(true)
+	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 		cmd.VersionLookup(ctx)
 	}
 
-	preferences, _ := prefs.NewPreferences(true)
+	preferences, _ := prefs.NewPreferences()
 	ui.Init(preferences)
 
 	app := cli.NewApp()

--- a/main.go
+++ b/main.go
@@ -7,12 +7,17 @@ import (
 
 	"github.com/manifoldco/torus-cli/cmd"
 	"github.com/manifoldco/torus-cli/config"
+	"github.com/manifoldco/torus-cli/prefs"
+	"github.com/manifoldco/torus-cli/ui"
 )
 
 func main() {
 	cli.VersionPrinter = func(ctx *cli.Context) {
 		cmd.VersionLookup(ctx)
 	}
+
+	preferences, _ := prefs.NewPreferences(true)
+	ui.Init(preferences)
 
 	app := cli.NewApp()
 	app.Version = config.Version

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -43,11 +43,13 @@ func (prefs Preferences) CountFields(fieldName string) int {
 
 // Core contains core option values
 type Core struct {
-	PublicKeyFile string `ini:"public_key_file,omitempty"`
-	CABundleFile  string `ini:"ca_bundle_file,omitempty"`
-	RegistryURI   string `ini:"registry_uri,omitempty"`
-	Context       bool   `ini:"context,omitempty"`
-	AutoConfirm   bool   `ini:"auto_confirm,omitempty"`
+	PublicKeyFile  string `ini:"public_key_file,omitempty"`
+	CABundleFile   string `ini:"ca_bundle_file,omitempty"`
+	RegistryURI    string `ini:"registry_uri,omitempty"`
+	Context        bool   `ini:"context,omitempty"`
+	AutoConfirm    bool   `ini:"auto_confirm,omitempty"`
+	EnableProgress bool   `ini:"progress"`
+	EnableHints    bool   `ini:"hints"`
 }
 
 // Defaults contains default values for use in command argument flags
@@ -124,8 +126,10 @@ func NewPreferences(useDefaults bool) (*Preferences, error) {
 	if useDefaults {
 		prefs = &Preferences{
 			Core: Core{
-				RegistryURI: registryURI,
-				Context:     true,
+				RegistryURI:    registryURI,
+				Context:        true,
+				EnableHints:    true,
+				EnableProgress: true,
 			},
 		}
 	}
@@ -137,13 +141,13 @@ func NewPreferences(useDefaults bool) (*Preferences, error) {
 	}
 
 	if err != nil {
-		return nil, err
+		return prefs, err
 	}
 
 	rcPath, _ := RcPath()
 	err = ini.MapTo(prefs, rcPath)
 	if err != nil {
-		return nil, err
+		return prefs, err
 	}
 
 	return prefs, nil

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -121,17 +121,14 @@ func RcPath() (string, error) {
 }
 
 // NewPreferences returns a new instance of preferences struct
-func NewPreferences(useDefaults bool) (*Preferences, error) {
-	prefs := &Preferences{}
-	if useDefaults {
-		prefs = &Preferences{
-			Core: Core{
-				RegistryURI:    registryURI,
-				Context:        true,
-				EnableHints:    true,
-				EnableProgress: true,
-			},
-		}
+func NewPreferences() (*Preferences, error) {
+	prefs := &Preferences{
+		Core: Core{
+			RegistryURI:    registryURI,
+			Context:        true,
+			EnableHints:    true,
+			EnableProgress: true,
+		},
 	}
 
 	filePath, _ := RcPath()

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1,0 +1,35 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/manifoldco/torus-cli/prefs"
+)
+
+// enableProgress is whether progress events should be displayed
+var enableProgress = false
+
+// enableHints is whether hints should be displayed
+var enableHints = false
+
+// Init prepares the ui preferences
+func Init(preferences *prefs.Preferences) {
+	enableProgress = preferences.Core.EnableProgress
+	enableHints = preferences.Core.EnableHints
+}
+
+// Progress handles the ui output for progress events, when enabled
+func Progress(str string) {
+	if !enableProgress {
+		return
+	}
+	fmt.Println(str)
+}
+
+// Hint handles the ui output for hint/onboarding messages, when enabled
+func Hint(str string) {
+	if !enableHints {
+		return
+	}
+	fmt.Println(str)
+}


### PR DESCRIPTION
- Introduces `ui` package, which will be home to any ui output functions
  - Will come in handy as we standardize all outputs per the style guide
- Adds prefs for `core.hints` and `core.progress` to enable (default) or disable these outputs