### PR TITLE
Install released versions of glide only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ builds/*
 zz_generated_*.go
 
 # Our 3rd party deps
+.glide
 vendor/*
 
 # Code generators

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.7.4-alpine
 
-RUN apk add --no-cache git make
+RUN apk add --no-cache curl git make
 
 # Create work directory for the CLI and build output dest
 RUN mkdir -p /go/src/github.com/manifoldco/torus-cli \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ ci: binary $(LINTERS) cmdlint test
 #################################################
 
 BOOTSTRAP=\
-	github.com/Masterminds/glide \
 	github.com/golang/lint/golint \
 	honnef.co/go/simple/cmd/gosimple \
 	github.com/jteeuwen/go-bindata/... \
@@ -41,6 +40,7 @@ BOOTSTRAP=\
 $(BOOTSTRAP):
 	go get -u $@
 bootstrap: $(BOOTSTRAP)
+	curl http://glide.sh/get | sh
 
 .PHONY: bootstrap $(BOOTSTRAP)
 


### PR DESCRIPTION
A recent change to glide broke our CI process. Let's try and eliminate
that, and use released versions only!