### PR TITLE
Add ui.hints throughout core commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ _unreleased_
 **Notable Changes**
 
 - Update the style of selection lists for improved readability.
+- Added hint output to core commands, prompting the user during signup if they
+  wish to enable them.
+- Confirm dialogues now show default value as uppercase
 
 **Fixes**
 

--- a/cmd/invites_list.go
+++ b/cmd/invites_list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/identity"
 )
 
@@ -101,5 +102,6 @@ func invitesList(ctx *cli.Context) error {
 	w.Flush()
 	fmt.Println("")
 
+	hints.Display([]string{"invites approve", "teams members"})
 	return nil
 }

--- a/cmd/invites_send.go
+++ b/cmd/invites_send.go
@@ -10,6 +10,7 @@ import (
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/identity"
 )
 
@@ -105,5 +106,6 @@ TeamSearch:
 	fmt.Println("\n\t" + strings.Join(matchTeams, "\n\t"))
 	fmt.Println("\nThey will receive an e-mail with instructions.")
 
+	hints.Display([]string{"invites approve", "teams members"})
 	return nil
 }

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -13,6 +13,7 @@ import (
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/dirprefs"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/identity"
 	"github.com/manifoldco/torus-cli/prefs"
 )
@@ -162,5 +163,6 @@ func linkCmd(ctx *cli.Context) error {
 		fmt.Printf("Warning: context is disabled. Use '%s prefs' to enable it.\n", ctx.App.Name)
 	}
 
+	hints.Display([]string{"context", "set", "run", "view"})
 	return nil
 }

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -11,6 +11,7 @@ import (
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/pathexp"
 )
 
@@ -168,6 +169,7 @@ func listObjects(ctx *cli.Context) error {
 		fmt.Println(p)
 	}
 
+	hints.Display([]string{"path", "view"})
 	return nil
 }
 

--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -17,6 +17,7 @@ import (
 	"github.com/manifoldco/torus-cli/base64"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/identity"
 	"github.com/manifoldco/torus-cli/primitive"
 )
@@ -161,7 +162,7 @@ func destroyMachineCmd(ctx *cli.Context) error {
 	}
 
 	preamble := "You are about to destroy a machine. This cannot be undone."
-	abortErr := ConfirmDialogue(ctx, nil, &preamble, true)
+	abortErr := ConfirmDialogue(ctx, nil, &preamble, "", true)
 	if abortErr != nil {
 		return abortErr
 	}
@@ -501,6 +502,7 @@ func createMachineRole(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Role %s created.\n", teamName)
+	hints.Display([]string{"allow", "deny", "policies"})
 	return nil
 }
 
