### PR TITLE
Introduce v2 User w/ Upgrade from v1->v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ _Unreleased_
 
 - Publish release details to GitHub as proper releases.
 - Show more details in the summary of invite and keypairs worklog items.
+- Passphrase derived public key authentication (PDPKA) is now used to
+  authenticate users. Old users will be upgraded to support this auth method on
+  their next login once they've upgraded to the latest version of Torus. New
+  users will support PDPKA out of the box. Once a user has upgraded to support
+  PDPKA, HMAC authentication is no longer supported.
 
 ## v0.21.1
 

--- a/api/session.go
+++ b/api/session.go
@@ -42,7 +42,7 @@ func (s *Session) Username() string {
 		return s.identity.(*envelope.Machine).Body.Name
 	}
 
-	return s.identity.(*envelope.User).Body.Username
+	return s.identity.(envelope.UserInf).Username()
 }
 
 // Name returns the fullname of the user or the machine name
@@ -51,7 +51,7 @@ func (s *Session) Name() string {
 		return s.identity.(*envelope.Machine).Body.Name
 	}
 
-	return s.identity.(*envelope.User).Body.Name
+	return s.identity.(envelope.UserInf).Name()
 }
 
 // Email returns none for a machine or the users email address
@@ -60,7 +60,7 @@ func (s *Session) Email() string {
 		return "none"
 	}
 
-	return s.identity.(*envelope.User).Body.Email
+	return s.identity.(envelope.UserInf).Email()
 }
 
 // NewSession returns a new session constructed from the payload of the current
