### PR TITLE
Remove Signup Object

### DIFF
--- a/daemon/routes/session.go
+++ b/daemon/routes/session.go
@@ -229,14 +229,13 @@ func signupRoute(client *registry.Client, s session.Session, db *db.DB) http.Han
 			return
 		}
 
-		userBody := registry.SignupBody{
-			User: primitive.User{
-				Username: signup.Username,
-				Name:     signup.Name,
-				Email:    signup.Email,
-				Password: passwordObj,
-				Master:   masterObj,
-			},
+		userBody := primitive.User{
+			Username: signup.Username,
+			Name:     signup.Name,
+			Email:    signup.Email,
+			Password: passwordObj,
+			Master:   masterObj,
+			State:    "unverified",
 		}
 
 		ID, err := identity.NewMutable(&userBody)
@@ -245,12 +244,10 @@ func signupRoute(client *registry.Client, s session.Session, db *db.DB) http.Han
 			return
 		}
 
-		userObj := registry.SignupEnvelope{
-			User: envelope.User{
-				ID:      &ID,
-				Version: 1,
-			},
-			Body: &userBody,
+		userObj := envelope.User{
+			ID:      &ID,
+			Version: 1,
+			Body:    &userBody,
 		}
 
 		user, err := client.Users.Create(ctx, &userObj, signup)

--- a/registry/users.go
+++ b/registry/users.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/envelope"
-	"github.com/manifoldco/torus-cli/primitive"
 
 	"github.com/manifoldco/torus-cli/daemon/crypto"
 )
@@ -20,7 +19,7 @@ type UsersClient struct {
 }
 
 // Create attempts to register a new user
-func (u *UsersClient) Create(ctx context.Context, userObj *SignupEnvelope,
+func (u *UsersClient) Create(ctx context.Context, userObj *envelope.User,
 	signup apitypes.Signup) (*envelope.User, error) {
 
 	v := &url.Values{}
@@ -120,19 +119,4 @@ func validateSelf(s *envelope.User) error {
 	}
 
 	return nil
-}
-
-type omit struct{}
-
-// SignupEnvelope contains fields for signup
-type SignupEnvelope struct {
-	envelope.User
-	Body *SignupBody `json:"body"`
-}
-
-// SignupBody contains fields for Signup object body during signup
-type SignupBody struct {
-	primitive.User
-
-	State omit `json:"state,omitempty"`
 }


### PR DESCRIPTION
The server now supports an optional state field being supplied during
signup, so we can remove the duplication inside the CLI code base!