### PR TITLE
Missing doc for core.hints

### DIFF
--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -17,6 +17,7 @@ Preference | Description
 `core.context` | Boolean determining if the `.torus.json` and defaults should be considered during command execution
 `core.auto_confirm` | Boolean determining if confirmation prompts should be automatically skipped (equivalent of always using `-y` command option)
 `core.vim` | Boolean determining if CLI input should use Vim bindings
+`core.hints` | Boolean determining if the "protip" hints are shown after command execution
 `defaults.org` | Organization name to be used with context
 `defaults.project` | Project name to be used with context
 `defaults.environment` | Environment name to be used with context

--- a/hints/hints.go
+++ b/hints/hints.go
@@ -47,9 +47,6 @@ func Init() {
 		"run": {
 			"Start your process with your decrypted secrets using `torus run`",
 		},
-		"system": {
-			"Disable hints with `torus prefs set core.hints false`",
-		},
 		"teams members": {
 			"Display current members of your organization with `torus members member`",
 		},


### PR DESCRIPTION
Now that the tips have been implemented, disabling them should be documented.