### PR TITLE
Worklog details structure

### DIFF
--- a/api/worklog.go
+++ b/api/worklog.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/url"
 
 	"github.com/manifoldco/torus-cli/apitypes"
@@ -13,6 +15,8 @@ type WorklogClient struct {
 	client *apiRoundTripper
 }
 
+var errUnknownWorklogType = errors.New("Unknown worklog item type")
+
 // List returns the list of all worklog items in the given org.
 func (w *WorklogClient) List(ctx context.Context, orgID *identity.ID) ([]apitypes.WorklogItem, error) {
 	v := &url.Values{}
@@ -20,16 +24,34 @@ func (w *WorklogClient) List(ctx context.Context, orgID *identity.ID) ([]apitype
 		v.Set("org_id", orgID.String())
 	}
 
-	var resp []apitypes.WorklogItem
+	var resp []rawWorklogItem
 	err := w.client.DaemonRoundTrip(ctx, "GET", "/worklog", v, nil, &resp, nil)
-	return resp, err
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]apitypes.WorklogItem, 0, len(resp))
+	for _, w := range resp {
+		err := w.setDetails()
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, *w.WorklogItem)
+	}
+	return out, err
 }
 
 // Get returns the worklog item with the given id in the given org.
 func (w *WorklogClient) Get(ctx context.Context, orgID *identity.ID, ident *apitypes.WorklogID) (*apitypes.WorklogItem, error) {
-	var res apitypes.WorklogItem
+	var res rawWorklogItem
 	err := w.singleItemWorker(ctx, "GET", orgID, ident, &res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+
+	err = res.setDetails()
+	return res.WorklogItem, err
 }
 
 // Resolve resolves the worklog item with the given id in the given org.
@@ -46,4 +68,30 @@ func (w *WorklogClient) singleItemWorker(ctx context.Context, verb string, orgID
 	}
 
 	return w.client.DaemonRoundTrip(ctx, verb, "/worklog/"+ident.String(), v, nil, res, nil)
+}
+
+type rawWorklogItem struct {
+	*apitypes.WorklogItem
+	Details json.RawMessage `json:"details"`
+}
+
+func (w *rawWorklogItem) setDetails() error {
+	if w == nil {
+		return nil
+	}
+
+	switch w.Type() {
+	case apitypes.SecretRotateWorklogType:
+		w.WorklogItem.Details = &apitypes.SecretRotateWorklogDetails{}
+	case apitypes.MissingKeypairsWorklogType:
+		w.WorklogItem.Details = &apitypes.MissingKeypairsWorklogDetails{}
+	case apitypes.InviteApproveWorklogType:
+		w.WorklogItem.Details = &apitypes.InviteApproveWorklogDetails{}
+	case apitypes.KeyringMembersWorklogType:
+		w.WorklogItem.Details = &apitypes.KeyringMembersWorklogDetails{}
+	default:
+		return errUnknownWorklogType
+	}
+
+	return json.Unmarshal(w.Details, w.WorklogItem.Details)
 }

--- a/apitypes/worklog.go
+++ b/apitypes/worklog.go
@@ -2,11 +2,14 @@ package apitypes
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/dchest/blake2b"
 
 	"github.com/manifoldco/torus-cli/base32"
 	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/pathexp"
+	"github.com/manifoldco/torus-cli/primitive"
 )
 
 // WorklogType is the enumerated byte type of WorklogItems
