### PR TITLE
Fix machine creation

### DIFF
--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -160,7 +160,7 @@ func (s *session) Set(sessionType apitypes.SessionType, identity, auth envelope.
 		return errors.New("Passphrase must not be empty")
 	}
 
-	if len(token) == 0 {
+	if len(token) == 0 && sessionType == apitypes.UserSession {
 		return errors.New("Token must not be empty")
 	}
 


### PR DESCRIPTION
When creating a machine, we build a temporary session to generate the
machine's login details.

Machines do not require the token portion of the session to be set;
rather than putting in a dummy value, check for the type.