### PR TITLE
The great worklog ui revamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ _Unreleased_
 - Torus now checks for available updates to itself, and reports on them during
   the `login` and `version` commands. This behaviour can be disabled with
   `torus prefs set core.check_updates false`.
+- Exciting new worklog ui:
+  - Items are grouped by type, making the display more compact and usable.
+  - Lots of color and formatting!
+  - Each worklog item includes details visible with `view`. For example, secret
+    rotation items include which users caused the need for rotation, and why
+    (i.e. 'james was removed from the org.').
 
 **Thanks**
 

--- a/api/worklog.go
+++ b/api/worklog.go
@@ -87,7 +87,9 @@ func (w *rawWorklogItem) setDetails() error {
 		w.WorklogItem.Details = &apitypes.MissingKeypairsWorklogDetails{}
 	case apitypes.InviteApproveWorklogType:
 		w.WorklogItem.Details = &apitypes.InviteApproveWorklogDetails{}
-	case apitypes.KeyringMembersWorklogType:
+	case apitypes.UserKeyringMembersWorklogType:
+		fallthrough
+	case apitypes.MachineKeyringMembersWorklogType:
 		w.WorklogItem.Details = &apitypes.KeyringMembersWorklogDetails{}
 	default:
 		return errUnknownWorklogType

--- a/api/worklog.go
+++ b/api/worklog.go
@@ -55,10 +55,8 @@ func (w *WorklogClient) Get(ctx context.Context, orgID *identity.ID, ident *apit
 }
 
 // Resolve resolves the worklog item with the given id in the given org.
-func (w *WorklogClient) Resolve(ctx context.Context, orgID *identity.ID, ident *apitypes.WorklogID) (*apitypes.WorklogResult, error) {
-	var res apitypes.WorklogResult
-	err := w.singleItemWorker(ctx, "POST", orgID, ident, &res)
-	return &res, err
+func (w *WorklogClient) Resolve(ctx context.Context, orgID *identity.ID, ident *apitypes.WorklogID) error {
+	return w.singleItemWorker(ctx, "POST", orgID, ident, nil)
 }
 
 func (w *WorklogClient) singleItemWorker(ctx context.Context, verb string, orgID *identity.ID, ident *apitypes.WorklogID, res interface{}) error {

--- a/apitypes/worklog.go
+++ b/apitypes/worklog.go
@@ -26,17 +26,6 @@ const (
 	AnyWorklogType WorklogType = 0xff
 )
 
-// WorklogResultType is the string type of worklog results
-type WorklogResultType string
-
-// WorklogResult result states.
-const (
-	SuccessWorklogResult WorklogResultType = "success"
-	FailureWorklogResult WorklogResultType = "failure"
-	ErrorWorklogResult   WorklogResultType = "error"
-	ManualWorklogResult  WorklogResultType = "manual"
-)
-
 // ErrIncorrectWorklogIDLen is returned when a base32 encoded worklog id is the
 // wrong length.
 var ErrIncorrectWorklogIDLen = errors.New("Incorrect worklog ID length")
@@ -228,12 +217,4 @@ func (w *WorklogItem) CreateID(worklogType WorklogType) {
 	id := WorklogID{byte(worklogType)}
 	copy(id[1:], h.Sum(nil))
 	w.ID = &id
-}
-
-// WorklogResult is the result, either positive or negative, of attempting to
-// resolve a WorklogItem
-type WorklogResult struct {
-	ID      *WorklogID        `json:"id"`
-	State   WorklogResultType `json:"state"`
-	Message string            `json:"message"`
 }

--- a/apitypes/worklog.go
+++ b/apitypes/worklog.go
@@ -20,7 +20,8 @@ const (
 	SecretRotateWorklogType WorklogType = 1 << iota
 	MissingKeypairsWorklogType
 	InviteApproveWorklogType
-	KeyringMembersWorklogType
+	UserKeyringMembersWorklogType
+	MachineKeyringMembersWorklogType
 
 	AnyWorklogType WorklogType = 0xff
 )
@@ -204,7 +205,9 @@ func (t WorklogType) String() string {
 		return "keypairs"
 	case InviteApproveWorklogType:
 		return "invite"
-	case KeyringMembersWorklogType:
+	case UserKeyringMembersWorklogType:
+		fallthrough
+	case MachineKeyringMembersWorklogType:
 		return "keyring"
 	default:
 		return "n/a"

--- a/apitypes/worklog.go
+++ b/apitypes/worklog.go
@@ -208,7 +208,7 @@ func (t WorklogType) String() string {
 	case UserKeyringMembersWorklogType:
 		fallthrough
 	case MachineKeyringMembersWorklogType:
-		return "keyring"
+		return "secret"
 	default:
 		return "n/a"
 	}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -102,7 +102,7 @@ func profileEdit(ctx *cli.Context) error {
 	}
 
 	var newPassword string
-	err = AskPerform("Would you like to change your password")
+	err = AskPerform("Would you like to change your password", "")
 	if err == nil {
 		password, err := changePassword(&c, client, session)
 		if err != nil {

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -41,7 +41,7 @@ func validateInviteCode(input string) error {
 }
 
 // AskPerform prompts the user if they want to do a specified action
-func AskPerform(label string) error {
+func AskPerform(label, indent string) error {
 	preferences, err := prefs.NewPreferences()
 	if err != nil {
 		return err
@@ -50,6 +50,7 @@ func AskPerform(label string) error {
 		Label:     label,
 		IsConfirm: true,
 		Preamble:  nil,
+		Indent:    indent,
 		IsVimMode: preferences.Core.Vim,
 	}
 	_, err = prompt.Run()

--- a/cmd/worklog.go
+++ b/cmd/worklog.go
@@ -184,7 +184,7 @@ func worklogResolve(ctx *cli.Context) error {
 		if item.Type() == apitypes.InviteApproveWorklogType {
 			w.Flush()
 
-			err = AskPerform("Approve invite for " + item.Subject())
+			err = AskPerform("Approve invite for "+item.Subject(), "")
 			switch err {
 			case nil:
 			case promptui.ErrAbort:

--- a/cmd/worklog.go
+++ b/cmd/worklog.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/urfave/cli"
@@ -324,10 +323,7 @@ func worklogResolve(ctx *cli.Context) error {
 				continue
 			}
 
-			res, err := client.Worklog.Resolve(c, org.ID, item.ID)
-			if err == nil && res.State != apitypes.SuccessWorklogResult {
-				err = errors.New(res.Message)
-			}
+			err := client.Worklog.Resolve(c, org.ID, item.ID)
 			displayResult(&item, err, grouped)
 		}
 	}

--- a/daemon/routes/worklog.go
+++ b/daemon/routes/worklog.go
@@ -99,22 +99,9 @@ func worklogResolveRoute(engine *logic.Engine, o *observer.Observer) http.Handle
 			return
 		}
 
-		res, err := engine.Worklog.Resolve(ctx, n, &orgID, &ident)
+		err = engine.Worklog.Resolve(ctx, n, &orgID, &ident)
 		if err != nil {
 			log.Printf("error resolving worklog item: %s", err)
-			encodeResponseErr(w, err)
-			return
-		}
-
-		if res == nil {
-			encodeResponseErr(w, notFoundError)
-			return
-		}
-
-		enc := json.NewEncoder(w)
-		err = enc.Encode(res)
-		if err != nil {
-			log.Printf("error encoding worklog resolve resp: %s", err)
 			encodeResponseErr(w, err)
 			return
 		}

--- a/promptui/codes.go
+++ b/promptui/codes.go
@@ -10,27 +10,32 @@ const esc = "\033["
 
 type attribute int
 
+// Forground weight/decoration attributes.
 const (
 	reset attribute = iota
-	fgBold
-	fgFaint
-	_ // fgItalic
-	fgUnderline
+
+	FGBold
+	FGFaint
+	FGItalic
+	FGUnderline
 )
 
+// Forground color attributes
 const (
-	_ attribute = iota + 30 // fgBlack
-	fgRed
-	fgGreen
-	fgYellow
-	fgBlue
-	_ // fgMagenta
-	_ // fgCyan
-	_ // fgWhite
+	FGBlack attribute = iota + 30
+	FGRed
+	FGGreen
+	FGYellow
+	FGBlue
+	FGMagenta
+	FGCyan
+	FGWhite
 )
+
+// ResetCode is the character code used to reset the terminal formatting
+var ResetCode = fmt.Sprintf("%s%dm", esc, reset)
 
 var (
-	resetCode  = fmt.Sprintf("%s%dm", esc, reset)
 	hideCursor = esc + "?25l"
 	showCursor = esc + "?25h"
 	clearLine  = esc + "2K"
@@ -48,7 +53,9 @@ func movementCode(n uint, code rune) string {
 	return esc + strconv.FormatUint(uint64(n), 10) + string(code)
 }
 
-func styler(attrs ...attribute) func(string) string {
+// Styler returns a func that applies the attributes given in the Styler call
+// to the provided string.
+func Styler(attrs ...attribute) func(string) string {
 	attrstrs := make([]string, len(attrs))
 	for i, v := range attrs {
 		attrstrs[i] = strconv.Itoa(int(v))
@@ -58,8 +65,8 @@ func styler(attrs ...attribute) func(string) string {
 
 	return func(s string) string {
 		end := ""
-		if !strings.HasSuffix(s, resetCode) {
-			end = resetCode
+		if !strings.HasSuffix(s, ResetCode) {
+			end = ResetCode
 		}
 		return fmt.Sprintf("%s%sm%s%s", esc, seq, s, end)
 	}

--- a/promptui/codes_test.go
+++ b/promptui/codes_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestStyler(t *testing.T) {
 	t.Run("renders a single code", func(t *testing.T) {
-		red := styler(fgRed)("hi")
+		red := Styler(FGRed)("hi")
 		expected := "\033[31mhi\033[0m"
 		if red != expected {
 			t.Errorf("style did not match: %s != %s", red, expected)
@@ -12,7 +12,7 @@ func TestStyler(t *testing.T) {
 	})
 
 	t.Run("combines multiple codes", func(t *testing.T) {
-		boldRed := styler(fgRed, fgBold)("hi")
+		boldRed := Styler(FGRed, FGBold)("hi")
 		expected := "\033[31;1mhi\033[0m"
 		if boldRed != expected {
 			t.Errorf("style did not match: %s != %s", boldRed, expected)
@@ -21,8 +21,8 @@ func TestStyler(t *testing.T) {
 	})
 
 	t.Run("should not repeat reset codes for nested styles", func(t *testing.T) {
-		red := styler(fgRed)("hi")
-		boldRed := styler(fgBold)(red)
+		red := Styler(FGRed)("hi")
+		boldRed := Styler(FGBold)(red)
 		expected := "\033[1m\033[31mhi\033[0m"
 		if boldRed != expected {
 			t.Errorf("style did not match: %s != %s", boldRed, expected)

--- a/promptui/prompt.go
+++ b/promptui/prompt.go
@@ -73,7 +73,7 @@ func (p *Prompt) Run() (string, error) {
 		p.Default = ""
 	}
 
-	state := iconInitial
+	state := IconInitial
 	prompt := p.Label + punctuation + suggestedAnswer + " "
 
 	c.Prompt = bold(state) + " " + bold(prompt)
@@ -126,15 +126,15 @@ func (p *Prompt) Run() (string, error) {
 		err := validFn(string(line))
 		if err != nil {
 			if _, ok := err.(*ValidationError); ok {
-				state = iconBad
+				state = IconBad
 			} else {
 				rl.Close()
 				return nil, 0, false
 			}
 		} else {
-			state = iconGood
+			state = IconGood
 			if p.IsConfirm {
-				state = iconInitial
+				state = IconInitial
 			}
 		}
 
@@ -155,14 +155,14 @@ func (p *Prompt) Run() (string, error) {
 			if verr, ok := oerr.(*ValidationError); ok {
 				msg = verr.msg
 				valid = false
-				state = iconBad
+				state = IconBad
 			} else {
 				return "", oerr
 			}
 		}
 
 		if valid {
-			state = iconGood
+			state = IconGood
 			break
 		}
 
@@ -207,10 +207,10 @@ func (p *Prompt) Run() (string, error) {
 
 	if p.IsConfirm {
 		if strings.ToLower(echo) != "y" {
-			state = iconBad
+			state = IconBad
 			err = ErrAbort
 		} else {
-			state = iconGood
+			state = IconGood
 		}
 	}
 

--- a/promptui/prompt.go
+++ b/promptui/prompt.go
@@ -28,6 +28,9 @@ type Prompt struct {
 	IsVimMode bool
 	Preamble  *string
 
+	// Indent will be placed before the prompt's state symbol
+	Indent string
+
 	stdin  io.Reader
 	stdout io.Writer
 }
@@ -76,7 +79,7 @@ func (p *Prompt) Run() (string, error) {
 	state := IconInitial
 	prompt := p.Label + punctuation + suggestedAnswer + " "
 
-	c.Prompt = bold(state) + " " + bold(prompt)
+	c.Prompt = p.Indent + bold(state) + " " + bold(prompt)
 	c.HistoryLimit = -1
 	c.UniqueEditLine = true
 
@@ -138,7 +141,7 @@ func (p *Prompt) Run() (string, error) {
 			}
 		}
 
-		rl.SetPrompt(bold(state) + " " + bold(prompt))
+		rl.SetPrompt(p.Indent + bold(state) + " " + bold(prompt))
 		rl.Refresh()
 		wroteErr = false
 
@@ -184,7 +187,7 @@ func (p *Prompt) Run() (string, error) {
 
 		firstListen = true
 		wroteErr = true
-		rl.SetPrompt("\n" + red(">> ") + msg + upLine(1) + "\r" + bold(state) + " " + bold(prompt))
+		rl.SetPrompt("\n" + red(">> ") + msg + upLine(1) + "\r" + p.Indent + bold(state) + " " + bold(prompt))
 		rl.Refresh()
 	}
 
@@ -214,7 +217,7 @@ func (p *Prompt) Run() (string, error) {
 		}
 	}
 
-	rl.Write([]byte(state + " " + prompt + faint(echo) + "\n"))
+	rl.Write([]byte(p.Indent + state + " " + prompt + faint(echo) + "\n"))
 
 	return out, err
 }

--- a/promptui/promptui.go
+++ b/promptui/promptui.go
@@ -35,10 +35,10 @@ func NewValidationError(msg string) *ValidationError {
 
 // SuccessfulValue returns a value as if it were entered via prompt, valid
 func SuccessfulValue(label, value string) string {
-	return iconGood + " " + label + ": " + faint(value)
+	return IconGood + " " + label + ": " + faint(value)
 }
 
 // FailedValue returns a value as if it were entered via prompt, invalid
 func FailedValue(label, value string) string {
-	return iconBad + " " + label + ": " + faint(value)
+	return IconBad + " " + label + ": " + faint(value)
 }

--- a/promptui/select.go
+++ b/promptui/select.go
@@ -127,7 +127,7 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 
 		prefix := ""
 		prefix += upLine(uint(len(list))) + "\r" + clearLine
-		p := prefix + bold(iconInitial) + " " + bold(prompt) + downLine(1) + strings.Join(list, downLine(1))
+		p := prefix + bold(IconInitial) + " " + bold(prompt) + downLine(1) + strings.Join(list, downLine(1))
 		rl.SetPrompt(p)
 		rl.Refresh()
 
@@ -157,7 +157,7 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 	rl.Write([]byte("\r"))
 
 	out := s.Items[selected]
-	rl.Write([]byte(iconGood + " " + prompt + faint(out) + "\n"))
+	rl.Write([]byte(IconGood + " " + prompt + faint(out) + "\n"))
 
 	rl.Write([]byte(showCursor))
 	return selected, out, err

--- a/promptui/styles.go
+++ b/promptui/styles.go
@@ -1,16 +1,17 @@
 package promptui
 
 var (
-	bold       = styler(fgBold)
-	faint      = styler(fgFaint)
-	underlined = styler(fgUnderline)
+	bold       = Styler(FGBold)
+	faint      = Styler(FGFaint)
+	underlined = Styler(FGUnderline)
 )
 
+// Icons used for displaying prompts or status
 var (
-	iconInitial = styler(fgBlue)("?")
-	iconGood    = styler(fgGreen)("✔")
-	_           = styler(fgYellow)("⚠") // iconWarn
-	iconBad     = styler(fgRed)("✗")
+	IconInitial = Styler(FGBlue)("?")
+	IconGood    = Styler(FGGreen)("✔")
+	IconWarn    = Styler(FGYellow)("⚠")
+	IconBad     = Styler(FGRed)("✗")
 )
 
-var red = styler(fgBold, fgRed)
+var red = Styler(FGBold, FGRed)


### PR DESCRIPTION
Final changes needed for our new worklog ui (except line wrapping ;) )

The bulk of this is just the rewrite of `cmd/worklog.go`, but there are a few secondary bits too:
- minor changes to `ui` and `promptui`
- split out user vs machine keyring rotation types
- remove the worklog result type (using details and error results instead).