### PR TITLE
APIClient: drop event messages after action is processed.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -144,6 +144,9 @@ func (c *Client) Do(ctx context.Context, r *http.Request, v interface{}, reqID *
 					err = json.Unmarshal(raw, &event)
 					if err != nil {
 						output(nil, err)
+						go func() {
+							<-done
+						}()
 						return
 					}
 					if event.ID == *reqID {

--- a/api/client.go
+++ b/api/client.go
@@ -157,7 +157,9 @@ func (c *Client) Do(ctx context.Context, r *http.Request, v interface{}, reqID *
 	}
 
 	resp, err := c.client.Do(r)
-	close(done)
+	if progress != nil {
+		done <- true
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Calling close is none blocking, it closes the channel immediately and
reads will still happen from the `stream.Events` channel instead of the
`<- done` channel.

We want to block here until the message is actually read from the done
channel so we can continue processing the end result and not show other
event messages.

There is also an extra goroutine spun up when there's an error 
unmarshaling the event:

When an error happens in unmarshaling the JSON, we'll end up in a
deadlock. This is because we do a return, ending the for and select
loop, which listens on the done channel. This means that nothing will
ever get read from the done channel. On line 166, we try to put
something on the done channel and block until it's read.

This goroutine acts as a reader for that channel and will unblock our
message, allowing us to drop the incoming events in case of an
unmarshal error.