### PR TITLE
Display as much info as possible in `version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ _Unreleased_
 
 **Notable Changes**
 
-- Add preferences for `core.disable_progress` and `core.disable_hints` to control levels of output
-  in preparation for additional onboarding output.
+- Add preferences for `core.disable_progress` and `core.disable_hints` to
+  control levels of output in preparation for additional onboarding output.
+
+**Fixes**
+
+- Ensure that `torus version` will always return, even if the upstream server
+  is misconfigured.
 
 ## v0.18.0
 

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -65,11 +65,7 @@ func debugInfoCmd(ctx *cli.Context) error {
 	timestamp := time.Now()
 
 	// Cli and registry versions
-	daemonVersion, registryVersion, vErr := retrieveVersions(c, client)
-	if vErr != nil {
-		daemonVersion = &apitypes.Version{Version: "N/A"}
-		registryVersion = &apitypes.Version{Version: "N/A"}
-	}
+	daemonVersion, registryVersion := retrieveVersions(c, client)
 
 	// User information
 	session, uErr := client.Session.Who(c)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -39,10 +39,7 @@ func listVersionsCmd(ctx *cli.Context) error {
 
 	client := api.NewClient(cfg)
 	c := context.Background()
-	daemonVersion, registryVersion, err := retrieveVersions(c, client)
-	if err != nil {
-		return err
-	}
+	daemonVersion, registryVersion := retrieveVersions(c, client)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 	fmt.Fprintf(w, "%s\t%s\n", "CLI", cfg.Version)
@@ -53,25 +50,31 @@ func listVersionsCmd(ctx *cli.Context) error {
 	return nil
 }
 
-func retrieveVersions(c context.Context, client *api.Client) (*apitypes.Version, *apitypes.Version, error) {
+func retrieveVersions(c context.Context, client *api.Client) (*apitypes.Version, *apitypes.Version) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	var daemonVersion *apitypes.Version
-	var dErr error
 
 	go func() {
+		var dErr error
 		daemonVersion, dErr = client.Version.Get(c)
+		if dErr != nil {
+			daemonVersion = &apitypes.Version{
+				Version: "unknown (" + dErr.Error() + ")",
+			}
+		}
 		wg.Done()
 	}()
 
 	registryVersion, rErr := client.Version.GetRegistry(c)
+	if rErr != nil {
+		registryVersion = &apitypes.Version{
+			Version: "unknown (" + rErr.Error() + ")",
+		}
+	}
 	wg.Wait()
 
-	if dErr != nil || rErr != nil {
-		return nil, nil, cli.NewMultiError(dErr, rErr)
-	}
-
-	return daemonVersion, registryVersion, nil
+	return daemonVersion, registryVersion
 
 }


### PR DESCRIPTION
If we can't reach the server, still display the client and daemon
version info, and include error details for the unknown value.

Closes #1218