### PR TITLE
Add headings to command option tables

### DIFF
--- a/docs/commands/organizations.md
+++ b/docs/commands/organizations.md
@@ -85,8 +85,9 @@ By default only invites which have not yet been approved will be shown.
 
 ### Command Options
 
---approved | Display approved invites instead of pending
+Option | Description
 ---- | ----
+--approved | Display approved invites instead of pending
 
 ### approve
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)

--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -7,8 +7,9 @@ Torus exposes your decrypted secrets to your process through environment variabl
 
 ### Command Options
 
-  --org, ORG, -o ORG | Executing the command for the specified org.
+  Option | Description
   ---- | ----
+  --org, ORG, -o ORG | Executing the command for the specified org.
   --project PROJECT, -p PROJECT | Executing the command for the specified project.
   --environment ENV, -e ENV | Executing the command for the specified environment. Can be specified multiple times.
   --service SERVICE, -s SERVICE | Execute the command for the specified environment. (default: default)
@@ -37,8 +38,9 @@ By default items are displayed in environment variable format.
 
 ### Command Options
 
-  --verbose, -v | List the sources of the secrets (shortcut for --format verbose)
+  Option | Description
   ---- | ----
+  --verbose, -v | List the sources of the secrets (shortcut for --format verbose)
   --format FORMAT, -f FORMAT | Format used to display data (json, env, verbose) (default: env)
 
 ## run

--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -9,8 +9,9 @@ There are two categories of preferences: Core and Defaults. Core contains prefer
 
 The following are the available preferences:
 
-`core.registry_uri` | The hostname (including protocol) of the Torus Registry
+Preference | Description
 ---- | ----
+`core.registry_uri` | The hostname (including protocol) of the Torus Registry
 `core.ca_bundle_file` | Certificate bundle used to communicate with the Torus Registry.
 `core.public_key_file` | Location of the ed25519 public key file.
 `core.context` | Boolean determining if the `.torus.json` and defaults should be considered during command execution


### PR DESCRIPTION
This makes the options look better in markdown, but we'll hide the headings for command options in the actual docs html/css.