@@ -591,7 +593,8 @@ func createMachine(ctx *cli.Context) error {
 	fmt.Fprintf(w, "Machine Token Secret:\t%s\n", tokenSecret)
 
 	w.Flush()
-	return err
+	hints.Display([]string{"allow", "deny"})
+	return nil
 }
 
 func createMachineByName(c context.Context, client *api.Client,

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 )
 
 func init() {
@@ -79,7 +80,12 @@ func orgsCreate(ctx *cli.Context) error {
 	client := api.NewClient(cfg)
 
 	_, err = createOrgByName(c, ctx, client, name)
-	return err
+	if err != nil {
+		return err
+	}
+
+	hints.Display([]string{"invites send", "projects", "link"})
+	return nil
 }
 
 func createOrgByName(c context.Context, ctx *cli.Context, client *api.Client, name string) (*api.OrgResult, error) {

--- a/cmd/prefs.go
+++ b/cmd/prefs.go
@@ -83,11 +83,6 @@ func listPref(ctx *cli.Context) error {
 }
 
 func setPref(ctx *cli.Context) error {
-	preferences, err := prefs.NewPreferences()
-	if err != nil {
-		return errs.NewErrorExitError("Failed to load prefs.", err)
-	}
-
 	args := ctx.Args()
 	key := args.Get(0)
 	value := args.Get(1)
@@ -97,6 +92,15 @@ func setPref(ctx *cli.Context) error {
 
 	if len(strings.Split(key, ".")) < 2 {
 		return errs.NewExitError("Key must be have at least two dot delimited segments.")
+	}
+
+	return setPrefByName(key, value)
+}
+
+func setPrefByName(key, value string) error {
+	preferences, err := prefs.NewPreferences()
+	if err != nil {
+		return errs.NewErrorExitError("Failed to load prefs.", err)
 	}
 
 	// Validate public key file

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -133,7 +133,7 @@ func profileEdit(ctx *cli.Context) error {
 	if email != ogEmail {
 		preamble = "\nYou will be required to re-verify your email address before taking any further actions within Torus."
 	}
-	abortErr := ConfirmDialogue(ctx, nil, &preamble, false)
+	abortErr := ConfirmDialogue(ctx, nil, &preamble, "", false)
 	if abortErr != nil {
 		return abortErr
 	}

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -56,7 +56,7 @@ func AskPerform(label string) error {
 }
 
 // ConfirmDialogue prompts the user to confirm their action
-func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string, allowSkip bool) error {
+func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string, defaultValue string, allowSkip bool) error {
 	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return err
@@ -78,6 +78,7 @@ func ConfirmDialogue(ctx *cli.Context, labelOverride, warningOverride *string, a
 	prompt := promptui.Prompt{
 		Label:     label,
 		IsConfirm: true,
+		Default:   defaultValue,
 		Preamble:  &warning,
 		IsVimMode: preferences.Core.Vim,
 	}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -12,6 +12,7 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/pathexp"
 )
 
@@ -75,6 +76,7 @@ func setCmd(ctx *cli.Context) error {
 	pe := (*cred.Body).GetPathExp()
 	fmt.Printf("\nCredential %s has been set at %s/%s\n", name, pe, name)
 
+	hints.Display([]string{"view", "run"})
 	return nil
 }
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -16,6 +16,7 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/identity"
 	"github.com/manifoldco/torus-cli/primitive"
 )
@@ -361,6 +362,8 @@ func createTeamCmd(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Team %s created.\n", teamName)
+
+	hints.Display([]string{"allow", "deny"})
 	return nil
 }
 

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -42,7 +42,7 @@ func unsetCmd(ctx *cli.Context) error {
 
 	preamble := fmt.Sprintf("You are about to unset \"%s/%s\". This cannot be undone.", pathexp.String(), *cname)
 
-	abortErr := ConfirmDialogue(ctx, nil, &preamble, true)
+	abortErr := ConfirmDialogue(ctx, nil, &preamble, "", true)
 	if abortErr != nil {
 		return abortErr
 	}

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -14,6 +14,7 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 )
 
 func init() {
@@ -62,14 +63,17 @@ func viewCmd(ctx *cli.Context) error {
 
 	switch format {
 	case "env":
-		return printEnvFormat(secrets, path)
+		err = printEnvFormat(secrets, path)
 	case "verbose":
-		return printVerboseFormat(secrets, path)
+		err = printVerboseFormat(secrets, path)
 	case "json":
-		return printJSONFormat(secrets, path)
+		err = printJSONFormat(secrets, path)
 	default:
 		return errs.NewUsageExitError("Unknown format: "+format, ctx)
 	}
+
+	hints.Display([]string{"link", "run"})
+	return err
 }
 
 func printEnvFormat(secrets []apitypes.CredentialEnvelope, path string) error {

--- a/hints/hints.go
+++ b/hints/hints.go
@@ -1,0 +1,76 @@
+package hints
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/manifoldco/torus-cli/ui"
+)
+
+var commandHints map[string][]string
+
+// Init generates the commandHints map
+func Init() {
+	commandHints = map[string][]string{
+		"allow": {
+			"Grant additional access to secrets for a team or role using `torus allow`",
+		},
+		"context": {
+			"Your linked organization and project are found in .torus.json after running `torus link`",
+		},
+		"deny": {
+			"Restrict access to secrets for a team or role using `torus deny`",
+		},
+		"invites approve": {
+			"Approve multiple invites with `torus worklog resolve`",
+		},
+		"invites send": {
+			"Invite another user to join your organization with `torus invites send`",
+		},
+		"link": {
+			"Define an organization and project for your current working directory using `torus link`",
+		},
+		"ls": {
+			"Explore the objects and secrets for your org through `torus ls`",
+		},
+		"path": {
+			"Each secret path has 7 segments: /org/project/env/service/identity/instance/secret",
+			"Secret paths can contain wildcards, such as `dev-*` for the environment",
+		},
+		"policies": {
+			"Display policies for your organization with `torus policies list`",
+			"View details of an existing policy with `torus policies view`",
+		},
+		"projects": {
+			"Create a project for your secrets using `torus projects create`",
+		},
+		"run": {
+			"Start your process with your decrypted secrets using `torus run`",
+		},
+		"system": {
+			"Disable hints with `torus prefs set core.hints false`",
+		},
+		"teams members": {
+			"Display current members of your organization with `torus members member`",
+		},
+		"view": {
+			"View secret values which have been set using `torus view`",
+			"See the exact path for each secret set using `torus view -v`",
+		},
+	}
+}
+
+// Display chooses a random hint from the allotted commands and displays it
+func Display(possible []string) {
+	// Seed random integer
+	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+	i := r.Intn(len(possible))
+	cmd := possible[i]
+	if hints, ok := commandHints[cmd]; ok {
+		// Display random hint from chosen command's list
+		item := r.Intn(len(hints))
+		if len(hints) > item {
+			ui.Hint(hints[item], false)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/manifoldco/torus-cli/cmd"
 	"github.com/manifoldco/torus-cli/config"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/prefs"
 	"github.com/manifoldco/torus-cli/ui"
 )
@@ -18,6 +19,7 @@ func main() {
 
 	preferences, _ := prefs.NewPreferences()
 	ui.Init(preferences)
+	hints.Init()
 
 	app := cli.NewApp()
 	app.Version = config.Version

--- a/promptui/prompt.go
+++ b/promptui/prompt.go
@@ -65,7 +65,12 @@ func (p *Prompt) Run() (string, error) {
 	punctuation := ":"
 	if p.IsConfirm {
 		punctuation = "?"
-		suggestedAnswer = " " + faint("[y/n]")
+		answers := "y/N"
+		if strings.ToLower(p.Default) == "y" {
+			answers = "Y/n"
+		}
+		suggestedAnswer = " " + faint("["+answers+"]")
+		p.Default = ""
 	}
 
 	state := iconInitial

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2,6 +2,10 @@ package ui
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/chzyer/readline"
+	"github.com/kr/text"
 
 	"github.com/manifoldco/torus-cli/prefs"
 )
@@ -27,9 +31,28 @@ func Progress(str string) {
 }
 
 // Hint handles the ui output for hint/onboarding messages, when enabled
-func Hint(str string) {
+func Hint(str string, noPadding bool) {
 	if !enableHints {
 		return
 	}
-	fmt.Println(str)
+	if !noPadding {
+		fmt.Println("")
+	}
+	printWrapLabeled("Protip:", str)
+}
+
+func printWrapLabeled(label, message string) {
+	cols := readline.GetScreenWidth() - 2
+	fmt.Printf("%s  ", label)
+	longest := len(label)
+	wrapped := text.Wrap(message, cols-(2+longest))
+	fmt.Println(indentOthers(wrapped, 2+longest))
+}
+
+func indentOthers(str string, indent int) string {
+	nl := strings.IndexRune(str, '\n')
+	if nl == -1 {
+		nl = len(str)
+	}
+	return str[:nl] + text.Indent(str[nl:], fmt.Sprintf("%*s", indent, ""))
 }


### PR DESCRIPTION
Closes https://github.com/manifoldco/torus-cli/issues/96 https://github.com/manifoldco/torus-cli/issues/139

We want to help users discover the next steps they may want to take after executing a command. Previously we added a pref `core.hints` to enable whether these will be displayed, these hints are behind this flag.

`hints.Display` takes a list of hint categories (which are lists of strings). It chooses a random category to display a hint for, then chooses a random hint from that list.