### PR TITLE
Stop attempting to convert credentials to numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ _unreleased_
 **Notable Changes**
 
 - Support Ubuntu 16.10 (Yakkety Yak) for deb packages.
+- Secrets set on the command line are now always treated as strings. Previously,
+  We would attempt to convert to ints or floats. Torus doesn't know if
+  you want `-007` to be a string suffix for your spy identifiers, or the number
+  `-7`; so no longer guess, and use the provided value.
+  This change will affect newly set values, but not existing ones.
 
 **Fixes**
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/urfave/cli"
@@ -56,16 +55,7 @@ func setCmd(ctx *cli.Context) error {
 	}
 
 	cred, err := setCredential(ctx, args[0], func() *apitypes.CredentialValue {
-		var v *apitypes.CredentialValue
-		if i, err := strconv.Atoi(args[1]); err == nil {
-			v = apitypes.NewIntCredentialValue(i)
-		} else if f, err := strconv.ParseFloat(args[1], 64); err == nil {
-			v = apitypes.NewFloatCredentialValue(f)
-		} else {
-			v = apitypes.NewStringCredentialValue(args[1])
-		}
-
-		return v
+		return apitypes.NewStringCredentialValue(args[1])
 	})
 
 	if err != nil {


### PR DESCRIPTION
We support types for credentials, which is nice. However, we can't
accurately know if a string given to us on the command line that *looks*
like a number really should be a number.

If we assume it should be a number, we end up losing data, like leading
zeros, or converting long decimals to scientific notation.

For values given on the command line, stop attempting to convert the
value, and instead store it as a string.

Closes #163