### PR TITLE
Daemon round trip

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -169,3 +169,18 @@ func (rt *apiRoundTripper) RoundTrip(ctx context.Context, method, path string, q
 	_, err = rt.Do(ctx, req, response)
 	return err
 }
+
+func (rt *apiRoundTripper) DaemonRoundTrip(ctx context.Context, method, path string, query *url.Values, body, response interface{}, progress ProgressFunc) error {
+	req, reqID, err := rt.NewDaemonRequest(method, path, query, body)
+	if err != nil {
+		return err
+	}
+
+	if progress == nil {
+		_, err = rt.Do(ctx, req, response)
+	} else {
+		_, err = rt.DoWithProgress(ctx, req, response, reqID, progress)
+	}
+
+	return err
+}

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -20,28 +20,7 @@ func (c *CredentialsClient) Search(ctx context.Context, pathexp string) ([]apity
 	v := &url.Values{}
 	v.Set("pathexp", pathexp)
 
-	req, _, err := c.client.NewDaemonRequest("GET", "/credentials", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp := []apitypes.CredentialResp{}
-
-	_, err = c.client.Do(ctx, req, &resp)
-	if err != nil {
-		return nil, err
-	}
-
-	creds := make([]apitypes.CredentialEnvelope, len(resp))
-	for i, c := range resp {
-		v, err := createEnvelopeFromResp(c)
-		if err != nil {
-			return nil, err
-		}
-		creds[i] = *v
-	}
-
-	return creds, err
+	return c.listWorker(ctx, v)
 }
 
 // Get returns all credentials at the given path.
@@ -49,6 +28,10 @@ func (c *CredentialsClient) Get(ctx context.Context, path string) ([]apitypes.Cr
 	v := &url.Values{}
 	v.Set("path", path)
 
+	return c.listWorker(ctx, v)
+}
+
+func (c *CredentialsClient) listWorker(ctx context.Context, v *url.Values) ([]apitypes.CredentialEnvelope, error) {
 	req, _, err := c.client.NewDaemonRequest("GET", "/credentials", v, nil)
 	if err != nil {
 		return nil, err

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -32,14 +32,8 @@ func (c *CredentialsClient) Get(ctx context.Context, path string) ([]apitypes.Cr
 }
 
 func (c *CredentialsClient) listWorker(ctx context.Context, v *url.Values) ([]apitypes.CredentialEnvelope, error) {
-	req, _, err := c.client.NewDaemonRequest("GET", "/credentials", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp := []apitypes.CredentialResp{}
-
-	_, err = c.client.Do(ctx, req, &resp)
+	var resp []apitypes.CredentialResp
+	err := c.client.DaemonRoundTrip(ctx, "GET", "/credentials", v, nil, &resp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -61,13 +55,8 @@ func (c *CredentialsClient) Create(ctx context.Context, cred *apitypes.Credentia
 	progress ProgressFunc) (*apitypes.CredentialEnvelope, error) {
 
 	env := apitypes.CredentialEnvelope{Version: 2, Body: cred}
-	req, reqID, err := c.client.NewDaemonRequest("POST", "/credentials", nil, &env)
-	if err != nil {
-		return nil, err
-	}
-
 	resp := apitypes.CredentialResp{}
-	_, err = c.client.DoWithProgress(ctx, req, &resp, reqID, progress)
+	err := c.client.DaemonRoundTrip(ctx, "POST", "/credentials", nil, &env, &resp, progress)
 	if err != nil {
 		return nil, err
 	}

--- a/api/keypairs.go
+++ b/api/keypairs.go
@@ -34,12 +34,5 @@ func (k *KeyPairsClient) Revoke(ctx context.Context, orgID *identity.ID, output 
 
 func (k *KeyPairsClient) worker(ctx context.Context, action string, orgID *identity.ID, output ProgressFunc) error {
 	kpr := keyPairsRequest{OrgID: orgID}
-
-	req, reqID, err := k.client.NewDaemonRequest("POST", "/keypairs/"+action, nil, &kpr)
-	if err != nil {
-		return err
-	}
-
-	_, err = k.client.DoWithProgress(ctx, req, nil, reqID, output)
-	return err
+	return k.client.DaemonRoundTrip(ctx, "POST", "/keypairs/"+action, nil, &kpr, nil, output)
 }

--- a/api/keypairs.go
+++ b/api/keypairs.go
@@ -23,25 +23,19 @@ type keyPairsRequest struct {
 }
 
 // Create generates new keypairs for the user in the given org.
-func (k *KeyPairsClient) Create(ctx context.Context, orgID *identity.ID,
-	output ProgressFunc) error {
-
-	kpr := keyPairsRequest{OrgID: orgID}
-
-	req, reqID, err := k.client.NewDaemonRequest("POST", "/keypairs/generate", nil, &kpr)
-	if err != nil {
-		return err
-	}
-
-	_, err = k.client.DoWithProgress(ctx, req, nil, reqID, output)
-	return err
+func (k *KeyPairsClient) Create(ctx context.Context, orgID *identity.ID, output ProgressFunc) error {
+	return k.worker(ctx, "generate", orgID, output)
 }
 
 // Revoke revokes the existing keypairs for the user in the given org.
 func (k *KeyPairsClient) Revoke(ctx context.Context, orgID *identity.ID, output ProgressFunc) error {
+	return k.worker(ctx, "revoke", orgID, output)
+}
+
+func (k *KeyPairsClient) worker(ctx context.Context, action string, orgID *identity.ID, output ProgressFunc) error {
 	kpr := keyPairsRequest{OrgID: orgID}
 
-	req, reqID, err := k.client.NewDaemonRequest("POST", "/keypairs/revoke", nil, &kpr)
+	req, reqID, err := k.client.NewDaemonRequest("POST", "/keypairs/"+action, nil, &kpr)
 	if err != nil {
 		return err
 	}

--- a/api/machines.go
+++ b/api/machines.go
@@ -39,18 +39,9 @@ func (m *MachinesClient) Create(ctx context.Context, orgID, teamID *identity.ID,
 		Secret: secret,
 	}
 
-	req, reqID, err := m.client.NewDaemonRequest("POST", "/machines", nil, &mcr)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	result := &apitypes.MachineSegment{}
-	_, err = m.client.DoWithProgress(ctx, req, result, reqID, output)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return result, secret, nil
+	err = m.client.DaemonRoundTrip(ctx, "POST", "/machines", nil, &mcr, &result, output)
+	return result, secret, err
 }
 
 func createTokenSecret() (*base64.Value, error) {

--- a/api/org_invites.go
+++ b/api/org_invites.go
@@ -20,11 +20,5 @@ func newOrgInvitesClient(upstream *registry.OrgInvitesClient, rt *apiRoundTrippe
 
 // Approve executes the approve invite request
 func (i *OrgInvitesClient) Approve(ctx context.Context, inviteID identity.ID, output ProgressFunc) error {
-	req, reqID, err := i.client.NewDaemonRequest("POST", "/org-invites/"+inviteID.String()+"/approve", nil, nil)
-	if err != nil {
-		return err
-	}
-
-	_, err = i.client.DoWithProgress(ctx, req, nil, reqID, output)
-	return err
+	return i.client.DaemonRoundTrip(ctx, "POST", "/org-invites/"+inviteID.String()+"/approve", nil, nil, nil, output)
 }

--- a/api/session.go
+++ b/api/session.go
@@ -109,13 +109,8 @@ type rawSelf struct {
 
 // Who returns the Session object for the current authenticated user or machine
 func (s *SessionClient) Who(ctx context.Context) (*Session, error) {
-	req, _, err := s.client.NewDaemonRequest("GET", "/self", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	raw := &rawSelf{}
-	_, err = s.client.Do(ctx, req, raw)
+	err := s.client.DaemonRoundTrip(ctx, "GET", "/self", nil, nil, raw, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -147,18 +142,9 @@ func (s *SessionClient) Who(ctx context.Context) (*Session, error) {
 
 // Get returns the status of the user's session.
 func (s *SessionClient) Get(ctx context.Context) (*apitypes.SessionStatus, error) {
-	req, _, err := s.client.NewDaemonRequest("GET", "/session", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	resp := &apitypes.SessionStatus{}
-	_, err = s.client.Do(ctx, req, resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	err := s.client.DaemonRoundTrip(ctx, "GET", "/session", nil, nil, resp, nil)
+	return resp, err
 }
 
 // UserLogin logs the user in using the provided email and passphrase
@@ -208,22 +194,10 @@ func performLogin(ctx context.Context, s *SessionClient, loginType apitypes.Sess
 		Credentials: rawLogin,
 	}
 
-	req, _, err := s.client.NewDaemonRequest("POST", "/login", nil, &wrapper)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.client.Do(ctx, req, nil)
-	return err
+	return s.client.DaemonRoundTrip(ctx, "POST", "/login", nil, &wrapper, nil, nil)
 }
 
 // Logout logs the user out of their session
 func (s *SessionClient) Logout(ctx context.Context) error {
-	req, _, err := s.client.NewDaemonRequest("POST", "/logout", nil, nil)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.client.Do(ctx, req, nil)
-	return err
+	return s.client.DaemonRoundTrip(ctx, "POST", "/logout", nil, nil, nil, nil)
 }

--- a/api/users.go
+++ b/api/users.go
@@ -20,24 +20,14 @@ func newUsersClient(upstream *registry.UsersClient, rt *apiRoundTripper) *UsersC
 
 // Create will have the daemon create a new user request
 func (u *UsersClient) Create(ctx context.Context, signup *apitypes.Signup, output *ProgressFunc) (*envelope.User, error) {
-	req, _, err := u.client.NewDaemonRequest("POST", "/signup", nil, &signup)
-	if err != nil {
-		return nil, err
-	}
-
 	user := envelope.User{}
-	_, err = u.client.Do(ctx, req, &user)
+	err := u.client.DaemonRoundTrip(ctx, "POST", "/signup", nil, &signup, &user, nil)
 	return &user, err
 }
 
 // Update performs a profile update to the user object
 func (u *UsersClient) Update(ctx context.Context, delta apitypes.ProfileUpdate) (*envelope.User, error) {
-	req, _, err := u.client.NewDaemonRequest("PATCH", "/self", nil, &delta)
-	if err != nil {
-		return nil, err
-	}
-
 	user := envelope.User{}
-	_, err = u.client.Do(ctx, req, &user)
+	err := u.client.DaemonRoundTrip(ctx, "PATCH", "/self", nil, &delta, &user, nil)
 	return &user, err
 }

--- a/api/version.go
+++ b/api/version.go
@@ -20,12 +20,7 @@ func newVersionClient(upstream *registry.VersionClient, rt *apiRoundTripper) *Ve
 
 // GetDaemon returns the daemon's release version.
 func (v *VersionClient) GetDaemon(ctx context.Context) (*apitypes.Version, error) {
-	req, _, err := v.client.NewDaemonRequest("GET", "/version", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	version := &apitypes.Version{}
-	_, err = v.client.Do(ctx, req, version)
+	err := v.client.DaemonRoundTrip(ctx, "GET", "/version", nil, nil, version, nil)
 	return version, err
 }

--- a/api/worklog.go
+++ b/api/worklog.go
@@ -33,36 +33,29 @@ func (w *WorklogClient) List(ctx context.Context, orgID *identity.ID) ([]apitype
 
 // Get returns the worklog item with the given id in the given org.
 func (w *WorklogClient) Get(ctx context.Context, orgID *identity.ID, ident *apitypes.WorklogID) (*apitypes.WorklogItem, error) {
-	v := &url.Values{}
-	if orgID != nil {
-		v.Set("org_id", orgID.String())
-	}
-
-	req, _, err := w.client.NewDaemonRequest("GET", "/worklog/"+ident.String(), v, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var entry apitypes.WorklogItem
-
-	_, err = w.client.Do(ctx, req, &entry)
-	return &entry, err
+	var res apitypes.WorklogItem
+	err := w.singleItemWorker(ctx, "GET", orgID, ident, &res)
+	return &res, err
 }
 
 // Resolve resolves the worklog item with the given id in the given org.
 func (w *WorklogClient) Resolve(ctx context.Context, orgID *identity.ID, ident *apitypes.WorklogID) (*apitypes.WorklogResult, error) {
+	var res apitypes.WorklogResult
+	err := w.singleItemWorker(ctx, "POST", orgID, ident, &res)
+	return &res, err
+}
+
+func (w *WorklogClient) singleItemWorker(ctx context.Context, verb string, orgID *identity.ID, ident *apitypes.WorklogID, res interface{}) error {
 	v := &url.Values{}
 	if orgID != nil {
 		v.Set("org_id", orgID.String())
 	}
 
-	req, _, err := w.client.NewDaemonRequest("POST", "/worklog/"+ident.String(), v, nil)
+	req, _, err := w.client.NewDaemonRequest(verb, "/worklog/"+ident.String(), v, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	var res apitypes.WorklogResult
-
-	_, err = w.client.Do(ctx, req, &res)
-	return &res, err
+	_, err = w.client.Do(ctx, req, res)
+	return err
 }

--- a/api/worklog.go
+++ b/api/worklog.go
@@ -20,14 +20,8 @@ func (w *WorklogClient) List(ctx context.Context, orgID *identity.ID) ([]apitype
 		v.Set("org_id", orgID.String())
 	}
 
-	req, _, err := w.client.NewDaemonRequest("GET", "/worklog", v, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	var resp []apitypes.WorklogItem
-
-	_, err = w.client.Do(ctx, req, &resp)
+	err := w.client.DaemonRoundTrip(ctx, "GET", "/worklog", v, nil, &resp, nil)
 	return resp, err
 }
 
@@ -51,11 +45,5 @@ func (w *WorklogClient) singleItemWorker(ctx context.Context, verb string, orgID
 		v.Set("org_id", orgID.String())
 	}
 
-	req, _, err := w.client.NewDaemonRequest(verb, "/worklog/"+ident.String(), v, nil)
-	if err != nil {
-		return err
-	}
-
-	_, err = w.client.Do(ctx, req, res)
-	return err
+	return w.client.DaemonRoundTrip(ctx, verb, "/worklog/"+ident.String(), v, nil, res, nil)
 }


### PR DESCRIPTION
Like RoundTrip for registry, DaemonRoundTrip is a convenience function
that combines request creation with execution. It includes optional
progress output.