@@ -73,11 +76,118 @@ func (id WorklogID) Type() WorklogType {
 // WorklogItem is an item that the daemon has identified as needing to be done
 // to ensure system correctness, or security in the face of stale secrets.
 type WorklogItem struct {
-	ID      *WorklogID `json:"id"`
-	Subject string     `json:"subject"`
-	Summary string     `json:"summary"`
+	ID *WorklogID `json:"id"`
 
-	SubjectID *identity.ID `json:"subject_id"` // Optional.
+	Details WorklogDetails `json:"details"`
+}
+
+// Subject returns the human readable subject of this WorklogItem.
+func (w *WorklogItem) Subject() string {
+	return w.Details.Subject()
+}
+
+// Summary returns the human readable summary of this WorklogItem.
+func (w *WorklogItem) Summary() string {
+	return w.Details.Summary()
+}
+
+// WorklogDetails is the common interface exposed by worklog item types.
+type WorklogDetails interface {
+	Subject() string
+	Summary() string
+}
+
+// InviteApproveWorklogDetails holds WorklogItem details for the
+// InviteApproveWorklogType.
+type InviteApproveWorklogDetails struct {
+	InviteID *identity.ID `json:"invite_id"`
+	Email    string       `json:"email"`
+	Username string       `json:"username"`
+	Name     string       `json:"name"`
+	Org      string       `json:"org"`
+	Teams    []string     `json:"teams"`
+}
+
+// Subject returns the human readable subject of this WorklogItem.
+func (i *InviteApproveWorklogDetails) Subject() string {
+	return i.Email
+}
+
+// Summary returns the human readable summary of this WorklogItem.
+func (i *InviteApproveWorklogDetails) Summary() string {
+	summary := fmt.Sprintf("The invite for %s to org %s is ready for approval.",
+		i.Email, i.Org)
+	return summary
+}
+
+// KeyringMembersWorklogDetails holds WorklogItem details for the
+// KeyringMembersWorklogType.
+type KeyringMembersWorklogDetails struct {
+	EntityID *identity.ID      `json:"entity_id"`
+	Name     string            `json:"name"`
+	Type     string            `json:"type"`
+	OwnerIDs []identity.ID     `json:"owner_ids"`
+	Keyrings []pathexp.PathExp `json:"keyrings"`
+}
+
+// Subject returns the human readable subject of this WorklogItem.
+func (k *KeyringMembersWorklogDetails) Subject() string {
+	return k.Name
+}
+
+// Summary returns the human readable summary of this WorklogItem.
+func (k *KeyringMembersWorklogDetails) Summary() string {
+	return fmt.Sprintf("This %s is missing access to one or more secrets.", k.Type)
+}
+
+// MissingKeypairsWorklogDetails holds WorklogItem details for the
+// MissingKeypairsWorklogType..
+type MissingKeypairsWorklogDetails struct {
+	Org               string `json:"org"`
+	EncryptionMissing bool   `json:"encryption_missing"`
+	SigningMissing    bool   `json:"signing_missing"`
+}
+
+// Subject returns the human readable subject of this WorklogItem.
+func (m *MissingKeypairsWorklogDetails) Subject() string {
+	return m.Org
+}
+
+// Summary returns the human readable summary of this WorklogItem.
+func (m *MissingKeypairsWorklogDetails) Summary() string {
+	msg := "Signing and encryption keypairs missing for org %s."
+	if !m.EncryptionMissing {
+		msg = "Signing keypair missing for org %s."
+	} else if !m.SigningMissing {
+		msg = "Encryption keypair missing for org %s."
+	}
+
+	return fmt.Sprintf(msg, m.Org)
+}
+
+// SecretRotateWorklogDetails holds WorklogItem details for the
+// SecretRotateWorklogType.
+type SecretRotateWorklogDetails struct {
+	PathExp *pathexp.PathExp            `json:"pathexp"`
+	Name    string                      `json:"name"`
+	Reasons []SecretRotateWorklogReason `json:"reasons"`
+}
+
+// SecretRotateWorklogReason holds the username and claim revocation type
+// for a secret rotation reason.
+type SecretRotateWorklogReason struct {
+	Username string                                `json:"username"`
+	Type     primitive.KeyringMemberRevocationType `json:"type"`
+}
+
+// Subject returns the human readable subject of this WorklogItem.
+func (s *SecretRotateWorklogDetails) Subject() string {
+	return s.PathExp.String() + "/" + s.Name
+}
+
+// Summary returns the human readable summary of this WorklogItem.
+func (s *SecretRotateWorklogDetails) Summary() string {
+	return "A user's access was revoked. This secret's value should be changed."
 }
 
 // Type returns this item's type
@@ -110,7 +220,7 @@ func (w *WorklogItem) CreateID(worklogType WorklogType) {
 	}
 
 	h.Write([]byte{byte(worklogType)})
-	h.Write([]byte(w.Subject))
+	h.Write([]byte(w.Details.Subject()))
 
 	id := WorklogID{byte(worklogType)}
 	copy(id[1:], h.Sum(nil))

--- a/cmd/worklog.go
+++ b/cmd/worklog.go
@@ -82,7 +82,7 @@ func worklogList(ctx *cli.Context) error {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "IDENTITY\tTYPE\tSUBJECT")
 	for _, item := range items {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", item.ID, item.Type(), item.Subject)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", item.ID, item.Type(), item.Subject())
 	}
 
 	w.Flush()
@@ -125,10 +125,10 @@ func worklogView(ctx *cli.Context) error {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "Identity:\t%s\n", item.ID.String())
 	fmt.Fprintf(w, "Type:\t%s\n", item.Type())
