### PR TITLE
Updates

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	Credentials  *CredentialsClient
 	Worklog      *WorklogClient
 	Version      *VersionClient
+	Updates      *UpdatesClient
 }
 
 // NewClient returns a new Client.
@@ -67,6 +68,7 @@ func NewClient(cfg *config.Config) *Client {
 	c.Policies = &PoliciesClient{client: c}
 	c.Worklog = &WorklogClient{client: c}
 	c.Version = &VersionClient{client: c}
+	c.Updates = &UpdatesClient{client: c}
 
 	return c
 }

--- a/api/updates.go
+++ b/api/updates.go
@@ -14,13 +14,13 @@ type UpdatesClient struct {
 
 // Check returns the latest updates check result, useful for detecting whether
 // a newer version of Torus is available for download.
-func (c *UpdatesClient) Check(ctx context.Context) (*apitypes.Updates, error) {
+func (c *UpdatesClient) Check(ctx context.Context) (*apitypes.UpdateInfo, error) {
 	req, _, err := c.client.NewRequest("GET", "/updates", nil, nil, false)
 	if err != nil {
 		return nil, err
 	}
 
-	var needsUpdate apitypes.Updates
+	var needsUpdate apitypes.UpdateInfo
 	if _, err := c.client.Do(ctx, req, &needsUpdate, nil, nil); err != nil {
 		return nil, err
 	}

--- a/api/updates.go
+++ b/api/updates.go
@@ -6,10 +6,14 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 )
 
+// UpdatesClient checks if there are updates available coming from
+// the daemon update checker component.
 type UpdatesClient struct {
 	client *Client
 }
 
+// Check returns the latest updates check result, useful for detecting whether
+// a newer version of Torus is available for download.
 func (c *UpdatesClient) Check(ctx context.Context) (*apitypes.Updates, error) {
 	req, _, err := c.client.NewRequest("GET", "/updates", nil, nil, false)
 	if err != nil {

--- a/api/updates.go
+++ b/api/updates.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"context"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+)
+
+type UpdatesClient struct {
+	client *Client
+}
+
+func (c *UpdatesClient) Check(ctx context.Context) (*apitypes.Updates, error) {
+	req, _, err := c.client.NewRequest("GET", "/updates", nil, nil, false)
+	if err != nil {
+		return nil, err
+	}
+
+	var needsUpdate apitypes.Updates
+	_, err = c.client.Do(ctx, req, &needsUpdate, nil, nil)
+	return &needsUpdate, nil
+}

--- a/api/updates.go
+++ b/api/updates.go
@@ -17,6 +17,9 @@ func (c *UpdatesClient) Check(ctx context.Context) (*apitypes.Updates, error) {
 	}
 
 	var needsUpdate apitypes.Updates
-	_, err = c.client.Do(ctx, req, &needsUpdate, nil, nil)
+	if _, err := c.client.Do(ctx, req, &needsUpdate, nil, nil); err != nil {
+		return nil, err
+	}
+
 	return &needsUpdate, nil
 }

--- a/apitypes/apitypes.go
+++ b/apitypes/apitypes.go
@@ -267,3 +267,10 @@ type Membership struct {
 type VerifyEmail struct {
 	Code string `json:"code"`
 }
+
+// UpdateInfo contains info about the latest version of Torus available
+// for download and if that version is higher than the local running one.
+type UpdateInfo struct {
+	NeedsUpdate bool   `json:"needs_update"`
+	Version     string `json:"version"`
+}

--- a/apitypes/updates.go
+++ b/apitypes/updates.go
@@ -1,0 +1,6 @@
+package apitypes
+
+type Updates struct {
+	NeedsUpdate bool   `json:"needs_update"`
+	Version     string `json:"version"`
+}

--- a/apitypes/updates.go
+++ b/apitypes/updates.go
@@ -1,6 +1,0 @@
-package apitypes
-
-type Updates struct {
-	NeedsUpdate bool   `json:"needs_update"`
-	Version     string `json:"version"`
-}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -16,7 +16,7 @@ func init() {
 		Name:     "login",
 		Usage:    "Log in to a user account, authenticating the CLI",
 		Category: "ACCOUNT",
-		Action:   chain(ensureDaemon, login),
+		Action:   chain(ensureDaemon, login, checkUpdates),
 	}
 	Cmds = append(Cmds, login)
 }

--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -20,7 +20,7 @@ import (
 	"github.com/manifoldco/torus-cli/prefs"
 )
 
-const updateCheckUrl = "https://get.torus.sh/manifest.json"
+const downloadURL = "https://www.torus.sh/install"
 
 // chain allows easy sequential calling of BeforeFuncs and AfterFuncs.
 // chain will exit on the first error seen.
@@ -353,7 +353,7 @@ func checkUpdates(ctx *cli.Context) error {
 	defer w.Flush()
 
 	if updateInfo.NeedsUpdate {
-		fmt.Fprintf(w, "New version %s available! Visit %s to download\n", updateInfo.Version, updateCheckUrl)
+		fmt.Fprintf(w, "New version %s available! Visit %s to download\n", updateInfo.Version, downloadURL)
 	}
 
 	return nil

--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"text/tabwriter"
 	"time"
 
 	"github.com/urfave/cli"
@@ -335,6 +334,8 @@ func checkRequiredFlags(ctx *cli.Context) error {
 	return nil
 }
 
+// checkUpdates checks if there's a torus update available. If so,
+// it prints a message to the stdout with the download URL if so.
 func checkUpdates(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -349,11 +350,8 @@ func checkUpdates(ctx *cli.Context) error {
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-	defer w.Flush()
-
 	if updateInfo.NeedsUpdate {
-		fmt.Fprintf(w, "New version %s available! Visit %s to download\n", updateInfo.Version, downloadURL)
+		fmt.Printf("New version %s available! Visit %s to download\n", updateInfo.Version, downloadURL)
 	}
 
 	return nil

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -27,7 +27,7 @@ func init() {
 // VersionLookup ensures the environment is ready and then executes version cmd
 func VersionLookup(ctx *cli.Context) error {
 	return chain(
-		ensureDaemon, listVersionsCmd,
+		ensureDaemon, listVersionsCmd, checkUpdates,
 	)(ctx)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,10 +27,11 @@ type Config struct {
 	APIVersion string
 	Version    string
 
-	TorusRoot  string
-	SocketPath string
-	PidPath    string
-	DBPath     string
+	TorusRoot      string
+	SocketPath     string
+	PidPath        string
+	DBPath         string
+	LastUpdatePath string
 
 	RegistryURI *url.URL
 	CABundle    *x509.CertPool
@@ -63,10 +64,11 @@ func NewConfig(torusRoot string) (*Config, error) {
 		APIVersion: apiVersion,
 		Version:    Version,
 
-		TorusRoot:  torusRoot,
-		SocketPath: path.Join(torusRoot, "daemon.socket"),
-		PidPath:    path.Join(torusRoot, "daemon.pid"),
-		DBPath:     path.Join(torusRoot, "daemon.db"),
+		TorusRoot:      torusRoot,
+		SocketPath:     path.Join(torusRoot, "daemon.socket"),
+		PidPath:        path.Join(torusRoot, "daemon.pid"),
+		DBPath:         path.Join(torusRoot, "daemon.db"),
+		LastUpdatePath: path.Join(torusRoot, "last_update"),
 
 		RegistryURI: registryURI,
 		CABundle:    caBundle,

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -14,12 +14,13 @@ import (
 	"github.com/manifoldco/torus-cli/daemon/observer"
 	"github.com/manifoldco/torus-cli/daemon/registry"
 	"github.com/manifoldco/torus-cli/daemon/session"
+	"github.com/manifoldco/torus-cli/daemon/updates"
 )
 
 // NewRouteMux returns a *bone.Mux responsible for handling the cli to daemon
 // http api.
 func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
-	t *http.Transport, o *observer.Observer, client *registry.Client, lEngine *logic.Engine) *bone.Mux {
+	t *http.Transport, o *observer.Observer, client *registry.Client, lEngine *logic.Engine, uEngine *updates.Engine) *bone.Mux {
 
 	mux := bone.New()
 
@@ -50,6 +51,19 @@ func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
 	mux.GetFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 		enc := json.NewEncoder(w)
 		err := enc.Encode(&apitypes.Version{Version: c.Version})
+		if err != nil {
+			encodeResponseErr(w, err)
+		}
+	})
+
+	mux.GetFunc("/updates", func(w http.ResponseWriter, r *http.Request) {
+		needsUpdate, version := uEngine.VersionInfo()
+		payload := &apitypes.Updates{
+			NeedsUpdate: needsUpdate,
+			Version:     version,
+		}
+		enc := json.NewEncoder(w)
+		err := enc.Encode(payload)
 		if err != nil {
 			encodeResponseErr(w, err)
 		}

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -58,7 +58,7 @@ func NewRouteMux(c *config.Config, s session.Session, db *db.DB,
 
 	mux.GetFunc("/updates", func(w http.ResponseWriter, r *http.Request) {
 		needsUpdate, version := uEngine.VersionInfo()
-		payload := &apitypes.Updates{
+		payload := &apitypes.UpdateInfo{
 			NeedsUpdate: needsUpdate,
 			Version:     version,
 		}

--- a/daemon/socket/proxy.go
+++ b/daemon/socket/proxy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/manifoldco/torus-cli/daemon/registry"
 	"github.com/manifoldco/torus-cli/daemon/routes"
 	"github.com/manifoldco/torus-cli/daemon/session"
+	"github.com/manifoldco/torus-cli/daemon/updates"
 )
 
 // AuthProxy exposes an HTTP interface over a domain socket.
@@ -34,16 +35,17 @@ import (
 // directly proxy requests from the cli to the registry, and exposes an
 // interface over `/v1` for secure and composite operations.
 type AuthProxy struct {
-	u      *url.URL
-	l      net.Listener
-	s      httpdown.Server
-	c      *config.Config
-	db     *db.DB
-	sess   session.Session
-	o      *observer.Observer
-	t      *http.Transport
-	client *registry.Client
-	logic  *logic.Engine
+	u       *url.URL
+	l       net.Listener
+	s       httpdown.Server
+	c       *config.Config
+	db      *db.DB
+	sess    session.Session
+	o       *observer.Observer
+	t       *http.Transport
+	client  *registry.Client
+	logic   *logic.Engine
+	updates *updates.Engine
 }
 
 // NewAuthProxy returns a new AuthProxy. It will return an error if creation
@@ -54,7 +56,7 @@ type AuthProxy struct {
 // users). If false, the socket will only be readable and writable by the user
 // running the daemon.
 func NewAuthProxy(c *config.Config, sess session.Session, db *db.DB, t *http.Transport,
-	client *registry.Client, logic *logic.Engine, groupShared bool) (*AuthProxy, error) {
+	client *registry.Client, logic *logic.Engine, updates *updates.Engine, groupShared bool) (*AuthProxy, error) {
 
 	l, err := makeSocket(c.SocketPath, groupShared)
 	if err != nil {
@@ -62,15 +64,16 @@ func NewAuthProxy(c *config.Config, sess session.Session, db *db.DB, t *http.Tra
 	}
 
 	return &AuthProxy{
-		u:      c.RegistryURI,
-		l:      l,
-		c:      c,
-		db:     db,
-		sess:   sess,
-		o:      observer.New(),
-		t:      t,
-		client: client,
-		logic:  logic,
+		u:       c.RegistryURI,
+		l:       l,
+		c:       c,
+		db:      db,
+		sess:    sess,
+		o:       observer.New(),
+		t:       t,
+		client:  client,
+		logic:   logic,
+		updates: updates,
 	}, nil
 }
 
@@ -107,7 +110,7 @@ func (p *AuthProxy) Listen() error {
 	go p.o.Start()
 
 	mux.HandleFunc("/proxy/", proxyCanceler(proxy))
-	mux.SubRoute("/v1", routes.NewRouteMux(p.c, p.sess, p.db, p.t, p.o, p.client, p.logic))
+	mux.SubRoute("/v1", routes.NewRouteMux(p.c, p.sess, p.db, p.t, p.o, p.client, p.logic, p.updates))
 
 	h := httpdown.HTTP{}
 	p.s = h.Serve(&http.Server{Handler: requestIDHandler(loggingHandler(mux))}, p.l)

--- a/daemon/updates/updates.go
+++ b/daemon/updates/updates.go
@@ -94,7 +94,8 @@ func (e *Engine) start() {
 // has passed. By default the check is performed at the `releaseHourCheck`-th hour
 // of the `releaseDay` weekday.
 func (e *Engine) nextCheck() time.Duration {
-	day := time.Now().Weekday()
+	now := time.Now().UTC()
+	day := now.Weekday()
 	if e.lastCheck.IsZero() || (day >= releaseDay && time.Since(e.lastCheck).Hours() > releaseHourCheck) {
 		return time.Second
 	}
@@ -105,14 +106,14 @@ func (e *Engine) nextCheck() time.Duration {
 	} else {
 		daysDue = 7 - daysDue
 	}
-	hoursDue := 24*(daysDue) - time.Now().Hour() + releaseHourCheck
+	hoursDue := 24*(daysDue) - now.Hour() + releaseHourCheck
 
 	log.Printf("checking updates in %d hours", hoursDue)
 	return time.Duration(hoursDue) * time.Hour
 }
 
 func (e *Engine) storeLastCheck() error {
-	e.lastCheck = time.Now()
+	e.lastCheck = time.Now().UTC()
 	data := []byte(e.lastCheck.Format(timeLayout))
 	return ioutil.WriteFile(e.config.LastUpdatePath, data, 0600)
 }

--- a/daemon/updates/updates.go
+++ b/daemon/updates/updates.go
@@ -1,0 +1,167 @@
+package updates
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/manifoldco/torus-cli/config"
+	"github.com/manifoldco/torus-cli/prefs"
+)
+
+const (
+	url              = "https://get.torus.sh/manifest.json"
+	releaseHourCheck = 6 // Check updates at 6am
+)
+
+var (
+	timeLayout = time.RFC3339
+	releaseDay = time.Wednesday
+)
+
+type Engine struct {
+	config        *config.Config
+	stop          chan struct{}
+	lastCheck     time.Time
+	targetVersion string
+}
+
+type VersionInfo struct {
+	Version  string `json:"version"`
+	Released string `json:"released"`
+}
+
+func NewEngine(cfg *config.Config) *Engine {
+	return &Engine{
+		config: cfg,
+		stop:   make(chan struct{}),
+	}
+}
+
+func (e *Engine) Start() error {
+	pref, err := prefs.NewPreferences()
+	if err != nil {
+		return fmt.Errorf("cannot load preferences")
+	}
+
+	if pref.Core.EnableCheckUpdates {
+		go e.start()
+	}
+
+	return nil
+}
+
+func (e *Engine) Stop() error {
+	close(e.stop)
+	return nil
+}
+
+func (e *Engine) start() {
+	if err := e.getLastCheck(); err != nil {
+		log.Printf("cannot get last update: %s", err)
+	}
+
+	log.Printf("last update check: %s", e.lastCheck)
+	e.targetVersion = e.config.Version
+	for {
+		select {
+		case <-e.stop:
+			log.Printf("stopped checking for updates")
+			return
+		case <-time.After(e.nextCheck()):
+			log.Printf("check updates")
+
+			latest, err := e.getLatestVersion()
+			if err != nil {
+				log.Printf("cannot check for updates: %s", err)
+				continue
+			}
+
+			e.targetVersion = latest
+			if err := e.storeLastCheck(); err != nil {
+				log.Printf("cannot store update check: %s", err)
+			}
+		}
+	}
+}
+
+// nextCheck returns the time duration to wait before triggering an update check.
+// It is calculated based on wether there already were a check or enough time
+// has passed. By default the check is performed at the `releaseHourCheck`-th hour
+// of the `releaseDay` weekday.
+func (e *Engine) nextCheck() time.Duration {
+	day := time.Now().Weekday()
+	if e.lastCheck.IsZero() || (day >= releaseDay && time.Since(e.lastCheck).Hours() > releaseHourCheck) {
+		return time.Second
+	}
+
+	daysDue := int(day) - int(releaseDay)
+	if daysDue < 0 {
+		daysDue = -daysDue
+	} else {
+		daysDue = 7 - daysDue
+	}
+	hoursDue := 24*(daysDue) - time.Now().Hour() + releaseHourCheck
+
+	log.Printf("checking updates in %d hours", hoursDue)
+	return time.Duration(hoursDue) * time.Hour
+}
+
+func (e *Engine) storeLastCheck() error {
+	e.lastCheck = time.Now()
+	data := []byte(e.lastCheck.Format(timeLayout))
+	return ioutil.WriteFile(e.config.LastUpdatePath, data, 0600)
+}
+
+func (e *Engine) getLastCheck() error {
+	if _, err := os.Stat(e.config.LastUpdatePath); os.IsNotExist(err) {
+		if _, err := os.Create(e.config.LastUpdatePath); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	content, err := ioutil.ReadFile(e.config.LastUpdatePath)
+	if err != nil {
+		return err
+	}
+
+	e.lastCheck, err = time.Parse(timeLayout, string(content))
+	return err
+}
+
+func (e *Engine) getLatestVersion() (string, error) {
+	resp, err := http.Get(url)
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return "", fmt.Errorf("cannot get info: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("unsuccessful response: %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cannot read response body: %s", err)
+	}
+	var info VersionInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return "", fmt.Errorf("cannot decode response body: %s", err)
+	}
+
+	return info.Version, nil
+}
+
+func (e *Engine) needsUpdate() bool {
+	return e.targetVersion > e.config.Version
+}
+
+func (e *Engine) VersionInfo() (bool, string) {
+	return e.needsUpdate(), e.targetVersion
+}

--- a/daemon/updates/updates_test.go
+++ b/daemon/updates/updates_test.go
@@ -29,58 +29,55 @@ func TestNextCheck(t *testing.T) {
 	thursday := wednesday.Add(24 * time.Hour)
 
 	examples := []nextCheckExample{
-		nextCheckExample{
+		{
 			lastCheck: time.Time{},
 			expected:  minCheckDuration,
 		},
 
-		nextCheckExample{
+		{
 			now:       tuesday,
 			lastCheck: tuesday,
 			expected:  30 * time.Hour,
 		},
 
-		// when the current day is previous than release day
-		nextCheckExample{
+		{
 			now:       sunday,
 			lastCheck: wednesday.Add(time.Duration(-24*7+releaseHourCheck) * time.Hour),
 			expected:  time.Duration(24*3*time.Hour + releaseHourCheck*time.Hour),
 		},
 
-		nextCheckExample{
+		{
 			now:       tuesday,
 			lastCheck: wednesday.Add(-24 * 7 * time.Hour),
 			expected:  minCheckDuration,
 		},
 
-		// when the current day is after the release day
-		nextCheckExample{
+		{
 			now:       thursday,
 			lastCheck: wednesday.Add(releaseHourCheck * time.Hour),
 			expected:  time.Duration(24*6+releaseHourCheck) * time.Hour,
 		},
 
-		// when the current day is the same as release day
-		nextCheckExample{
+		{
 			now:       wednesday,
 			lastCheck: wednesday.Add(-24 * 7 * time.Hour),
 			expected:  minCheckDuration,
 		},
 
-		nextCheckExample{
+		{
 			now:       wednesday,
 			lastCheck: wednesday,
 			expected:  time.Duration(releaseHourCheck * time.Hour),
 		},
 
-		nextCheckExample{
+		{
 			now:       wednesday.Add((releaseHourCheck + 1) * time.Hour),
 			lastCheck: wednesday.Add(releaseHourCheck * time.Hour),
 			expected:  (24*7 - 1) * time.Hour,
 		},
 	}
 
-	for i, example := range examples {
+	for _, example := range examples {
 		timeManager := mockTimeManager{
 			now: example.now,
 		}
@@ -91,7 +88,7 @@ func TestNextCheck(t *testing.T) {
 
 		e.lastCheck = example.lastCheck
 		if d := e.nextCheck(); d != example.expected {
-			t.Fatalf("%d) %s - %s, expected %s, got %s", i+1, example.now, example.lastCheck, example.expected, d)
+			t.Fatalf("expected %s, got %s", example.expected, d)
 		}
 	}
 }

--- a/daemon/updates/updates_test.go
+++ b/daemon/updates/updates_test.go
@@ -1,0 +1,97 @@
+package updates
+
+import (
+	"testing"
+	"time"
+)
+
+type nextCheckExample struct {
+	now       time.Time
+	lastCheck time.Time
+	expected  time.Duration
+}
+
+type mockTimeManager struct {
+	now time.Time
+}
+
+func (m mockTimeManager) Now() time.Time {
+	return m.now
+}
+
+func TestNextCheck(t *testing.T) {
+	wednesday := time.Time{}
+	daysDiff := int(releaseDay) - int(wednesday.Weekday())
+	wednesday = wednesday.Add(time.Duration(daysDiff*24-wednesday.Hour()) * time.Hour)
+
+	sunday := wednesday.Add(-24 * 3 * time.Hour)
+	tuesday := wednesday.Add(-24 * time.Hour)
+	thursday := wednesday.Add(24 * time.Hour)
+
+	examples := []nextCheckExample{
+		nextCheckExample{
+			lastCheck: time.Time{},
+			expected:  minCheckDuration,
+		},
+
+		nextCheckExample{
+			now:       tuesday,
+			lastCheck: tuesday,
+			expected:  30 * time.Hour,
+		},
+
+		// when the current day is previous than release day
+		nextCheckExample{
+			now:       sunday,
+			lastCheck: wednesday.Add(time.Duration(-24*7+releaseHourCheck) * time.Hour),
+			expected:  time.Duration(24*3*time.Hour + releaseHourCheck*time.Hour),
+		},
+
+		nextCheckExample{
+			now:       tuesday,
+			lastCheck: wednesday.Add(-24 * 7 * time.Hour),
+			expected:  minCheckDuration,
+		},
+
+		// when the current day is after the release day
+		nextCheckExample{
+			now:       thursday,
+			lastCheck: wednesday.Add(releaseHourCheck * time.Hour),
+			expected:  time.Duration(24*6+releaseHourCheck) * time.Hour,
+		},
+
+		// when the current day is the same as release day
+		nextCheckExample{
+			now:       wednesday,
+			lastCheck: wednesday.Add(-24 * 7 * time.Hour),
+			expected:  minCheckDuration,
+		},
+
+		nextCheckExample{
+			now:       wednesday,
+			lastCheck: wednesday,
+			expected:  time.Duration(releaseHourCheck * time.Hour),
+		},
+
+		nextCheckExample{
+			now:       wednesday.Add((releaseHourCheck + 1) * time.Hour),
+			lastCheck: wednesday.Add(releaseHourCheck * time.Hour),
+			expected:  (24*7 - 1) * time.Hour,
+		},
+	}
+
+	for i, example := range examples {
+		timeManager := mockTimeManager{
+			now: example.now,
+		}
+
+		e := &Engine{
+			timeManager: timeManager,
+		}
+
+		e.lastCheck = example.lastCheck
+		if d := e.nextCheck(); d != example.expected {
+			t.Fatalf("%d) %s - %s, expected %s, got %s", i+1, example.now, example.lastCheck, example.expected, d)
+		}
+	}
+}

--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -18,6 +18,7 @@ Preference | Description
 `core.auto_confirm` | Boolean determining if confirmation prompts should be automatically skipped (equivalent of always using `-y` command option)
 `core.vim` | Boolean determining if CLI input should use Vim bindings
 `core.hints` | Boolean determining if the "protip" hints are shown after command execution
+`core.check_updates` | Boolean determining if the daemon can check for updates in the background
 `defaults.org` | Organization name to be used with context
 `defaults.project` | Project name to be used with context
 `defaults.environment` | Environment name to be used with context

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -43,14 +43,15 @@ func (prefs Preferences) CountFields(fieldName string) int {
 
 // Core contains core option values
 type Core struct {
-	PublicKeyFile  string `ini:"public_key_file,omitempty"`
-	CABundleFile   string `ini:"ca_bundle_file,omitempty"`
-	RegistryURI    string `ini:"registry_uri,omitempty"`
-	Context        bool   `ini:"context,omitempty"`
-	AutoConfirm    bool   `ini:"auto_confirm,omitempty"`
-	EnableProgress bool   `ini:"progress"`
-	EnableHints    bool   `ini:"hints"`
-	Vim            bool   `ini:"vim,omitempty"`
+	PublicKeyFile      string `ini:"public_key_file,omitempty"`
+	CABundleFile       string `ini:"ca_bundle_file,omitempty"`
+	RegistryURI        string `ini:"registry_uri,omitempty"`
+	Context            bool   `ini:"context,omitempty"`
+	AutoConfirm        bool   `ini:"auto_confirm,omitempty"`
+	EnableProgress     bool   `ini:"progress"`
+	EnableHints        bool   `ini:"hints"`
+	Vim                bool   `ini:"vim,omitempty"`
+	EnableCheckUpdates bool   `ini:"check_updates"`
 }
 
 // Defaults contains default values for use in command argument flags
@@ -125,10 +126,11 @@ func RcPath() (string, error) {
 func NewPreferences() (*Preferences, error) {
 	prefs := &Preferences{
 		Core: Core{
-			RegistryURI:    registryURI,
-			Context:        true,
-			EnableHints:    true,
-			EnableProgress: true,
+			RegistryURI:        registryURI,
+			Context:            true,
+			EnableHints:        true,
+			EnableProgress:     true,
+			EnableCheckUpdates: true,
 		},
 	}
 


### PR DESCRIPTION
Added the capability to fetch updates from `https://get.torus.sh/manifest.json` and inform user via the cli about new versions.

Such feature can be toggled with the `check_updates` prefs variable.

It's meant to be added as chained command via the cli middleware, it's added for demo purposes in the `login` and `version` commands.