### PR TITLE
Fewer registry pointers

### DIFF
--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -236,14 +236,14 @@ func listEnvs(ctx *context.Context, client *api.Client, orgID, projID *identity.
 		return nil, cli.NewExitError(envListFailed, -1)
 	}
 
-	var orgIDs []*identity.ID
+	var orgIDs []identity.ID
 	if orgID != nil {
-		orgIDs = []*identity.ID{orgID}
+		orgIDs = []identity.ID{*orgID}
 	}
 
-	var projectIDs []*identity.ID
+	var projectIDs []identity.ID
 	if projID != nil {
-		projectIDs = []*identity.ID{projID}
+		projectIDs = []identity.ID{*projID}
 	}
 
 	var names []string
@@ -251,5 +251,5 @@ func listEnvs(ctx *context.Context, client *api.Client, orgID, projID *identity.
 		names = []string{*name}
 	}
 
-	return client.Environments.List(c, &orgIDs, &projectIDs, &names)
+	return client.Environments.List(c, orgIDs, projectIDs, names)
 }

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -78,9 +78,9 @@ func listProjects(ctx *context.Context, client *api.Client, orgID *identity.ID, 
 		return nil, cli.NewExitError(projectListFailed, -1)
 	}
 
-	var orgIDs []*identity.ID
+	var orgIDs []identity.ID
 	if orgID != nil {
-		orgIDs = []*identity.ID{orgID}
+		orgIDs = []identity.ID{*orgID}
 	}
 
 	var projectNames []string
@@ -88,16 +88,16 @@ func listProjects(ctx *context.Context, client *api.Client, orgID *identity.ID, 
 		projectNames = []string{*name}
 	}
 
-	return client.Projects.Search(c, &orgIDs, &projectNames)
+	return client.Projects.Search(c, orgIDs, projectNames)
 }
 