@@ -68,10 +68,10 @@ func (s *Session) Email() string {
 func NewSession(resp *apitypes.Self) (*Session, error) {
 	switch resp.Type {
 	case apitypes.UserSession:
-		if _, ok := resp.Identity.(*envelope.User); !ok {
+		if _, ok := resp.Identity.(envelope.UserInf); !ok {
 			return nil, errors.New("Identity must be a user object")
 		}
-		if _, ok := resp.Auth.(*envelope.User); !ok {
+		if _, ok := resp.Auth.(envelope.UserInf); !ok {
 			return nil, errors.New("Auth must be a user object")
 		}
 	case apitypes.MachineSession:

--- a/api/users.go
+++ b/api/users.go
@@ -19,15 +19,23 @@ func newUsersClient(upstream *registry.UsersClient, rt *apiRoundTripper) *UsersC
 }
 
 // Create will have the daemon create a new user request
-func (u *UsersClient) Create(ctx context.Context, signup *apitypes.Signup, output *ProgressFunc) (*envelope.User, error) {
-	user := envelope.User{}
-	err := u.client.DaemonRoundTrip(ctx, "POST", "/signup", nil, &signup, &user, nil)
-	return &user, err
+func (u *UsersClient) Create(ctx context.Context, signup *apitypes.Signup, output *ProgressFunc) (envelope.UserInf, error) {
+	e := envelope.Unsigned{}
+	err := u.client.DaemonRoundTrip(ctx, "POST", "/signup", nil, &signup, &e, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return envelope.ConvertUser(&e)
 }
 
 // Update performs a profile update to the user object
-func (u *UsersClient) Update(ctx context.Context, delta apitypes.ProfileUpdate) (*envelope.User, error) {
-	user := envelope.User{}
-	err := u.client.DaemonRoundTrip(ctx, "PATCH", "/self", nil, &delta, &user, nil)
-	return &user, err
+func (u *UsersClient) Update(ctx context.Context, delta apitypes.ProfileUpdate) (envelope.UserInf, error) {
+	e := envelope.Unsigned{}
+	err := u.client.DaemonRoundTrip(ctx, "PATCH", "/self", nil, &delta, &e, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return envelope.ConvertUser(&e)
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -143,7 +143,7 @@ func profileEdit(ctx *cli.Context) error {
 	if err != nil {
 		return errs.NewErrorExitError("Failed to update profile.", err)
 	}
-	currentEmail := result.Body.Email
+	currentEmail := result.Email()
 
 	// If the password has changed, log the user in again
 	if newPassword != "" {

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -130,7 +130,7 @@ func signup(ctx *cli.Context, subCommand bool) error {
 	}
 
 	// Log the user in
-	err = performLogin(c, client, user.Body.Email, password, true)
+	err = performLogin(c, client, user.Email(), password, true)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ import (
 
 // Version is the compiled version of our binary. It is set via the Makefile.
 var Version = "alpha"
-var apiVersion = "0.2.0"
+var apiVersion = "0.3.0"
 
 const requiredPermissions = 0700
 

--- a/daemon/crypto/crypto.go
+++ b/daemon/crypto/crypto.go
@@ -202,10 +202,10 @@ func CreateMasterKeyObject(ctx context.Context, password []byte, masterKey *[]by
 
 // DeriveLoginKeypair dervies the ed25519 login keypair used for machine
 // authentication from the given salt and secret values.
-func DeriveLoginKeypair(ctx context.Context, secret, salt *base64url.Value) (
+func DeriveLoginKeypair(ctx context.Context, secret []byte, salt *base64url.Value) (
 	*LoginKeypair, error) {
 
-	key, err := deriveHash(ctx, *secret, salt.String())
+	key, err := deriveHash(ctx, secret, salt.String())
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/logic/machine.go
+++ b/daemon/logic/machine.go
@@ -39,7 +39,7 @@ func (m *Machine) CreateToken(ctx context.Context, notifier *observer.Notifier,
 		return nil, err
 	}
 
-	keypair, err := crypto.DeriveLoginKeypair(ctx, secret, salt)
+	keypair, err := crypto.DeriveLoginKeypair(ctx, *secret, salt)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (m *Machine) CreateToken(ctx context.Context, notifier *observer.Notifier,
 	tokenBody := &primitive.MachineToken{
 		OrgID:     orgID,
 		MachineID: machine.ID,
-		PublicKey: &primitive.MachineTokenPublicKey{
+		PublicKey: &primitive.LoginPublicKey{
 			Salt:  keypair.Salt(),
 			Value: keypair.PublicKey(),
 			Alg:   crypto.EdDSA,

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -122,11 +122,11 @@ func checkSessionType(sessionType apitypes.SessionType, identity, auth envelope.
 
 	switch sessionType {
 	case apitypes.UserSession:
-		if _, ok := identity.(*envelope.User); !ok {
+		if _, ok := identity.(envelope.UserInf); !ok {
 			return errors.New("Identity must be a user object")
 		}
 
-		if _, ok := auth.(*envelope.User); !ok {
+		if _, ok := auth.(envelope.UserInf); !ok {
 			return errors.New("Auth must be a user object")
 		}
 	case apitypes.MachineSession:
@@ -206,7 +206,7 @@ func (s *session) MasterKey() (*base64.Value, error) {
 	}
 
 	if s.Type() == apitypes.UserSession {
-		return s.auth.(*envelope.User).Body.Master.Value, nil
+		return s.auth.(envelope.UserInf).Master().Value, nil
 	}
 
 	return s.auth.(*envelope.MachineToken).Body.Master.Value, nil

--- a/envelope/envelope.go
+++ b/envelope/envelope.go
@@ -3,6 +3,8 @@
 package envelope
 
 import (
+	"fmt"
+
 	"github.com/manifoldco/torus-cli/base64"
 	"github.com/manifoldco/torus-cli/identity"
 	"github.com/manifoldco/torus-cli/pathexp"
@@ -40,6 +42,96 @@ type Unsigned struct {
 // GetID returns the ID of the object encapsulated in this envelope.
 func (e *Unsigned) GetID() *identity.ID {
 	return e.ID
+}
+
+// GetVersion returns the Schema version of the object encapsulated in this
+// envelope.
+func (e *Unsigned) GetVersion() uint8 {
+	return e.Version
+}
+
+// UserInf is the common interface for all user schema versions.
+type UserInf interface {
+	Envelope
+	Username() string
+	Name() string
+	Email() string
+	Password() *primitive.UserPassword
+	Master() *primitive.MasterKey
+}
+
+// Username returns the username owned by this User.
+func (u *UserV1) Username() string {
+	return u.Body.Username
+}
+
+// Name returns the Full Name of this User.
+func (u *UserV1) Name() string {
+	return u.Body.Name
+}
+
+// Email returns the current Email Address for this User.
+func (u *UserV1) Email() string {
+	return u.Body.Email
+}
+
+// Password returns the UserPassword for this User.
+func (u *UserV1) Password() *primitive.UserPassword {
+	return u.Body.Password
+}
+
+// Master returns the MasterKey for this User.
+func (u *UserV1) Master() *primitive.MasterKey {
+	return u.Body.Master
+}
+
+// Username returns the username owned by this User.
+func (u *User) Username() string {
+	return u.Body.Username
+}
+
+// Name returns the Full Name of this User.
+func (u *User) Name() string {
+	return u.Body.Name
+}
+
+// Email returns the current Email Address for this User.
+func (u *User) Email() string {
+	return u.Body.Email
+}
+
+// Password returns the UserPassword for this User.
+func (u *User) Password() *primitive.UserPassword {
+	return u.Body.Password
+}
+
+// Master returns the MasterKey for this User.
+func (u *User) Master() *primitive.MasterKey {
+	return u.Body.Master
+}
+
+// ConvertUser converts an unsigned envelope to a UserInf interface which
+// provides a common interface for all user versions.
+func ConvertUser(e *Unsigned) (UserInf, error) {
+	var user UserInf
+	switch e.Version {
+	case 1:
+		user = &UserV1{
+			ID:      e.ID,
+			Version: e.Version,
+			Body:    e.Body.(*primitive.UserV1),
+		}
+	case 2:
+		user = &User{
+			ID:      e.ID,
+			Version: e.Version,
+			Body:    e.Body.(*primitive.User),
+		}
+	default:
+		return nil, fmt.Errorf("Unknown User Schema Version: %d", e.Version)
+	}
+
+	return user, nil
 }
 
 // KeyringInf is the common interface for all keyring schema versions.


### PR DESCRIPTION
The version 2 user schema uses passphrase derived public key
authentication for creating auth tokens.

New signups will be created as v2 Users, while v1 Users will be upgraded
to v2 during the authentication process.

Once a user has upgraded to v2, the old (now deprecated) hmac based
authentication flow will no longer be allowed.

Cliff notes of changes made:

* Introduction of UserInf interface (common access layer for v1 and v2 Users)
* Convenience method for accessing the underlying `byte` array for the
  base64 package.
* Bump to supporting Registry API version `0.3.0`
* Introduction of the `Token` primitive type and envelope