### PR TITLE
Remove config dependency from logic engine

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -72,7 +72,7 @@ func New(cfg *config.Config, groupShared bool) (*Daemon, error) {
 	transport := socket.CreateHTTPTransport(cfg)
 	client := registry.NewClient(cfg.RegistryURI.String(), cfg.APIVersion,
 		cfg.Version, session, transport)
-	logic := logic.NewEngine(cfg, session, db, cryptoEngine, client)
+	logic := logic.NewEngine(session, db, cryptoEngine, client)
 	updates := updates.NewEngine(cfg)
 
 	proxy, err := socket.NewAuthProxy(cfg, session, db, transport, client, logic, updates, groupShared)

--- a/daemon/logic/engine.go
+++ b/daemon/logic/engine.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/base64"
-	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/envelope"
 	"github.com/manifoldco/torus-cli/identity"
 	"github.com/manifoldco/torus-cli/primitive"
@@ -27,7 +26,6 @@ import (
 // All data passing in and out of the engine is unencrypted for the currently
 // logged in user.
 type Engine struct {
-	config  *config.Config
 	session session.Session
 	db      *db.DB
 	crypto  *crypto.Engine
@@ -39,10 +37,9 @@ type Engine struct {
 }
 
 // NewEngine returns a new Engine
-func NewEngine(c *config.Config, s session.Session, db *db.DB, e *crypto.Engine,
+func NewEngine(s session.Session, db *db.DB, e *crypto.Engine,
 	client *registry.Client) *Engine {
 	engine := &Engine{
-		config:  c,
 		session: s,
 		db:      db,
 		crypto:  e,

--- a/daemon/logic/engine.go
+++ b/daemon/logic/engine.go
@@ -15,7 +15,6 @@ import (
 	"github.com/manifoldco/torus-cli/registry"
 
 	"github.com/manifoldco/torus-cli/daemon/crypto"
-	"github.com/manifoldco/torus-cli/daemon/db"
 	"github.com/manifoldco/torus-cli/daemon/observer"
 	"github.com/manifoldco/torus-cli/daemon/session"
 )
@@ -27,7 +26,7 @@ import (
 // logged in user.
 type Engine struct {
 	session session.Session
-	db      *db.DB
+	db      Database
 	crypto  *crypto.Engine
 	client  *registry.Client
 
@@ -36,8 +35,13 @@ type Engine struct {
 	Session Session
 }
 
+// Database interface for logic engine
+type Database interface {
+	Set(envs ...envelope.Envelope) error
+}
+
 // NewEngine returns a new Engine
-func NewEngine(s session.Session, db *db.DB, e *crypto.Engine,
+func NewEngine(s session.Session, db Database, e *crypto.Engine,
 	client *registry.Client) *Engine {
 	engine := &Engine{
 		session: s,


### PR DESCRIPTION
For the browser client we need to remove the dependency on config so that prefs is not included (gopher js does not support any system related calls).

Also adds a database interface to remove the boltdb dependency which is not used.