### PR TITLE
Ensure keypairs generate does not panic with existing keypairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.21.0
+
+_unreleased_
+
+**Fixes**
+
+- Ensure `keypairs generate` does not panic when used against an org that has
+  existing keypairs.
+
 ## v0.20.0
 
 _2016-12-13_

--- a/api/keypairs.go
+++ b/api/keypairs.go
@@ -25,8 +25,8 @@ type KeypairResult struct {
 	} `json:"private_key"`
 	Claims []struct {
 		ID   *identity.ID     `json:"id"`
-		Body *primitive.Claim `json:"claims"`
-	}
+		Body *primitive.Claim `json:"body"`
+	} `json:"claims"`
 }
 
 // Revoked returns a bool indicating if any revocation claims exist against this


### PR DESCRIPTION
Deserializing the claims structure for a keypair was not correct, which
would cause panics. Fix this.