### PR TITLE
ObserverTest: prevent a deadlock situation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ clean:
 #################################################
 
 test: generated vendor
-	@CGO_ENABLED=0 go test -short $$(glide nv)
+	@CGO_ENABLED=0 go test -run=. -bench=. -short $$(glide nv)
 
 METALINT=gometalinter --tests --disable-all --vendor --deadline=5m -s data \
 	 ./... --enable

--- a/daemon/observer/observer.go
+++ b/daemon/observer/observer.go
@@ -125,7 +125,8 @@ func (n *Notifier) Notifier(total uint) *Notifier {
 	return notifier
 }
 
-// Notify publishes an event to all SSE observers.
+// Notify publishes an event to all SSE observers. This function panics when it
+// is called more often than it is supposed to have been called.
 func (n *Notifier) Notify(eventType EventType, message string, increment bool) {
 	notif := &notification{
 		Type:      eventType,

--- a/daemon/observer/observer.go
+++ b/daemon/observer/observer.go
@@ -141,11 +141,14 @@ func (n *Notifier) Notify(eventType EventType, message string, increment bool) {
 	}
 
 	n.RLock()
-	if n.current > n.total {
-		panic(fmt.Sprintf(
-			"notifications exceed maximum %d/%d", n.current, n.total))
-	}
+	current := n.current
+	total := n.total
 	n.RUnlock()
+
+	if current > total {
+		panic(fmt.Sprintf(
+			"notifications exceed maximum %d/%d", current, total))
+	}
 
 	select {
 	case n.notifications <- notif:

--- a/daemon/observer/observer.go
+++ b/daemon/observer/observer.go
@@ -252,6 +252,7 @@ func (o *Observer) Start() {
 		select {
 		case evt := <-o.notify: // We have an event to observe
 			if len(o.observers) == 0 {
+				log.Printf("Ignoring event due to no observers: %s", evt.ID)
 				continue
 			}
 


### PR DESCRIPTION
The tests described in the test file didn't really describe a real world
situation. In the real world, an observer is either always present and
started well before we send notifications or no observer will be ever
present at all.

Running the tests, a deadlock occurred sometimes, locking up the tests
and eventually failing them. This was because the Observer in our tests
didn't register itself in time before we created a new notification. The
notification then got sent through the system and dropped because no
observer was present. Once the observer then started, it would keep listening
until the notification came through, resulting in a deadlock since the
event was already dropped beforehand.

This patch does actually not fix the deadlock situation itself, it is
still possible to happen - there is however logging present now to
document this. We do however set up the tests more reliable in a way
that we expect the real world to behave. We ensure that the observer is
registered before we send the notification. This way once we send a
notification, the observer sends it pack to the ResponseRecorder.

This PR also takes care of a data race:

`*notifier.Notify()` can be used concurrently. Because of this behaviour, it can
trigger a race condition when two events happen at the same time where
one would incremment the current counter and one would read from it.

This implements a Read/Write lock which allows this behaviour by locking
the instance on updating the counter and only adding a Read lock when
reading the value. This allows us to only write from a single point at a
single moment in time, but read from multiple points at a single moment
in time. It will also prevent users from reading the counter when
someone else is writing to it.