### PR TITLE
Introduce the hidden keypairs revoke command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ _unreleased_
 
 - Ensure `keypairs generate` does not panic when used against an org that has
   existing keypairs.
+- Teach `keypairs list` to display the real validity state of a key, not just
+  always "YES".
 
 ## v0.20.0
 

--- a/api/keypairs.go
+++ b/api/keypairs.go
@@ -41,7 +41,7 @@ func (k *KeypairResult) Revoked() bool {
 	return false
 }
 
-type keypairsGenerateRequest struct {
+type keypairsRequest struct {
 	OrgID *identity.ID `json:"org_id"`
 }
 
@@ -49,9 +49,9 @@ type keypairsGenerateRequest struct {
 func (k *KeypairsClient) Generate(ctx context.Context, orgID *identity.ID,
 	output *ProgressFunc) error {
 
-	kpgr := keypairsGenerateRequest{OrgID: orgID}
+	kpr := keypairsRequest{OrgID: orgID}
 
-	req, reqID, err := k.client.NewRequest("POST", "/keypairs/generate", nil, &kpgr, false)
+	req, reqID, err := k.client.NewRequest("POST", "/keypairs/generate", nil, &kpr, false)
 	if err != nil {
 		return err
 	}
@@ -79,4 +79,17 @@ func (k *KeypairsClient) List(ctx context.Context, orgID *identity.ID) ([]Keypai
 	}
 
 	return keypairs, nil
+}
+
+// Revoke revokes the existing keypairs for the user in the given org.
+func (k *KeypairsClient) Revoke(ctx context.Context, orgID *identity.ID, output *ProgressFunc) error {
+	kpr := keypairsRequest{OrgID: orgID}
+
+	req, reqID, err := k.client.NewRequest("POST", "/keypairs/revoke", nil, &kpr, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = k.client.Do(ctx, req, nil, &reqID, output)
+	return err
 }

--- a/apitypes/claimtree.go
+++ b/apitypes/claimtree.go
@@ -1,9 +1,15 @@
 package apitypes
 
 import (
+	"errors"
+
 	"github.com/manifoldco/torus-cli/envelope"
 	"github.com/manifoldco/torus-cli/primitive"
 )
+
+// ErrClaimCycleFound is returned when a cycle is found within the claims.
+// this *should* be impossible, as they are signed.
+var ErrClaimCycleFound = errors.New("Cycle detected in signed claims")
 
 // PublicKeySegment represents a sub section of a claimtree targeting a
 // specific public key and it's claims.
@@ -22,4 +28,23 @@ func (pks *PublicKeySegment) Revoked() bool {
 	}
 
 	return false
+}
+
+// HeadClaim returns the most recent Claim made against this PublicKey
+func (pks *PublicKeySegment) HeadClaim() (*envelope.Signed, error) {
+	// The head claim is the one that is not the previous claim of any others
+outerLoop:
+	for _, c1 := range pks.Claims {
+		for _, c2 := range pks.Claims {
+			if *c2.Body.(*primitive.Claim).Previous == *c1.ID {
+				// Something else is newer than c1
+				continue outerLoop
+			}
+
+		}
+		// nothing is newer than c1. return it
+		return &c1, nil
+	}
+
+	return nil, ErrClaimCycleFound
 }

--- a/daemon/logic/worklog.go
+++ b/daemon/logic/worklog.go
@@ -227,7 +227,7 @@ func (h *missingKeypairsHandler) list(ctx context.Context, org *envelope.Unsigne
 
 func (h *missingKeypairsHandler) resolve(ctx context.Context, n *observer.Notifier,
 	orgID *identity.ID, item *apitypes.WorklogItem) (*apitypes.WorklogResult, error) {
-	err := h.engine.GenerateKeypair(ctx, n, orgID)
+	err := h.engine.GenerateKeypairs(ctx, n, orgID)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/registry/claims.go
+++ b/daemon/registry/claims.go
@@ -1,0 +1,31 @@
+package registry
+
+import (
+	"context"
+	"log"
+
+	"github.com/manifoldco/torus-cli/envelope"
+)
+
+// ClaimsClient represents the `/claims` registry endpoint for making claims
+// against keypairs. Claims can either be a signature or a revocation.
+type ClaimsClient struct {
+	client *Client
+}
+
+// Create creates a a new signed claim on the server
+func (c ClaimsClient) Create(ctx context.Context, claim *envelope.Signed) (*envelope.Signed, error) {
+	req, err := c.client.NewRequest("POST", "/claims", nil, claim)
+	if err != nil {
+		log.Printf("Error building http request: %s", err)
+		return nil, err
+	}
+
+	resp := &envelope.Signed{}
+	_, err = c.client.Do(ctx, req, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/daemon/registry/client.go
+++ b/daemon/registry/client.go
@@ -34,6 +34,7 @@ type Client struct {
 	Projects        *ProjectsClient
 	Keyring         *KeyringClient
 	KeyringMember   *KeyringMemberClientV1
+	Claims          *ClaimsClient
 	ClaimTree       *ClaimTreeClient
 	CredentialGraph *CredentialGraphClient
 	Machines        *MachinesClient
@@ -59,6 +60,7 @@ func NewClient(prefix string, apiVersion string, version string, sess session.Se
 	c.Orgs = &Orgs{client: c}
 	c.OrgInvite = &OrgInviteClient{client: c}
 	c.Projects = &ProjectsClient{client: c}
+	c.Claims = &ClaimsClient{client: c}
 	c.ClaimTree = &ClaimTreeClient{client: c}
 	c.Keyring = &KeyringClient{client: c}
 	c.Keyring.Members = &KeyringMembersClient{client: c}

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -33,7 +33,9 @@ func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
 	mux.PatchFunc("/self", updateSelfRoute(client, s, lEngine))
 
 	mux.PostFunc("/machines", machinesCreateRoute(client, s, lEngine, o))
+
 	mux.PostFunc("/keypairs/generate", keypairsGenerateRoute(lEngine, o))
+	mux.PostFunc("/keypairs/revoke", keypairsRevokeRoute(lEngine, o))
 
 	mux.GetFunc("/credentials", credentialsGetRoute(lEngine, o))
 	mux.PostFunc("/credentials", credentialsPostRoute(lEngine, o))

--- a/daemon/routes/types.go
+++ b/daemon/routes/types.go
@@ -4,12 +4,7 @@ import (
 	"net/http"
 
 	"github.com/manifoldco/torus-cli/apitypes"
-	"github.com/manifoldco/torus-cli/identity"
 )
-
-type keyPairGenerate struct {
-	OrgID *identity.ID `json:"org_id"`
-}
 
 type errorMsg struct {
 	Type  apitypes.ErrorType `json:"type"`


### PR DESCRIPTION
This command is purely for testing and debugging; real revocation will
come packaged in a nicer form, bundled with other actions.

Along with this, teach `keypairs list` to display the actual validity
state of a keypair.

related: #153