### PR TITLE
Set HelpName as well as Name

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = "torus"
+	app.HelpName = "torus"
 	app.Usage = "A secure, shared workspace for secrets"
 	app.Version = config.Version
 	app.Commands = cmd.Cmds


### PR DESCRIPTION
To catch all cli templates that use the name in output. You can never
have too many names!

Closes #167