### PR TITLE
Don't create keyring worklog entries for keypairless users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ _Unreleased_
   users will support PDPKA out of the box. Once a user has upgraded to support
   PDPKA, HMAC authentication is no longer supported.
 
+**Fixes**
+
+- If a user is missing access to a keyring, but they do not yet have a valid
+  keypair, don't alert other users to add this user to the keyring; they won't
+  be able to!
+
 ## v0.21.1
 
 _2016-12-20_


### PR DESCRIPTION
If a user is missing access to a keyring, but they don't have a valid,
unrevoked keypair, don't generate worklog items for other users to add
them to the keyring; they won't be able to until the user has a valid
keypair.