### PR TITLE
Do not filter by specificity during torus ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _Unreleased_
   override has been set by the user.
 - Added directory styles to [get.torus.sh](https://get.torus.sh)
 - Updated validation for `torus allow` and `torus deny` to catch when secret name is missing
+- `torus ls` changes to not filter out paths based on specificity
 
 **Fixes**
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -142,12 +142,11 @@ func listObjects(ctx *cli.Context) error {
 			pathsErr = err
 			break
 		}
-		cset := credentialSet{}
-		for _, c := range creds {
-			cset.Add(c)
-		}
-		for _, cred := range cset {
+		for _, cred := range creds {
 			body := *cred.Body
+			if body.GetValue() == nil {
+				continue
+			}
 			name := body.GetName()
 			if matchPathSegment(targetName, name) {
 				paths = append(paths, fmt.Sprintf("%s/%s", body.GetPathExp(), name))


### PR DESCRIPTION
When you have two credentials with the same name, but different paths, they would not show up in the output of `torus ls`. This is expected during `view` due to specificity checks and context, but with `torus ls` you want to see all of the values.