### PR TITLE
Bump the requested api version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _Unreleased_
 
 - Ensure that `torus version` will always return, even if the upstream server
   is misconfigured.
+- Fix an issue where the wrong version of a credential would be used after a
+  user was removed from an org.
 
 ## v0.18.0
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ import (
 
 // Version is the compiled version of our binary. It is set via the Makefile.
 var Version = "alpha"
-var apiVersion = "0.1.0"
+var apiVersion = "0.2.0"
 
 const requiredPermissions = 0700
 


### PR DESCRIPTION
With the credentialgraphset.prune changes, we can now bump our api
version to 0.2.0 and fetch the *full* credential graph.