### PR TITLE
Perform additional validation for partial paths in access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _Unreleased_
 - `torus prefs list` now displays the default values for preferences if no
   override has been set by the user.
 - Added directory styles to [get.torus.sh](https://get.torus.sh)
+- Updated validation for `torus allow` and `torus deny` to catch when secret name is missing
 
 **Fixes**
 

--- a/cmd/allow.go
+++ b/cmd/allow.go
@@ -50,14 +50,20 @@ func doCrudl(ctx *cli.Context, effect primitive.PolicyEffect, extra primitive.Po
 		return errs.NewUsageExitError(msg, ctx)
 	}
 
-	idx := strings.LastIndex(args[1], "/")
+	// Separate the pathexp from the secret name
+	rawPath := args[1]
+	idx := strings.LastIndex(rawPath, "/")
 	if idx == -1 {
 		msg := "resource path format is incorrect."
 		return errs.NewUsageExitError(msg, ctx)
 	}
+	name := rawPath[idx+1:]
+	path := rawPath[:idx]
 
-	name := args[1][idx+1:]
-	path := args[1][:idx]
+	// Ensure that the secret name is valid
+	if !pathexp.ValidSecret(name) {
+		return errs.NewExitError("Invalid secret name")
+	}
 
 	pe, err := pathexp.Parse(path)
 	if err != nil {

--- a/pathexp/pathexp.go
+++ b/pathexp/pathexp.go
@@ -197,6 +197,11 @@ func NewPartial(org, project string, envs, services, identities, instances []str
 	return newPathexp(org, project, envs, services, identities, instances, false)
 }
 
+// ValidSecret returns whether the subject is a valid secret name value
+func ValidSecret(subject string) bool {
+	return fullglobOrGlob.MatchString(subject)
+}
+
 // ValidSlug returns whether the subject is a valid slug value
 func ValidSlug(subject string) bool {
 	return slug.MatchString(subject)


### PR DESCRIPTION
Closes https://github.com/manifoldco/torus-cli/issues/131

- Ensure secret name is supplied and is valid
- Catch invalid org name before roundtrip to server