### PR TITLE
Worklog keyring regenerated keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ _unreleased_
   was error prone and unusable with sudo installs in some cases.
 - Skip over users without encryption keys when storing secrets, instead of
   erroring out, allowing other users to still access the secrets.
+- Teach the `keypairs` `worklog` item how to handle users that have been
+  removed from a keyring (or had their keys revoked), and then subsequently
+  re-added: The old secret values still require rotation, but the user can be
+  given access to the secrets once again.
 
 ## v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ _unreleased_
 - Under NPM/Node.js, run via a passthrough script that will select the right
   binary. This replaces the previous install time symlinking script, which
   was error prone and unusable with sudo installs in some cases.
+- Skip over users without encryption keys when storing secrets, instead of
+  erroring out, allowing other users to still access the secrets.
 
 ## v0.20.0
 

--- a/daemon/logic/utils.go
+++ b/daemon/logic/utils.go
@@ -111,7 +111,9 @@ func createCredentialGraph(ctx context.Context, credBody *PlaintextCredential,
 		// For this user, find their public encryption key
 		encPubKey, err := findEncryptionPublicKey(claimTrees, credBody.OrgID, &subject)
 		if err != nil {
-			return nil, err
+			// If we didn't find an active key, don't encode this user in the
+			// keyring, but keep going.
+			continue
 		}
 
 		pubKey := encPubKey.Body.(*primitive.PublicKey)

--- a/internal/qa.md
+++ b/internal/qa.md
@@ -84,21 +84,39 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 
 ### Worklog/Keyring Versioning
 
-- [ ]   *prerequisite:* Create an org, and invite another user.
-- [ ]   *prerequisite:* Create a team, add the other user to it, and give it
-        access to a project (`projA`)
-- [ ]   *prerequisite:* Create a second project (`projB`) that the other user
-        does not have access to.
-- [ ]   *prerequiresite:* Set two secrets in both projects
-- [ ]   `torus orgs remove [username] —org [org-name]` removes the user from the
-        org.
-- [ ]   `torus worklog list` shows the secrets from `projA` as needing to be
-        changed, but does not show the secrets from `projB`.
-- [ ]   `torus worklog view <id>` shows a worklog entry by id.
-- [ ]   After each secret from `projA` is changed, it no longer appears in the
-        worklog.
-- [ ]   `torus view` can display a mixture of old and new secrets (ie after a
-        single new set in `projA`).
+- [ ]   *Keyring Versioning*
+  - [ ]   *prerequisite:* Create an org, and invite another user.
+  - [ ]   *prerequisite:* Create a team, add the other user to it, and give it
+          access to a project (`projA`)
+  - [ ]   *prerequisite:* Create a second project (`projB`) that the other user
+          does not have access to.
+  - [ ]   *prerequisite:* Set two secrets in both projects
+  - [ ]   `torus orgs remove [username] —org [org-name]` removes the user from
+          the org.
+  - [ ]   `torus worklog list` shows the secrets from `projA` as needing to be
+          changed, but does not show the secrets from `projB`.
+  - [ ]   `torus worklog view <id>` shows a worklog entry by id.
+  - [ ]   After each secret from `projA` is changed, it no longer appears in the
+          worklog.
+  - [ ]   `torus view` can display a mixture of old and new secrets (ie after a
+          single new set in `projA`).
+- [ ]   *Keypair revocation*
+  - [ ]   *prerequisite:* Create an org, and invite another user.
+  - [ ]   *prerequisite:* Create a team, add the other user to it, and give it
+          access to a project (`projA`)
+  - [ ]   *prerequisite:* Set a secret in the project
+  - [ ]   Run `torus keypairs revoke` as the other user, to revoke your keypairs
+  - [ ]   The other user now cannot see any secrets with `torus view`
+  - [ ]   As the first user, `torus worklog list` should show a secrets item
+          to rotate the secret.
+  - [ ]   Run `torus set` as the first user, to set a *new* secret. It should
+          not error (the revoked keypairs should cause no issues).
+  - [ ]   Run `torus keypairs generate` as the other user.
+  - [ ]   The first user should now see keyring entries in the worklog, to
+          encode the other user's new keypairs.
+  - [ ]   `torus worklog resolve` should resolve the keyring entries.
+  - [ ]   The other user should be able to `torus view` the original secret,
+          and the new secret.
 
 ### List
 


### PR DESCRIPTION
Only return unrevoked keyring memberships

When looking for a keyring membership, skip over any memberships that
match the user/machine token, but have been revoked; only return active
unrevoked memberships.

With this, the worklog can detect when a user was once in a keyring, had
their membership revoked, and then need to be re-added.