### PR TITLE
Support Vim Movement Bindings via Readline

### DIFF
--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -41,12 +41,17 @@ func validateInviteCode(input string) error {
 
 // AskPerform prompts the user if they want to do a specified action
 func AskPerform(label string) error {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return err
+	}
 	prompt := promptui.Prompt{
 		Label:     label,
 		IsConfirm: true,
 		Preamble:  nil,
+		IsVimMode: preferences.Defaults.Vim,
 	}
-	_, err := prompt.Run()
+	_, err = prompt.Run()
 	return err
 }
 
@@ -74,6 +79,7 @@ func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string, a
 		Label:     label,
 		IsConfirm: true,
 		Preamble:  &warning,
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	_, err = prompt.Run()
@@ -83,6 +89,10 @@ func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string, a
 // NamePrompt prompts the user to input a person's name
 func NamePrompt(override *string, defaultValue string, autoAccept bool) (string, error) {
 	var prompt promptui.Prompt
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return "", err
+	}
 
 	label := "Name"
 	if override != nil {
@@ -100,15 +110,20 @@ func NamePrompt(override *string, defaultValue string, autoAccept bool) (string,
 	}
 
 	prompt = promptui.Prompt{
-		Label:    label,
-		Default:  defaultValue,
-		Validate: validateSlug(strings.ToLower(label)),
+		Label:     label,
+		Default:   defaultValue,
+		Validate:  validateSlug(strings.ToLower(label)),
+		IsVimMode: preferences.Defaults.Vim,
 	}
 	return prompt.Run()
 }
 
 // VerificationPrompt prompts the user to input an email verify code
 func VerificationPrompt() (string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return "", err
+	}
 	prompt := promptui.Prompt{
 		Label: "Verification code",
 		Validate: func(input string) error {
@@ -118,6 +133,7 @@ func VerificationPrompt() (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid code")
 		},
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	return prompt.Run()
@@ -125,6 +141,11 @@ func VerificationPrompt() (string, error) {
 
 // SelectProjectPrompt prompts the user to select an org from a list, or enter a new name
 func SelectProjectPrompt(projects []api.ProjectResult) (int, string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return 0, "", err
+	}
+
 	names := make([]string, len(projects))
 	for i, p := range projects {
 		names[i] = p.Body.Name
@@ -132,10 +153,11 @@ func SelectProjectPrompt(projects []api.ProjectResult) (int, string, error) {
 
 	// Get the user's org selection
 	prompt := promptui.SelectWithAdd{
-		Label:    "Select project",
-		Items:    names,
-		AddLabel: "Create a new project",
-		Validate: validateSlug("project"),
+		Label:     "Select project",
+		Items:     names,
+		AddLabel:  "Create a new project",
+		Validate:  validateSlug("project"),
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	return prompt.Run()
@@ -143,6 +165,11 @@ func SelectProjectPrompt(projects []api.ProjectResult) (int, string, error) {
 
 // SelectOrgPrompt prompts the user to select an org from a list, or enter a new name
 func SelectOrgPrompt(orgs []api.OrgResult) (int, string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return 0, "", err
+	}
+
 	names := make([]string, len(orgs))
 	for i, o := range orgs {
 		names[i] = o.Body.Name
@@ -150,10 +177,11 @@ func SelectOrgPrompt(orgs []api.OrgResult) (int, string, error) {
 
 	// Get the user's org selection
 	prompt := promptui.SelectWithAdd{
-		Label:    "Select organization",
-		Items:    names,
-		AddLabel: "Create a new organization",
-		Validate: validateSlug("org"),
+		Label:     "Select organization",
+		Items:     names,
+		AddLabel:  "Create a new organization",
+		Validate:  validateSlug("org"),
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	return prompt.Run()
@@ -162,6 +190,11 @@ func SelectOrgPrompt(orgs []api.OrgResult) (int, string, error) {
 // SelectTeamPrompt prompts the user to select a team from a list or enter a
 // new name, an optional label can be provided.
 func SelectTeamPrompt(teams []api.TeamResult, label, addLabel string) (int, string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return 0, "", err
+	}
+
 	names := make([]string, len(teams))
 	for i, t := range teams {
 		names[i] = t.Body.Name
@@ -176,10 +209,11 @@ func SelectTeamPrompt(teams []api.TeamResult, label, addLabel string) (int, stri
 	}
 
 	prompt := promptui.SelectWithAdd{
-		Label:    label,
-		Items:    names,
-		AddLabel: addLabel,
-		Validate: validateSlug("team"),
+		Label:     label,
+		Items:     names,
+		AddLabel:  addLabel,
+		Validate:  validateSlug("team"),
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	return prompt.Run()
@@ -340,6 +374,11 @@ const PasswordMask = '●'
 
 // PasswordPrompt prompts the user to input a password value
 func PasswordPrompt(shouldConfirm bool, labelOverride *string) (string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return "", err
+	}
+
 	label := "Password"
 	if labelOverride != nil {
 		label = *labelOverride
@@ -359,6 +398,7 @@ func PasswordPrompt(shouldConfirm bool, labelOverride *string) (string, error) {
 
 			return promptui.NewValidationError("Please enter your password")
 		},
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	password, err := prompt.Run()
@@ -382,6 +422,7 @@ func PasswordPrompt(shouldConfirm bool, labelOverride *string) (string, error) {
 
 			return promptui.NewValidationError("Please confirm your password")
 		},
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	_, err = prompt.Run()
@@ -394,6 +435,11 @@ func PasswordPrompt(shouldConfirm bool, labelOverride *string) (string, error) {
 
 // EmailPrompt prompts the user to input an email
 func EmailPrompt(defaultValue string) (string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return "", err
+	}
+
 	prompt := promptui.Prompt{
 		Label: "Email",
 		Validate: func(input string) error {
@@ -402,6 +448,7 @@ func EmailPrompt(defaultValue string) (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid email address")
 		},
+		IsVimMode: preferences.Defaults.Vim,
 	}
 	if defaultValue != "" {
 		prompt.Default = defaultValue
@@ -412,6 +459,11 @@ func EmailPrompt(defaultValue string) (string, error) {
 
 // UsernamePrompt prompts the user to input a person's name
 func UsernamePrompt(un string) (string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return "", err
+	}
+
 	prompt := promptui.Prompt{
 		Label: "Username",
 		Validate: func(input string) error {
@@ -420,6 +472,7 @@ func UsernamePrompt(un string) (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid username")
 		},
+		IsVimMode: preferences.Defaults.Vim,
 	}
 	if un != "" {
 		prompt.Default = un
@@ -430,6 +483,11 @@ func UsernamePrompt(un string) (string, error) {
 
 // FullNamePrompt prompts the user to input a person's name
 func FullNamePrompt(name string) (string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return "", err
+	}
+
 	prompt := promptui.Prompt{
 		Label: "Name",
 		Validate: func(input string) error {
@@ -438,6 +496,7 @@ func FullNamePrompt(name string) (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid name")
 		},
+		IsVimMode: preferences.Defaults.Vim,
 	}
 	if name != "" {
 		prompt.Default = name
@@ -448,10 +507,16 @@ func FullNamePrompt(name string) (string, error) {
 
 // InviteCodePrompt prompts the user to input an invite code
 func InviteCodePrompt(defaultValue string) (string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return "", err
+	}
+
 	prompt := promptui.Prompt{
-		Label:    "Invite Code",
-		Default:  defaultValue,
-		Validate: validateInviteCode,
+		Label:     "Invite Code",
+		Default:   defaultValue,
+		Validate:  validateInviteCode,
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	return prompt.Run()
@@ -459,15 +524,20 @@ func InviteCodePrompt(defaultValue string) (string, error) {
 
 // SelectAcceptAction prompts the user to select an org from a list, or enter a new name
 func SelectAcceptAction() (int, string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return 0, "", err
+	}
+
 	names := []string{
 		"Login",
 		"Signup",
 	}
 
-	// Get the user's org selection
 	prompt := promptui.Select{
-		Label: "Do you want to login or create an account?",
-		Items: names,
+		Label:     "Do you want to login or create an account?",
+		Items:     names,
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	return prompt.Run()
@@ -475,6 +545,11 @@ func SelectAcceptAction() (int, string, error) {
 
 // SelectProfileAction prompts the user to select an option from a list
 func SelectProfileAction() (int, string, error) {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return 0, "", err
+	}
+
 	names := []string{
 		"Name or email",
 		"Change password",
@@ -482,8 +557,9 @@ func SelectProfileAction() (int, string, error) {
 
 	// Get the user's org selection
 	prompt := promptui.Select{
-		Label: "What would you like to update?",
-		Items: names,
+		Label:     "What would you like to update?",
+		Items:     names,
+		IsVimMode: preferences.Defaults.Vim,
 	}
 
 	return prompt.Run()

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -49,7 +49,7 @@ func AskPerform(label string) error {
 		Label:     label,
 		IsConfirm: true,
 		Preamble:  nil,
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 	_, err = prompt.Run()
 	return err
@@ -79,7 +79,7 @@ func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string, a
 		Label:     label,
 		IsConfirm: true,
 		Preamble:  &warning,
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	_, err = prompt.Run()
@@ -113,7 +113,7 @@ func NamePrompt(override *string, defaultValue string, autoAccept bool) (string,
 		Label:     label,
 		Default:   defaultValue,
 		Validate:  validateSlug(strings.ToLower(label)),
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 	return prompt.Run()
 }
@@ -133,7 +133,7 @@ func VerificationPrompt() (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid code")
 		},
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	return prompt.Run()
@@ -157,7 +157,7 @@ func SelectProjectPrompt(projects []api.ProjectResult) (int, string, error) {
 		Items:     names,
 		AddLabel:  "Create a new project",
 		Validate:  validateSlug("project"),
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	return prompt.Run()
@@ -181,7 +181,7 @@ func SelectOrgPrompt(orgs []api.OrgResult) (int, string, error) {
 		Items:     names,
 		AddLabel:  "Create a new organization",
 		Validate:  validateSlug("org"),
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	return prompt.Run()
@@ -213,7 +213,7 @@ func SelectTeamPrompt(teams []api.TeamResult, label, addLabel string) (int, stri
 		Items:     names,
 		AddLabel:  addLabel,
 		Validate:  validateSlug("team"),
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	return prompt.Run()
@@ -398,7 +398,7 @@ func PasswordPrompt(shouldConfirm bool, labelOverride *string) (string, error) {
 
 			return promptui.NewValidationError("Please enter your password")
 		},
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	password, err := prompt.Run()
@@ -422,7 +422,7 @@ func PasswordPrompt(shouldConfirm bool, labelOverride *string) (string, error) {
 
 			return promptui.NewValidationError("Please confirm your password")
 		},
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	_, err = prompt.Run()
@@ -448,7 +448,7 @@ func EmailPrompt(defaultValue string) (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid email address")
 		},
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 	if defaultValue != "" {
 		prompt.Default = defaultValue
@@ -472,7 +472,7 @@ func UsernamePrompt(un string) (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid username")
 		},
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 	if un != "" {
 		prompt.Default = un
@@ -496,7 +496,7 @@ func FullNamePrompt(name string) (string, error) {
 			}
 			return promptui.NewValidationError("Please enter a valid name")
 		},
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 	if name != "" {
 		prompt.Default = name
@@ -516,7 +516,7 @@ func InviteCodePrompt(defaultValue string) (string, error) {
 		Label:     "Invite Code",
 		Default:   defaultValue,
 		Validate:  validateInviteCode,
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	return prompt.Run()
@@ -537,7 +537,7 @@ func SelectAcceptAction() (int, string, error) {
 	prompt := promptui.Select{
 		Label:     "Do you want to login or create an account?",
 		Items:     names,
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	return prompt.Run()
@@ -559,7 +559,7 @@ func SelectProfileAction() (int, string, error) {
 	prompt := promptui.Select{
 		Label:     "What would you like to update?",
 		Items:     names,
-		IsVimMode: preferences.Defaults.Vim,
+		IsVimMode: preferences.Core.Vim,
 	}
 
 	return prompt.Run()

--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -15,11 +15,11 @@ The following are the available preferences:
 `core.public_key_file` | Location of the ed25519 public key file.
 `core.context` | Boolean determining if the `.torus.json` and defaults should be considered during command execution
 `core.auto_confirm` | Boolean determining if confirmation prompts should be automatically skipped (equivalent of always using `-y` command option)
+`core.vim` | Boolean determining if CLI input should use Vim bindings
 `defaults.org` | Organization name to be used with context
 `defaults.project` | Project name to be used with context
 `defaults.environment` | Environment name to be used with context
 `defaults.service` | Service name to be used with context
-`defaults.vim` | Boolean determining if CLI input should use Vim bindings
 
 ### set
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)

--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -18,14 +18,15 @@ The following are the available preferences:
 `defaults.org` | Organization name to be used with context
 `defaults.project` | Project name to be used with context
 `defaults.environment` | Environment name to be used with context
-`defaults.service` | Service name to be used with context  
+`defaults.service` | Service name to be used with context
+`defaults.vim` | Boolean determining if CLI input should use Vim bindings
 
 ### set
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
 `torus prefs set <key> <value>` sets a preference value by key, where key is the dot-delimited path of the category and preference name.
 
-If value is omitted it defaults to boolean true.
+If value is omitted it defaults to boolean true, except for the Vim setting, which is false by default.
 
 ### list
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -34,6 +34,7 @@ Supported system default preferences:
 - project
 - environment
 - service
+- vim
 
 ### Linked directory
 

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -34,7 +34,6 @@ Supported system default preferences:
 - project
 - environment
 - service
-- vim
 
 ### Linked directory
 

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -58,6 +58,7 @@ type Defaults struct {
 	Project      string `ini:"project,omitempty"`
 	Environment  string `ini:"environment,omitempty"`
 	Service      string `ini:"service,omitempty"`
+	Vim          bool   `ini:"vim,omitempty"`
 }
 
 // SetValue for ini key on preferences struct

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -50,6 +50,7 @@ type Core struct {
 	AutoConfirm    bool   `ini:"auto_confirm,omitempty"`
 	EnableProgress bool   `ini:"progress"`
 	EnableHints    bool   `ini:"hints"`
+	Vim            bool   `ini:"vim,omitempty"`
 }
 
 // Defaults contains default values for use in command argument flags
@@ -58,7 +59,6 @@ type Defaults struct {
 	Project      string `ini:"project,omitempty"`
 	Environment  string `ini:"environment,omitempty"`
 	Service      string `ini:"service,omitempty"`
-	Vim          bool   `ini:"vim,omitempty"`
 }
 
 // SetValue for ini key on preferences struct

--- a/promptui/prompt.go
+++ b/promptui/prompt.go
@@ -25,6 +25,7 @@ type Prompt struct {
 	Mask rune
 
 	IsConfirm bool
+	IsVimMode bool
 	Preamble  *string
 
 	stdin  io.Reader
@@ -50,6 +51,10 @@ func (p *Prompt) Run() (string, error) {
 	if p.Mask != 0 {
 		c.EnableMask = true
 		c.MaskRune = p.Mask
+	}
+
+	if p.IsVimMode {
+		c.VimMode = true
 	}
 
 	if p.Preamble != nil {

--- a/promptui/select.go
+++ b/promptui/select.go
@@ -14,8 +14,9 @@ const SelectedAdd = -1
 
 // Select represents a list for selecting a single item
 type Select struct {
-	Label string   // Label is the value displayed on the command line prompt.
-	Items []string // Items are the items to use in the list.
+	Label     string   // Label is the value displayed on the command line prompt.
+	Items     []string // Items are the items to use in the list.
+	IsVimMode bool     // Wether readline is using Vim mode.
 }
 
 // Run runs the Select list. It returns the index of the selected element,
@@ -33,6 +34,10 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 	}
 
 	c.Stdin = stdin
+
+	if s.IsVimMode {
+		c.VimMode = true
+	}
 
 	prompt := s.Label + ": "
 
@@ -155,6 +160,8 @@ type SelectWithAdd struct {
 	// Validate is optional. If set, this function is used to validate the input
 	// after each character entry.
 	Validate ValidateFunc
+
+	IsVimMode bool // Whether readline is using Vim mode.
 }
 
 // Run runs the Select list. It returns the index of the selected element,
@@ -164,8 +171,9 @@ func (sa *SelectWithAdd) Run() (int, string, error) {
 		newItems := append([]string{sa.AddLabel}, sa.Items...)
 
 		s := Select{
-			Label: sa.Label,
-			Items: newItems,
+			Label:     sa.Label,
+			Items:     newItems,
+			IsVimMode: sa.IsVimMode,
 		}
 
 		selected, value, err := s.innerRun(1, '+')
@@ -178,8 +186,9 @@ func (sa *SelectWithAdd) Run() (int, string, error) {
 	}
 
 	p := Prompt{
-		Label:    sa.AddLabel,
-		Validate: sa.Validate,
+		Label:     sa.AddLabel,
+		Validate:  sa.Validate,
+		IsVimMode: sa.IsVimMode,
 	}
 	value, err := p.Run()
 	return SelectedAdd, value, err

--- a/promptui/select.go
+++ b/promptui/select.go
@@ -16,7 +16,7 @@ const SelectedAdd = -1
 type Select struct {
 	Label     string   // Label is the value displayed on the command line prompt.
 	Items     []string // Items are the items to use in the list.
-	IsVimMode bool     // Wether readline is using Vim mode.
+	IsVimMode bool     // Whether readline is using Vim mode.
 }
 
 // Run runs the Select list. It returns the index of the selected element,
@@ -63,7 +63,21 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 
 	counter := 0
 
+	rl.Operation.ExitVimInsertMode() // Never use insert mode for selects
+
 	c.SetListener(func(line []rune, pos int, key rune) ([]rune, int, bool) {
+		if rl.Operation.IsEnableVimMode() {
+			rl.Operation.ExitVimInsertMode()
+			// Remap j and k for down/up selections immediately after an
+			// `i` press
+			switch key {
+			case 'j':
+				key = readline.CharNext
+			case 'k':
+				key = readline.CharPrev
+			}
+		}
+
 		switch key {
 		case readline.CharEnter:
 			return nil, 0, true


### PR DESCRIPTION
Closes #56

Changes promptui to allow users to specify a boolean `vim` option in their `.torusrc`. Setting `vim = true` enables the Vim mode provided by [chzyer/readline](https://github.com/chzyer/readline).

It seems to work well so far, but there are two things I've found that aren't quite right:
  1. The cursor doesn't change when switching modes (normally not a problem, but when there's no way to tell what mode you're in, this could be a bit frustrating.
  2. You start in the equivalent of Vim's insert mode, which is confusing in any prompt where the user is required to select an option. Since you're in insert mode, you can't select an option until you leave insert mode by pressing [ESC] (or, by mashing your keyboard, like I did at first :P ).

I've set Vim mode to false by default, since it would definitely be confusing for new users.

---

###### Example

Run any command, ie, `torus-cli login` and try using Vim bindings to input things, and to navigate around your input.

###### Why the changes were made this way

I noticed readline had a Vim mode, so I added support in prompui for enabling the Vim mode.

In terms of implementation, I've gone with adding an `IsVimMode` field to the relevant structs in promptui, and populating them based on the in the user's preferences. This works, and is consistent, but doing

```go
preferences, err := prefs.NewPreferences()
if err != nil {
    return err
}
```

all the time feels repetitive. Maybe there's a better way, like reading from the preferences before running a command, and then passing that Vim config value as a parameter.