### PR TITLE
Registry roundtrip convenience call

### DIFF
--- a/cmd/invites_list.go
+++ b/cmd/invites_list.go
@@ -72,7 +72,7 @@ func invitesList(ctx *cli.Context) error {
 	}
 
 	usernameByID := make(map[string]string)
-	for _, profile := range *profiles {
+	for _, profile := range profiles {
 		usernameByID[profile.ID.String()] = profile.Body.Username
 	}
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -286,7 +286,7 @@ func teamMembersListCmd(ctx *cli.Context) error {
 	fmt.Println(strings.Repeat("-", utf8.RuneCountInString(title)))
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
-	for _, profile := range *profiles {
+	for _, profile := range profiles {
 		me := ""
 		if session.Username() == profile.Body.Username {
 			me = "*"

--- a/registry/claims.go
+++ b/registry/claims.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"log"
 
 	"github.com/manifoldco/torus-cli/envelope"
 )
@@ -15,17 +14,7 @@ type ClaimsClient struct {
 
 // Create creates a a new signed claim on the server
 func (c ClaimsClient) Create(ctx context.Context, claim *envelope.Claim) (*envelope.Claim, error) {
-	req, err := c.client.NewRequest("POST", "/claims", nil, claim)
-	if err != nil {
-		log.Printf("Error building http request: %s", err)
-		return nil, err
-	}
-
 	resp := &envelope.Claim{}
-	_, err = c.client.Do(ctx, req, resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	err := c.client.RoundTrip(ctx, "POST", "/claims", nil, claim, &resp)
+	return resp, err
 }

--- a/registry/claimtree.go
+++ b/registry/claimtree.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"log"
 	"net/url"
 
 	"github.com/manifoldco/torus-cli/apitypes"
@@ -41,17 +40,7 @@ func (c *ClaimTreeClient) List(ctx context.Context, orgID *identity.ID,
 		query.Set("owner_id", ownerID.String())
 	}
 
-	req, err := c.client.NewRequest("GET", "/claimtree", query, nil)
-	if err != nil {
-		log.Printf("Error building http request: %s", err)
-		return nil, err
-	}
-
-	resp := []ClaimTree{}
-	_, err = c.client.Do(ctx, req, &resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	var resp []ClaimTree
+	err := c.client.RoundTrip(ctx, "GET", "/claimtree", query, nil, &resp)
+	return resp, err
 }

--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"log"
 
 	"github.com/manifoldco/torus-cli/envelope"
 )
@@ -15,17 +14,7 @@ type Credentials struct {
 
 // Create creates the provided credential in the registry.
 func (c *Credentials) Create(ctx context.Context, credential *envelope.Credential) (*envelope.Credential, error) {
-	req, err := c.client.NewRequest("POST", "/credentials", nil, credential)
-	if err != nil {
-		log.Printf("Error building http request: %s", err)
-		return nil, err
-	}
-
 	resp := &envelope.Credential{}
-	_, err = c.client.Do(ctx, req, resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	err := c.client.RoundTrip(ctx, "POST", "/credentials", nil, credential, &resp)
+	return resp, err
 }

--- a/registry/envs.go
+++ b/registry/envs.go
@@ -38,13 +38,7 @@ func (e *EnvironmentsClient) Create(ctx context.Context, orgID, projectID *ident
 		Body:    &envBody,
 	}
 
-	req, err := e.client.NewRequest("POST", "/envs", nil, env)
-	if err != nil {
-		return err
-	}
-
-	_, err = e.client.Do(ctx, req, nil)
-	return err
+	return e.client.RoundTrip(ctx, "POST", "/envs", nil, env, nil)
 }
 
 // List retrieves relevant envs by name and/or orgID and/or projectID
@@ -66,12 +60,7 @@ func (e *EnvironmentsClient) List(ctx context.Context, orgIDs, projectIDs *[]*id
 		}
 	}
 
-	req, err := e.client.NewRequest("GET", "/envs", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	envs := []envelope.Environment{}
-	_, err = e.client.Do(ctx, req, &envs)
+	var envs []envelope.Environment
+	err := e.client.RoundTrip(ctx, "GET", "/envs", v, nil, &envs)
 	return envs, err
 }

--- a/registry/keyring.go
+++ b/registry/keyring.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"net/url"
 
 	"github.com/manifoldco/torus-cli/envelope"
@@ -170,19 +169,13 @@ func (k *KeyringClient) List(ctx context.Context, orgID *identity.ID,
 		query.Set("owner_id", ownerID.String())
 	}
 
-	req, err := k.client.NewRequest("GET", "/keyrings", query, nil)
-	if err != nil {
-		log.Printf("Error building http request for GET /keyrings: %s", err)
-		return nil, err
-	}
-
 	resp := []struct {
 		Keyring *envelope.Signed              `json:"keyring"`
 		Members json.RawMessage               `json:"members"`
 		Claims  []envelope.KeyringMemberClaim `json:"claims"`
 	}{}
 
-	_, err = k.client.Do(ctx, req, &resp)
+	err := k.client.RoundTrip(ctx, "GET", "/keyrings", query, nil, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/keyring_member.go
+++ b/registry/keyring_member.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"log"
 
 	"github.com/manifoldco/torus-cli/envelope"
 )
@@ -16,20 +15,8 @@ type KeyringMemberClientV1 struct {
 // Post sends a creation requests for a set of KeyringMember objects to the
 // registry.
 func (k *KeyringMemberClientV1) Post(ctx context.Context, members []envelope.KeyringMemberV1) ([]envelope.KeyringMemberV1, error) {
-
-	req, err := k.client.NewRequest("POST", "/keyring-members", nil, members)
-	if err != nil {
-		log.Printf("Error creating POST /keyring-members request: %s", err)
-		return nil, err
-	}
-
 	resp := []envelope.KeyringMemberV1{}
-	_, err = k.client.Do(ctx, req, &resp)
-	if err != nil {
-		log.Printf("Error performing POST /keyring-members request: %s", err)
-		return nil, err
-	}
-
+	err := k.client.RoundTrip(ctx, "POST", "/keyring-members", nil, members, &resp)
 	return resp, err
 }
 
@@ -44,17 +31,5 @@ type KeyringMembersClient struct {
 func (k *KeyringMembersClient) Post(ctx context.Context, member KeyringMember) error {
 	keyringID := member.Member.Body.KeyringID
 	members := []KeyringMember{member}
-	req, err := k.client.NewRequest("POST", "/keyrings/"+keyringID.String()+"/members", nil, members)
-	if err != nil {
-		log.Printf("Error creating POST /keyring/:id/members request: %s", err)
-		return err
-	}
-
-	_, err = k.client.Do(ctx, req, nil)
-	if err != nil {
-		log.Printf("Error performing POST /keyring/:id/members request: %s", err)
-		return err
-	}
-
-	return err
+	return k.client.RoundTrip(ctx, "POST", "/keyrings/"+keyringID.String()+"/members", nil, members, nil)
 }

--- a/registry/policies.go
+++ b/registry/policies.go
@@ -28,13 +28,8 @@ func (p *PoliciesClient) Create(ctx context.Context, policy *primitive.Policy) (
 		Body:    policy,
 	}
 
-	req, err := p.client.NewRequest("POST", "/policies", nil, env)
-	if err != nil {
-		return nil, err
-	}
-
 	res := envelope.Policy{}
-	_, err = p.client.Do(ctx, req, &res)
+	err = p.client.RoundTrip(ctx, "POST", "/policies", nil, env, &res)
 	return &res, err
 }
 
@@ -48,13 +43,8 @@ func (p *PoliciesClient) List(ctx context.Context, orgID *identity.ID, name stri
 		v.Set("name", name)
 	}
 
-	req, err := p.client.NewRequest("GET", "/policies", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	policies := []envelope.Policy{}
-	_, err = p.client.Do(ctx, req, &policies)
+	err := p.client.RoundTrip(ctx, "GET", "/policies", v, nil, &policies)
 	return policies, err
 }
 
@@ -77,22 +67,12 @@ func (p *PoliciesClient) Attach(ctx context.Context, org, policy, team *identity
 		Body:    &attachment,
 	}
 
-	req, err := p.client.NewRequest("POST", "/policy-attachments", nil, &env)
-	if err != nil {
-		return err
-	}
-	_, err = p.client.Do(ctx, req, nil)
-	return err
+	return p.client.RoundTrip(ctx, "POST", "/policy-attachments", nil, &env, nil)
 }
 
 // Detach deletes a specific attachment
 func (p *PoliciesClient) Detach(ctx context.Context, attachmentID *identity.ID) error {
-	req, err := p.client.NewRequest("DELETE", "/policy-attachments/"+attachmentID.String(), nil, nil)
-	if err != nil {
-		return err
-	}
-	_, err = p.client.Do(ctx, req, nil)
-	return err
+	return p.client.RoundTrip(ctx, "DELETE", "/policy-attachments/"+attachmentID.String(), nil, nil, nil)
 }
 
 // AttachmentsList retrieves all policy attachments for an org
@@ -108,12 +88,7 @@ func (p *PoliciesClient) AttachmentsList(ctx context.Context, orgID, ownerID, po
 		v.Set("policy_id", policyID.String())
 	}
 
-	req, err := p.client.NewRequest("GET", "/policy-attachments", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	attachments := []envelope.PolicyAttachment{}
-	_, err = p.client.Do(ctx, req, &attachments)
+	err := p.client.RoundTrip(ctx, "GET", "/policy-attachments", v, nil, &attachments)
 	return attachments, err
 }

--- a/registry/profiles.go
+++ b/registry/profiles.go
@@ -15,37 +15,19 @@ type ProfilesClient struct {
 
 // ListByName returns profiles looked up by username
 func (p *ProfilesClient) ListByName(ctx context.Context, name string) (*apitypes.Profile, error) {
-	req, err := p.client.NewRequest("GET", "/profiles/"+name, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	result := &apitypes.Profile{}
-	_, err = p.client.Do(ctx, req, result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	err := p.client.RoundTrip(ctx, "GET", "/profiles/"+name, nil, nil, &result)
+	return result, err
 }
 
 // ListByID returns profiles looked up by User ID
-func (p *ProfilesClient) ListByID(ctx context.Context, userIDs []identity.ID) (*[]apitypes.Profile, error) {
+func (p *ProfilesClient) ListByID(ctx context.Context, userIDs []identity.ID) ([]apitypes.Profile, error) {
 	v := &url.Values{}
 	for _, id := range userIDs {
 		v.Add("id", id.String())
 	}
 
-	req, err := p.client.NewRequest("GET", "/profiles", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	results := []apitypes.Profile{}
-	_, err = p.client.Do(ctx, req, &results)
-	if err != nil {
-		return nil, err
-	}
-
-	return &results, nil
+	var results []apitypes.Profile
+	err := p.client.RoundTrip(ctx, "GET", "/profiles", v, nil, &results)
+	return results, err
 }

--- a/registry/projects.go
+++ b/registry/projects.go
@@ -36,13 +36,8 @@ func (p *ProjectsClient) Create(ctx context.Context, org *identity.ID, name stri
 	project.Body.OrgID = org
 	project.Body.Name = name
 
-	req, err := p.client.NewRequest("POST", "/projects", nil, &project)
-	if err != nil {
-		return nil, err
-	}
-
 	res := envelope.Project{}
-	_, err = p.client.Do(ctx, req, &res)
+	err := p.client.RoundTrip(ctx, "POST", "/projects", nil, &project, &res)
 	return &res, err
 }
 
@@ -60,13 +55,8 @@ func (p *ProjectsClient) Search(ctx context.Context, orgIDs *[]*identity.ID, nam
 		}
 	}
 
-	req, err := p.client.NewRequest("GET", "/projects", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	projects := []envelope.Project{}
-	_, err = p.client.Do(ctx, req, &projects)
+	var projects []envelope.Project
+	err := p.client.RoundTrip(ctx, "GET", "/projects", v, nil, &projects)
 	return projects, err
 }
 
@@ -80,12 +70,8 @@ func (p *ProjectsClient) List(ctx context.Context, orgID *identity.ID) ([]envelo
 func (p *ProjectsClient) GetTree(ctx context.Context, orgID *identity.ID) ([]ProjectTreeSegment, error) {
 	v := &url.Values{}
 	v.Set("org_id", orgID.String())
-	req, err := p.client.NewRequest("GET", "/projecttree", v, nil)
-	if err != nil {
-		return nil, err
-	}
 
-	segments := []ProjectTreeSegment{}
-	_, err = p.client.Do(ctx, req, &segments)
+	var segments []ProjectTreeSegment
+	err := p.client.RoundTrip(ctx, "GET", "/projecttree", v, nil, &segments)
 	return segments, err
 }

--- a/registry/self.go
+++ b/registry/self.go
@@ -14,7 +14,7 @@ var errUnknownSessionType = errors.New("Unknown session type")
 
 // SelfClient represents the registry `/self` endpoints.
 type SelfClient struct {
-	client RoundTripper
+	client RequestDoer
 }
 
 type rawSelf struct {

--- a/registry/self.go
+++ b/registry/self.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/envelope"
@@ -27,15 +26,8 @@ type rawSelf struct {
 
 // Get returns the current identities associated with this token
 func (s *SelfClient) Get(ctx context.Context, token string) (*apitypes.Self, error) {
-	req, err := s.client.NewRequest("GET", "/self", nil, nil)
-	replaceAuthToken(req, token)
-	if err != nil {
-		log.Printf("Error making Self request: %s", err)
-		return nil, err
-	}
-
 	raw := &rawSelf{}
-	_, err = s.client.Do(ctx, req, raw)
+	err := tokenRoundTrip(ctx, s.client, token, "GET", "/self", nil, nil, raw)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/services.go
+++ b/registry/services.go
@@ -34,13 +34,8 @@ func (s *ServicesClient) List(ctx context.Context, orgIDs, projectIDs *[]*identi
 		}
 	}
 
-	req, err := s.client.NewRequest("GET", "/services", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	services := []envelope.Service{}
-	_, err = s.client.Do(ctx, req, &services)
+	var services []envelope.Service
+	err := s.client.RoundTrip(ctx, "GET", "/services", v, nil, &services)
 	return services, err
 }
 
@@ -67,11 +62,5 @@ func (s *ServicesClient) Create(ctx context.Context, orgID, projectID *identity.
 		Body:    &serviceBody,
 	}
 
-	req, err := s.client.NewRequest("POST", "/services", nil, service)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.client.Do(ctx, req, nil)
-	return err
+	return s.client.RoundTrip(ctx, "POST", "/services", nil, service, nil)
 }

--- a/registry/teams.go
+++ b/registry/teams.go
@@ -29,45 +29,19 @@ func (t *TeamsClient) List(ctx context.Context, orgID *identity.ID, name string,
 		v.Set("type", string(teamType))
 	}
 
-	req, err := t.client.NewRequest("GET", "/teams", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	teams := []envelope.Team{}
-	_, err = t.client.Do(ctx, req, &teams)
+	var teams []envelope.Team
+	err := t.client.RoundTrip(ctx, "GET", "/teams", v, nil, &teams)
 	return teams, err
 }
 
 // GetByOrg retrieves all teams for an org id
 func (t *TeamsClient) GetByOrg(ctx context.Context, orgID *identity.ID) ([]envelope.Team, error) {
-	v := &url.Values{}
-	v.Set("org_id", orgID.String())
-
-	req, err := t.client.NewRequest("GET", "/teams", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	teams := []envelope.Team{}
-	_, err = t.client.Do(ctx, req, &teams)
-	return teams, err
+	return t.List(ctx, orgID, "", primitive.AnyTeamType)
 }
 
 // GetByName retrieves the team with the specified name
 func (t *TeamsClient) GetByName(ctx context.Context, orgID *identity.ID, name string) ([]envelope.Team, error) {
-	v := &url.Values{}
-	v.Set("org_id", orgID.String())
-	v.Set("name", name)
-
-	req, err := t.client.NewRequest("GET", "/teams", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	teams := []envelope.Team{}
-	_, err = t.client.Do(ctx, req, &teams)
-	return teams, err
+	return t.List(ctx, orgID, name, primitive.AnyTeamType)
 }
 
 // Create performs a request to create a new team object
@@ -94,12 +68,7 @@ func (t *TeamsClient) Create(ctx context.Context, orgID *identity.ID, name strin
 		Body:    &teamBody,
 	}
 
-	req, err := t.client.NewRequest("POST", "/teams", nil, team)
-	if err != nil {
-		return nil, err
-	}
-
-	teamResult := &envelope.Team{}
-	_, err = t.client.Do(ctx, req, teamResult)
-	return teamResult, err
+	result := &envelope.Team{}
+	err = t.client.RoundTrip(ctx, "POST", "/teams", nil, &team, result)
+	return result, err
 }

--- a/registry/tokens.go
+++ b/registry/tokens.go
@@ -91,59 +91,25 @@ func (t *TokensClient) PostLogin(ctx context.Context, creds apitypes.LoginCreden
 // PostAuth requests an auth token from the registry for the provided login
 // token value, and it's HMAC.
 func (t *TokensClient) PostAuth(ctx context.Context, token, hmac string) (string, error) {
-	auth := authTokenResponse{}
-
-	req, err := t.client.NewRequest("POST", "/tokens", nil,
-		&authTokenHMACRequest{Type: tokenTypeAuth, TokenHMAC: hmac})
-	replaceAuthToken(req, token)
-	if err != nil {
-		log.Printf("Error building http request: %s", err)
-		return auth.Token, err
-	}
-
-	_, err = t.client.Do(ctx, req, &auth)
-	if err != nil {
-		log.Printf("Error making api request: %s", err)
-	}
-
-	return auth.Token, err
+	authReq := authTokenHMACRequest{Type: tokenTypeAuth, TokenHMAC: hmac}
+	return t.postAuthWorker(ctx, token, &authReq)
 }
 
 // PostPDPKAuth requests an auth token from the registry for the provided login
 // token value, and it's signature.
 func (t *TokensClient) PostPDPKAuth(ctx context.Context, token string, sig *base64.Value) (string, error) {
+	authReq := authTokenPDPKARequest{Type: tokenTypeAuth, TokenSig: sig}
+	return t.postAuthWorker(ctx, token, &authReq)
+}
+
+func (t *TokensClient) postAuthWorker(ctx context.Context, token string, authReq interface{}) (string, error) {
 	auth := authTokenResponse{}
-
-	req, err := t.client.NewRequest("POST", "/tokens", nil,
-		&authTokenPDPKARequest{Type: tokenTypeAuth, TokenSig: sig})
-	replaceAuthToken(req, token)
-	if err != nil {
-		log.Printf("Error building http request: %s", err)
-		return auth.Token, err
-	}
-
-	_, err = t.client.Do(ctx, req, &auth)
-	if err != nil {
-		log.Printf("Error making api request: %s", err)
-	}
-
+	err := tokenRoundTrip(ctx, t.client, token, "POST", "/tokens", nil, authReq, &auth)
 	return auth.Token, err
 }
 
 // Delete deletes the token with the provided value from the registry. This
 // effectively logs a user out.
 func (t *TokensClient) Delete(ctx context.Context, token string) error {
-	req, err := t.client.NewRequest("DELETE", "/tokens/"+token, nil, nil)
-	replaceAuthToken(req, token)
-	if err != nil {
-		log.Printf("Error building http request: %s", err)
-		return err
-	}
-
-	_, err = t.client.Do(ctx, req, nil)
-	if err != nil {
-		log.Printf("Error making api request: %s", err)
-	}
-
-	return err
+	return tokenRoundTrip(ctx, t.client, token, "DELETE", "/tokens/"+token, nil, nil, nil)
 }

--- a/registry/tokens.go
+++ b/registry/tokens.go
@@ -50,7 +50,7 @@ type authTokenResponse struct {
 // This token is then HMAC'd and returned to the server, exchanging it for
 // an auth token, which is used for all other operations.
 type TokensClient struct {
-	client RoundTripper
+	client RequestDoer
 }
 
 // PostLogin requests a login token from the registry for the provided email

--- a/registry/users.go
+++ b/registry/users.go
@@ -32,16 +32,10 @@ func (u *UsersClient) Create(ctx context.Context, userObj *envelope.User,
 	if signup.Email != "" {
 		v.Set("email", signup.Email)
 	}
-	req, err := u.client.NewRequest("POST", "/users", v, userObj)
-	if err != nil {
-		log.Printf("Error making api request: %s", err)
-		return nil, err
-	}
 
 	user := envelope.User{}
-	_, err = u.client.Do(ctx, req, &user)
+	err := u.client.RoundTrip(ctx, "POST", "/users", v, &userObj, &user)
 	if err != nil {
-		log.Printf("Error making api request: %s", err)
 		return nil, err
 	}
 
@@ -59,27 +53,14 @@ func (u *UsersClient) VerifyEmail(ctx context.Context, verifyCode string) error 
 	verify := apitypes.VerifyEmail{
 		Code: verifyCode,
 	}
-	req, err := u.client.NewRequest("POST", "/users/verify", nil, &verify)
-	if err != nil {
-		return err
-	}
-
-	_, err = u.client.Do(ctx, req, nil)
-	return err
+	return u.client.RoundTrip(ctx, "POST", "/users/verify", nil, &verify, nil)
 }
 
 // Update patches the user object with whitelisted fields
 func (u *UsersClient) Update(ctx context.Context, userObj interface{}) (*envelope.User, error) {
-	req, err := u.client.NewRequest("PATCH", "/users/self", nil, userObj)
-	if err != nil {
-		log.Printf("Error making api request: %s", err)
-		return nil, err
-	}
-
 	user := envelope.User{}
-	_, err = u.client.Do(ctx, req, &user)
+	err := u.client.RoundTrip(ctx, "PATCH", "/users/self", nil, userObj, &user)
 	if err != nil {
-		log.Printf("Error making api request: %s", err)
 		return nil, err
 	}
 

--- a/registry/utils.go
+++ b/registry/utils.go
@@ -1,6 +1,11 @@
 package registry
 
-import "net/http"
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/url"
+)
 
 func replaceAuthToken(req *http.Request, token string) {
 	if token != "" {
@@ -8,4 +13,22 @@ func replaceAuthToken(req *http.Request, token string) {
 	} else {
 		req.Header.Del("Authorization")
 	}
+}
+
+func tokenRoundTrip(ctx context.Context, rd RequestDoer, token, method,
+	path string, query *url.Values, body, response interface{}) error {
+
+	req, err := rd.NewRequest(method, path, query, body)
+	replaceAuthToken(req, token)
+	if err != nil {
+		log.Printf("Error building request: %s", err)
+		return err
+	}
+
+	_, err = rd.Do(ctx, req, response)
+	if err != nil {
+		log.Printf("Error making request: %s", err)
+	}
+
+	return err
 }

--- a/registry/version.go
+++ b/registry/version.go
@@ -14,12 +14,7 @@ type VersionClient struct {
 
 // Get returns the registry's release version.
 func (v *VersionClient) Get(ctx context.Context) (*apitypes.Version, error) {
-	req, err := v.client.NewRequest("GET", "/version", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	version := &apitypes.Version{}
-	_, err = v.client.Do(ctx, req, version)
-	return version, err
+	version := apitypes.Version{}
+	err := v.client.RoundTrip(ctx, "GET", "/version", nil, nil, &version)
+	return &version, err
 }


### PR DESCRIPTION
RoundTrip is a convenience function that combines request creation with
execution. Putting these two calls together reduces the error checking
each call pair had to do before by one. This adds up, over all the
calls!