### PR TITLE
Fix padding addition for base32 when divisible by 8

### DIFF
--- a/base32/base32.go
+++ b/base32/base32.go
@@ -19,10 +19,13 @@ func EncodeToString(in []byte) string {
 // DecodeString decodes the given base32 encodeed bytes
 func DecodeString(raw string) ([]byte, error) {
 	pad := 8 - (len(raw) % 8)
-	nb := make([]byte, len(raw)+pad)
-	copy(nb, raw)
-	for i := 0; i < pad; i++ {
-		nb[len(raw)+i] = '='
+	nb := []byte(raw)
+	if pad != 8 {
+		nb = make([]byte, len(raw)+pad)
+		copy(nb, raw)
+		for i := 0; i < pad; i++ {
+			nb[len(raw)+i] = '='
+		}
 	}
 
 	return lowerBase32.DecodeString(string(nb))

--- a/base32/base32_test.go
+++ b/base32/base32_test.go
@@ -1,0 +1,59 @@
+package base32
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	t.Run("uses the correct alphabet", func(t *testing.T) {
+		o := EncodeToString([]byte{0x1A, 0xA5, 0x00, 0x00, 0x00})
+
+		expected := "3ajg0000"
+		if o != expected {
+			t.Error("Bad encoding. wanted:", expected, "got:", o)
+		}
+	})
+
+	t.Run("does not include = padding", func(t *testing.T) {
+		o := EncodeToString([]byte{0x1A, 0xA5})
+
+		expected := "3ajg"
+		if o != expected {
+			t.Error("Bad encoding. wanted:", expected, "got:", o)
+		}
+	})
+}
+
+func TestDecode(t *testing.T) {
+	t.Run("can decode a value", func(t *testing.T) {
+		o, err := DecodeString("3ajg0000")
+		if err != nil {
+			t.Fatal("unexpected error decoding:", err)
+		}
+
+		expected := []byte{0x1A, 0xA5, 0x00, 0x00, 0x00}
+		if !bytes.Equal(o, expected) {
+			t.Error("Bad decoding. wanted:", expected, "got:", o)
+		}
+	})
+
+	t.Run("handles values that should be padded", func(t *testing.T) {
+		o, err := DecodeString("3ajg")
+		if err != nil {
+			t.Fatal("unexpected error decoding:", err)
+		}
+
+		expected := []byte{0x1A, 0xA5}
+		if !bytes.Equal(o, expected) {
+			t.Error("Bad decoding. wanted:", expected, "got:", o)
+		}
+	})
+
+	t.Run("errors on an invalid alphabet character", func(t *testing.T) {
+		_, err := DecodeString("3aig0000")
+		if err == nil {
+			t.Fatal("Decoding did not error when it should have!")
+		}
+	})
+}


### PR DESCRIPTION
We should add no padding, not full padding.