### PR TITLE
Add invite approval to the worklog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ _Unreleased_
   `TORUS_TOKEN_SECRE` must be set in `/etc/torus/token.environment`. See v0.17.0
   for the matching rpm change.
 - Teach `worklog` about missing user keypairs.
+- Teach `worklog` about approving invites.
 - Unhide `worklog resolve`, as it can now be used to generate missing keypairs
-  for an org.
+  for an org, or approve an invite.
 
 **Fixes**
 

--- a/apitypes/worklog.go
+++ b/apitypes/worklog.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dchest/blake2b"
 
 	"github.com/manifoldco/torus-cli/base32"
+	"github.com/manifoldco/torus-cli/identity"
 )
 
 // WorklogType is the enumerated byte type of WorklogItems
@@ -15,6 +16,7 @@ type WorklogType byte
 const (
 	SecretRotateWorklogType WorklogType = 1 << iota
 	MissingKeypairsWorklogType
+	InviteApproveWorklogType
 )
 
 // WorklogResultType is the string type of worklog results
@@ -66,6 +68,8 @@ type WorklogItem struct {
 	ID      *WorklogID `json:"id"`
 	Subject string     `json:"subject"`
 	Summary string     `json:"summary"`
+
+	SubjectID *identity.ID `json:"subject_id"` // Optional.
 }
 
 // Type returns this item's type
@@ -80,6 +84,8 @@ func (t WorklogType) String() string {
 		return "secret"
 	case MissingKeypairsWorklogType:
 		return "keypairs"
+	case InviteApproveWorklogType:
+		return "invite"
 	default:
 		return "n/a"
 	}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -102,7 +102,7 @@ func profileEdit(ctx *cli.Context) error {
 	}
 
 	var newPassword string
-	err = AskPerform(ctx, "Would you like to change your password?")
+	err = AskPerform("Would you like to change your password?")
 	if err == nil {
 		password, err := changePassword(&c, client, session)
 		if err != nil {

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -40,7 +40,7 @@ func validateInviteCode(input string) error {
 }
 
 // AskPerform prompts the user if they want to do a specified action
-func AskPerform(ctx *cli.Context, label string) error {
+func AskPerform(label string) error {
 	prompt := promptui.Prompt{
 		Label:     label,
 		IsConfirm: true,

--- a/cmd/worklog.go
+++ b/cmd/worklog.go
@@ -12,6 +12,7 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/promptui"
 )
 
 func init() {
@@ -175,6 +176,19 @@ func worklogResolve(ctx *cli.Context) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	for _, item := range toResolve {
+		if item.Type() == apitypes.InviteApproveWorklogType {
+			w.Flush()
+
+			err = AskPerform("Approve invite for " + item.Subject)
+			switch err {
+			case nil:
+			case promptui.ErrAbort:
+				continue
+			default:
+				return err
+			}
+		}
+
 		res, err := client.Worklog.Resolve(c, org.ID, item.ID)
 		if err != nil {
 			return errs.NewErrorExitError("Error resolving worklog item.", err)

--- a/daemon/registry/org_invite.go
+++ b/daemon/registry/org_invite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/url"
 
 	"github.com/manifoldco/torus-cli/envelope"
 	"github.com/manifoldco/torus-cli/identity"
@@ -58,4 +59,27 @@ func (o *OrgInviteClient) Get(ctx context.Context, inviteID *identity.ID) (*enve
 	}
 
 	return &invite, nil
+}
+
+// List lists all invites for a given org with the given states
+func (o *OrgInviteClient) List(ctx context.Context, orgID *identity.ID, states []string, email string) ([]envelope.Unsigned, error) {
+	v := &url.Values{}
+	v.Set("org_id", orgID.String())
+
+	for _, state := range states {
+		v.Add("state", state)
+	}
+
+	if email != "" {
+		v.Add("email", email)
+	}
+
+	req, err := o.client.NewRequest("GET", "/org-invites", v, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var invites []envelope.Unsigned
+	_, err = o.client.Do(ctx, req, &invites)
+	return invites, err
 }


### PR DESCRIPTION
Invite approval (the last step to add a user to an org after they've
accepted their invite) can be resolved automatically, but should still
prompt the user for confirmation, in case they've changed their mind
about giving someone access.

Support invite approval in the worklog, with a confirmation prompt.