### PR TITLE
Support usage of ** inside a pathexp being parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Unreleased_
 
 - Add preferences for `core.disable_progress` and `core.disable_hints` to control levels of output
   in preparation for additional onboarding output.
+- Support `**` in path expressions passed to commands.
 
 ## v0.18.0
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -94,6 +94,9 @@ func determineCredential(ctx *cli.Context, nameOrPath string) (*pathexp.PathExp,
 		if err != nil {
 			return nil, nil, errs.NewExitError(err.Error())
 		}
+		if name == "*" {
+			return nil, nil, errs.NewExitError("Secret name cannot be wildcard")
+		}
 	} else {
 		// Falling back to flags. do the expensive population of the user flag now,
 		// and see if any required flags (all of them) are missing.

--- a/docs/concepts/path.md
+++ b/docs/concepts/path.md
@@ -45,6 +45,17 @@ Wildcards support prefixes, so that you can namespace objects:
 
 So the value of "secret" is available to all applicable environments that match the wildcard such as: "env-1", "env-development", "env-ironment".
 
+Paths support `**` to be expanded to fill absent segments.
+
+#### Examples
+
+The following paths are equivalent when supplied to a command:
+
+```
+/org/project/**/name
+/org/project/*/*/*/*/name
+```
+
 ## Alternations
 Path segments may also contain alternations (otherwise known as "OR" statements). Alternations enable you to allow two or more values to match at a particular depth of the hierarchy.
 


### PR DESCRIPTION
- Adds support for path inputs to contain `**`
- All paths will still be stored/used internally as their complete equivalent