-	fmt.Fprintf(w, "Subject:\t%s\n", item.Subject)
+	fmt.Fprintf(w, "Subject:\t%s\n", item.Subject())
 	w.Flush()
 	fmt.Println("Summary:")
-	fmt.Println(item.Summary)
+	fmt.Println(item.Details.Summary())
 
 	return nil
 }
@@ -184,7 +184,7 @@ func worklogResolve(ctx *cli.Context) error {
 		if item.Type() == apitypes.InviteApproveWorklogType {
 			w.Flush()
 
-			err = AskPerform("Approve invite for " + item.Subject)
+			err = AskPerform("Approve invite for " + item.Subject())
 			switch err {
 			case nil:
 			case promptui.ErrAbort:

--- a/daemon/logic/credential_graph_set_test.go
+++ b/daemon/logic/credential_graph_set_test.go
@@ -92,6 +92,7 @@ func buildGraphWithRevocation(rawPathExp string, version int, secrets ...cred) r
 	cg.(*registry.CredentialGraphV2).Claims = []envelope.KeyringMemberClaim{
 		{Body: &primitive.KeyringMemberClaim{
 			ClaimType: primitive.RevocationClaimType,
+			OwnerID:   &identity.ID{0x00, 0x01},
 		}},
 	}
 
@@ -648,7 +649,7 @@ func TestCredentialGraphSetNeedRotation(t *testing.T) {
 			t.Fatal("Wrong number of credentials needing revision found")
 		}
 
-		if out[0].GetID() != id2 {
+		if out[0].Credential.GetID() != id2 {
 			t.Error("Wrong credential needing revision returned")
 		}
 	})

--- a/daemon/logic/worklog.go
+++ b/daemon/logic/worklog.go
@@ -164,7 +164,8 @@ func (h *secretRotateHandler) list(ctx context.Context, org *envelope.Org) ([]ap
 	}
 
 	var items []apitypes.WorklogItem
-	for _, cred := range needRotation {
+	for _, reason := range needRotation {
+		cred := reason.Credential
 		item := apitypes.WorklogItem{
 			Subject: cred.PathExp().String() + "/" + cred.Name(),
 			Summary: "A user's access was revoked. This secret's value should be changed.",

--- a/daemon/logic/worklog.go
+++ b/daemon/logic/worklog.go
@@ -165,10 +165,33 @@ func (h *secretRotateHandler) list(ctx context.Context, org *envelope.Org) ([]ap
 
 	var items []apitypes.WorklogItem
 	for _, reason := range needRotation {
+		var ids []identity.ID
+		claimsByOwner := make(map[identity.ID]primitive.KeyringMemberClaim, len(reason.Reasons))
+		for _, r := range reason.Reasons {
+			ids = append(ids, *r.OwnerID)
+			claimsByOwner[*r.OwnerID] = r
+		}
+
+		users, err := h.engine.client.Profiles.ListByID(ctx, ids)
+		if err != nil {
+			return nil, err
+		}
+
+		var reasons []apitypes.SecretRotateWorklogReason
+		for _, user := range users {
+			reasons = append(reasons, apitypes.SecretRotateWorklogReason{
+				Username: user.Body.Username,
+				Type:     claimsByOwner[*user.ID].Reason.Type,
+			})
+		}
+
 		cred := reason.Credential
 		item := apitypes.WorklogItem{
-			Subject: cred.PathExp().String() + "/" + cred.Name(),
-			Summary: "A user's access was revoked. This secret's value should be changed.",
+			Details: &apitypes.SecretRotateWorklogDetails{
+				PathExp: cred.PathExp(),
+				Name:    cred.Name(),
+				Reasons: reasons,
+			},
 		}
 		item.CreateID(apitypes.SecretRotateWorklogType)
 
@@ -180,10 +203,11 @@ func (h *secretRotateHandler) list(ctx context.Context, org *envelope.Org) ([]ap
 
 func (h *secretRotateHandler) resolve(ctx context.Context, n *observer.Notifier,
 	orgID *identity.ID, item *apitypes.WorklogItem) (*apitypes.WorklogResult, error) {
+
 	return &apitypes.WorklogResult{
 		ID:      item.ID,
 		State:   apitypes.ManualWorklogResult,
-		Message: "Please set a new value for the secret at " + item.Subject,
+		Message: "Please set a new value for the secret at " + item.Subject(),
 	}, nil
 }
 
@@ -204,17 +228,12 @@ func (h *missingKeypairsHandler) list(ctx context.Context, org *envelope.Org) ([
 	var items []apitypes.WorklogItem
 	if encClaimed == nil || sigClaimed == nil {
 		item := apitypes.WorklogItem{
-			Subject: org.Body.Name,
-			Summary: "Signing and encryption keypairs missing for org %s.",
+			Details: &apitypes.MissingKeypairsWorklogDetails{
+				Org:               org.Body.Name,
+				EncryptionMissing: encClaimed == nil,
+				SigningMissing:    sigClaimed == nil,
+			},
 		}
-
-		if encClaimed != nil {
-			item.Summary = "Signing keypair missing for org %s."
-		} else if sigClaimed != nil {
-			item.Summary = "Encryption keypair missing for org %s."
-		}
-
-		item.Summary = fmt.Sprintf(item.Summary, org.Body.Name)
 
 		item.CreateID(apitypes.MissingKeypairsWorklogType)
 
@@ -258,14 +277,37 @@ func (h *inviteApproveHandler) list(ctx context.Context, org *envelope.Org) ([]a
 		return nil, err
 	}
 
+	teams, err := h.engine.client.Teams.List(ctx, org.ID, "", primitive.AnyTeamType)
+	if err != nil {
+		return nil, err
+	}
+
+	teamsByID := make(map[identity.ID]string)
+	for _, t := range teams {
+		teamsByID[*t.ID] = t.Body.Name
+	}
+
 	var items []apitypes.WorklogItem
 	for _, invite := range invites {
-		summary := fmt.Sprintf("The invite for %s to org %s is ready for approval.",
-			invite.Body.Email, org.Body.Name)
+		users, err := h.engine.client.Profiles.ListByID(ctx, []identity.ID{*invite.Body.InviteeID})
+		if err != nil {
+			return nil, err
+		}
+
+		var teamNames []string
+		for _, t := range invite.Body.PendingTeams {
+			teamNames = append(teamNames, teamsByID[t])
+		}
+
 		item := apitypes.WorklogItem{
-			Subject:   invite.Body.Email,
-			Summary:   summary,
-			SubjectID: invite.ID,
+			Details: &apitypes.InviteApproveWorklogDetails{
+				InviteID: invite.ID,
+				Email:    invite.Body.Email,
+				Username: users[0].Body.Username,
+				Name:     users[0].Body.Name,
+				Org:      org.Body.Name,
+				Teams:    teamNames,
+			},
 		}
 		item.CreateID(apitypes.InviteApproveWorklogType)
 
@@ -277,7 +319,7 @@ func (h *inviteApproveHandler) list(ctx context.Context, org *envelope.Org) ([]a
 
 func (h *inviteApproveHandler) resolve(ctx context.Context, n *observer.Notifier,
 	orgID *identity.ID, item *apitypes.WorklogItem) (*apitypes.WorklogResult, error) {
-	_, err := h.engine.ApproveInvite(ctx, n, item.SubjectID)
+	_, err := h.engine.ApproveInvite(ctx, n, item.Details.(*apitypes.InviteApproveWorklogDetails).InviteID)
 	if err != nil {
 		return nil, err
 	}
@@ -353,6 +395,7 @@ func (h *keyringMembersHandler) list(ctx context.Context, org *envelope.Org) ([]
 
 	missing := make(map[string]apitypes.WorklogItem)
 	for _, graph := range graphs {
+	MembersLoop:
 		for _, member := range members {
 			for _, owner := range member.KeyOwnerIDs() {
 				m, _, err := graph.FindMember(&owner)
@@ -397,15 +440,27 @@ func (h *keyringMembersHandler) list(ctx context.Context, org *envelope.Org) ([]
 
 				if _, ok := missing[name]; !ok {
 					item := apitypes.WorklogItem{
-						Subject:   name,
-						Summary:   fmt.Sprintf("This %s is missing access to one or more secrets.", typ),
-						SubjectID: member.GetID(),
+						Details: &apitypes.KeyringMembersWorklogDetails{
+							EntityID: member.GetID(),
+							Name:     name,
+							Type:     typ,
+							OwnerIDs: member.KeyOwnerIDs(),
+						},
 					}
 					item.CreateID(apitypes.KeyringMembersWorklogType)
 					missing[name] = item
 				}
+				d := missing[name].Details.(*apitypes.KeyringMembersWorklogDetails)
 
-				break
+				path := *graph.GetKeyring().PathExp()
+				for _, o := range d.Keyrings {
+					if o.Equal(&path) {
+						continue MembersLoop
+					}
+				}
+				d.Keyrings = append(d.Keyrings, path)
+
+				continue MembersLoop
 			}
 		}
 	}
@@ -440,22 +495,10 @@ func (h *keyringMembersHandler) resolve(ctx context.Context, n *observer.Notifie
 		return nil, err
 	}
 
-	// Get all keyrings and find the active ones. We can then add the user to
-	// the ones they're missing from.
 	cgs := newCredentialGraphSet()
-	paths := make(map[string]*pathexp.PathExp)
-	keyrings, err := h.engine.client.Keyring.List(ctx, orgID, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, k := range keyrings {
-		path := k.GetKeyring().PathExp()
-		paths[path.String()] = path
-	}
-
-	for _, pe := range paths {
-		graphs, err := h.engine.client.CredentialGraph.List(ctx, "", pe, nil)
+	details := item.Details.(*apitypes.KeyringMembersWorklogDetails)
+	for _, pe := range details.Keyrings {
+		graphs, err := h.engine.client.CredentialGraph.List(ctx, "", &pe, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -471,28 +514,8 @@ func (h *keyringMembersHandler) resolve(ctx context.Context, n *observer.Notifie
 		return nil, err
 	}
 
-	// XXX replace this with rich structured data on the worklog item
-	var typ string
-	var ownerIDs []identity.ID
-	if item.SubjectID.Type() == (&primitive.User{}).Type() {
-		ownerIDs = append(ownerIDs, *item.SubjectID)
-		typ = "User"
-	} else {
-		segment, err := h.engine.client.Machines.Get(ctx, item.SubjectID)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, token := range segment.Tokens {
-			if token.Token.Body.State == primitive.MachineTokenActiveState {
-				ownerIDs = append(ownerIDs, *token.Token.ID)
-			}
-		}
-		typ = "Machine"
-	}
-
 	for _, graph := range graphs {
-		for _, ownerID := range ownerIDs {
+		for _, ownerID := range details.OwnerIDs {
 			// See if the user/machine token in question is in this keyring
 			m, _, err := graph.FindMember(&ownerID)
 			if err != nil && err != registry.ErrMemberNotFound {
@@ -510,6 +533,7 @@ func (h *keyringMembersHandler) resolve(ctx context.Context, n *observer.Notifie
 			// post the result. Now the user/machine token is a member!
 
 			krm, mekshare, err := graph.FindMember(h.engine.session.AuthID())
+
 			if err != nil {
 				return nil, err
 			}
@@ -518,7 +542,6 @@ func (h *keyringMembersHandler) resolve(ctx context.Context, n *observer.Notifie
 			if err != nil {
 				return nil, err
 			}
-
 			targetPubKey, err := findEncryptionPublicKey(claimTrees, orgID, &ownerID)
 			if err != nil {
 				return nil, err
@@ -564,6 +587,11 @@ func (h *keyringMembersHandler) resolve(ctx context.Context, n *observer.Notifie
 				}
 			}
 		}
+	}
+
+	typ := "User"
+	if details.Type == "machine" {
+		typ = "Machine"
 	}
 
 	return &apitypes.WorklogResult{

--- a/registry/keyring.go
+++ b/registry/keyring.go
@@ -28,6 +28,7 @@ type KeyringSection interface {
 	KeyringVersion() int
 	FindMember(*identity.ID) (*primitive.KeyringMember, *primitive.MEKShare, error)
 	HasRevocations() bool
+	GetClaims() []envelope.KeyringMemberClaim
 }
 
 // KeyringSectionV1 represents a section of the CredentialGraph only pertaining to
@@ -80,6 +81,12 @@ func (k *KeyringSectionV1) FindMember(id *identity.ID) (*primitive.KeyringMember
 // track in V1 so it is always false.
 func (KeyringSectionV1) HasRevocations() bool {
 	return false
+}
+
+// GetClaims returns the Member claims for this keyring. These don't exist in V1
+// so it is always an empty list.
+func (KeyringSectionV1) GetClaims() []envelope.KeyringMemberClaim {
+	return nil
 }
 
 // KeyringSectionV2 represents a Keyring and its members.
@@ -147,6 +154,11 @@ func (k *KeyringSectionV2) HasRevocations() bool {
 		}
 	}
 	return false
+}
+
+// GetClaims returns the list of Member claims for this keyring.
+func (k *KeyringSectionV2) GetClaims() []envelope.KeyringMemberClaim {
+	return k.Claims
 }
 
 // KeyringMember holds membership information for v2 keyrings. In v2, a user


### PR DESCRIPTION
Populate rich worklog details

For each worklog item type, attach a Details struct containing type
specifid information (such as teams pending for an invite, etc).

Use some of this data for generating the item subject and summary string
in the cli, rather than the daemon.

This data will be used for presenting extra data in the worklog, and
formatting it in a most joyful manner.