### PR TITLE
Teach the worklog how to correct keyring memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _unreleased_
 - Added hint output to core commands, prompting the user during signup if they
   wish to enable them.
 - Confirm dialogues now show default value as uppercase
+- Teach `worklog` how to identify and fix cases where users or machines
+  haven't been included in a keyring for secrets access when they should be.
 
 **Fixes**
 

--- a/apitypes/worklog.go
+++ b/apitypes/worklog.go
@@ -17,6 +17,7 @@ const (
 	SecretRotateWorklogType WorklogType = 1 << iota
 	MissingKeypairsWorklogType
 	InviteApproveWorklogType
+	KeyringMembersWorklogType
 
 	AnyWorklogType WorklogType = 0xff
 )
@@ -93,6 +94,8 @@ func (t WorklogType) String() string {
 		return "keypairs"
 	case InviteApproveWorklogType:
 		return "invite"
+	case KeyringMembersWorklogType:
+		return "keyring"
 	default:
 		return "n/a"
 	}

--- a/daemon/registry/keyring.go
+++ b/daemon/registry/keyring.go
@@ -98,7 +98,9 @@ func (k *KeyringSectionV2) FindMember(id *identity.ID) (*primitive.KeyringMember
 		mbody := m.Member.Body.(*primitive.KeyringMember)
 		if *mbody.OwnerID == *id {
 			krm = mbody
-			mekshare = m.MEKShare.Body.(*primitive.MEKShare)
+			if m.MEKShare != nil {
+				mekshare = m.MEKShare.Body.(*primitive.MEKShare)
+			}
 			break
 		}
 	}


### PR DESCRIPTION
If an invite or machine creation fails partway through, we can end up in
a state where the user/machine is created, but are not given access to
all keyrings, and the secrets therein.

Teach the worklog how to identify and resolve this problem.