-func listProjectsByOrgID(ctx *context.Context, client *api.Client, orgIDs []*identity.ID) ([]envelope.Project, error) {
+func listProjectsByOrgID(ctx *context.Context, client *api.Client, orgIDs []identity.ID) ([]envelope.Project, error) {
 	c, client, err := NewAPIClient(ctx, client)
 	if err != nil {
 		return nil, cli.NewExitError(projectListFailed, -1)
 	}
 
-	return client.Projects.Search(c, &orgIDs, nil)
+	return client.Projects.Search(c, orgIDs, nil)
 }
 
 func listProjectsByOrgName(ctx *context.Context, client *api.Client, orgName string) ([]envelope.Project, error) {
@@ -117,7 +117,7 @@ func listProjectsByOrgName(ctx *context.Context, client *api.Client, orgName str
 	}
 
 	// Pull all projects for the given orgID
-	orgIDs := []*identity.ID{org.ID}
+	orgIDs := []identity.ID{*org.ID}
 	projects, err := listProjectsByOrgID(&c, client, orgIDs)
 	if err != nil {
 		return nil, errs.NewExitError(projectListFailed)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -150,14 +150,14 @@ func listServices(ctx *context.Context, client *api.Client, orgID, projID *ident
 		return nil, cli.NewExitError(serviceListFailed, -1)
 	}
 
-	var orgIDs []*identity.ID
+	var orgIDs []identity.ID
 	if orgID != nil {
-		orgIDs = []*identity.ID{orgID}
+		orgIDs = []identity.ID{*orgID}
 	}
 
-	var projectIDs []*identity.ID
+	var projectIDs []identity.ID
 	if projID != nil {
-		projectIDs = []*identity.ID{projID}
+		projectIDs = []identity.ID{*projID}
 	}
 
 	var names []string
@@ -165,7 +165,7 @@ func listServices(ctx *context.Context, client *api.Client, orgID, projID *ident
 		names = []string{*name}
 	}
 
-	return client.Services.List(c, &orgIDs, &projectIDs, &names)
+	return client.Services.List(c, orgIDs, projectIDs, names)
 }
 
 const serviceCreateFailed = "Could not create service."

--- a/registry/envs.go
+++ b/registry/envs.go
@@ -42,22 +42,16 @@ func (e *EnvironmentsClient) Create(ctx context.Context, orgID, projectID *ident
 }
 
 // List retrieves relevant envs by name and/or orgID and/or projectID
-func (e *EnvironmentsClient) List(ctx context.Context, orgIDs, projectIDs *[]*identity.ID, names *[]string) ([]envelope.Environment, error) {
+func (e *EnvironmentsClient) List(ctx context.Context, orgIDs, projectIDs []identity.ID, names []string) ([]envelope.Environment, error) {
 	v := &url.Values{}
-	if orgIDs != nil {
-		for _, id := range *orgIDs {
-			v.Add("org_id", id.String())
-		}
+	for _, id := range orgIDs {
+		v.Add("org_id", id.String())
 	}
-	if projectIDs != nil {
-		for _, id := range *projectIDs {
-			v.Add("project_id", id.String())
-		}
+	for _, id := range projectIDs {
+		v.Add("project_id", id.String())
 	}
-	if names != nil {
-		for _, n := range *names {
-			v.Add("name", n)
-		}
+	for _, n := range names {
+		v.Add("name", n)
 	}
 
 	var envs []envelope.Environment

--- a/registry/projects.go
+++ b/registry/projects.go
@@ -42,17 +42,13 @@ func (p *ProjectsClient) Create(ctx context.Context, org *identity.ID, name stri
 }
 
 // Search retrieves relevant projects by name and/or orgID
-func (p *ProjectsClient) Search(ctx context.Context, orgIDs *[]*identity.ID, names *[]string) ([]envelope.Project, error) {
+func (p *ProjectsClient) Search(ctx context.Context, orgIDs []identity.ID, names []string) ([]envelope.Project, error) {
 	v := &url.Values{}
-	if orgIDs != nil {
-		for _, id := range *orgIDs {
-			v.Add("org_id", id.String())
-		}
+	for _, id := range orgIDs {
+		v.Add("org_id", id.String())
 	}
-	if names != nil {
-		for _, n := range *names {
-			v.Add("name", n)
-		}
+	for _, n := range names {
+		v.Add("name", n)
 	}
 
 	var projects []envelope.Project
@@ -62,8 +58,8 @@ func (p *ProjectsClient) Search(ctx context.Context, orgIDs *[]*identity.ID, nam
 
 // List returns a list of all Projects within the given org.
 func (p *ProjectsClient) List(ctx context.Context, orgID *identity.ID) ([]envelope.Project, error) {
-	orgs := []*identity.ID{orgID}
-	return p.Search(ctx, &orgs, nil)
+	orgs := []identity.ID{*orgID}
+	return p.Search(ctx, orgs, nil)
 }
 
 // GetTree returns a project tree

--- a/registry/services.go
+++ b/registry/services.go
@@ -16,22 +16,16 @@ type ServicesClient struct {
 }
 
 // List retrieves relevant services by name and/or orgID and/or projectID
-func (s *ServicesClient) List(ctx context.Context, orgIDs, projectIDs *[]*identity.ID, names *[]string) ([]envelope.Service, error) {
+func (s *ServicesClient) List(ctx context.Context, orgIDs, projectIDs []identity.ID, names []string) ([]envelope.Service, error) {
 	v := &url.Values{}
-	if orgIDs != nil {
-		for _, id := range *orgIDs {
-			v.Add("org_id", id.String())
-		}
+	for _, id := range orgIDs {
+		v.Add("org_id", id.String())
 	}
-	if projectIDs != nil {
-		for _, id := range *projectIDs {
-			v.Add("project_id", id.String())
-		}
+	for _, id := range projectIDs {
+		v.Add("project_id", id.String())
 	}
-	if names != nil {
-		for _, n := range *names {
-			v.Add("name", n)
-		}
+	for _, n := range names {
+		v.Add("name", n)
 	}
 
 	var services []envelope.Service


### PR DESCRIPTION
A nil slice is effectively the same as a zero length slice. Use nil
slices instead of a nil pointer to a slice for empty arguments to
registry calls, making things simpler.

Built on top of #179