### PR TITLE
Transport timeouts.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/donovanhide/eventsource"
 	"github.com/satori/go.uuid"
@@ -14,7 +15,10 @@ import (
 	"github.com/manifoldco/torus-cli/registry"
 )
 
-const daemonAPIVersion = "v1"
+const (
+	daemonAPIVersion = "v1"
+	dialTimeout      = time.Second
+)
 
 type blacklisted struct{}
 

--- a/api/client.go
+++ b/api/client.go
@@ -55,7 +55,7 @@ func NewClient(cfg *config.Config) *Client {
 		DefaultRequestDoer: registry.DefaultRequestDoer{
 			Client: &http.Client{
 				Transport: newTransport(cfg),
-				Timeout:   30 * time.Second,
+				Timeout:   time.Minute,
 			},
 			Host: "http://localhost",
 		},

--- a/api/client.go
+++ b/api/client.go
@@ -55,6 +55,7 @@ func NewClient(cfg *config.Config) *Client {
 		DefaultRequestDoer: registry.DefaultRequestDoer{
 			Client: &http.Client{
 				Transport: newTransport(cfg),
+				Timeout:   30 * time.Second,
 			},
 			Host: "http://localhost",
 		},

--- a/api/transport.go
+++ b/api/transport.go
@@ -12,7 +12,7 @@ import (
 func newTransport(cfg *config.Config) *http.Transport {
 	return &http.Transport{
 		Dial: func(network, address string) (net.Conn, error) {
-			return net.Dial("unix", cfg.TransportAddress)
+			return net.DialTimeout("unix", cfg.TransportAddress, dialTimeout)
 		},
 	}
 }

--- a/api/transport_windows.go
+++ b/api/transport_windows.go
@@ -11,7 +11,7 @@ import (
 func newTransport(cfg *config.Config) *http.Transport {
 	return &http.Transport{
 		Dial: func(network, address string) (net.Conn, error) {
-			return npipe.Dial(cfg.TransportAddress)
+			return npipe.DialTimeout(cfg.TransportAddress, dialTimeout)
 		},
 	}
 }

--- a/registry/client.go
+++ b/registry/client.go
@@ -46,8 +46,11 @@ func NewClient(prefix string, apiVersion string, version string,
 
 	rt := &registryRoundTripper{
 		DefaultRequestDoer: DefaultRequestDoer{
-			Client: &http.Client{Transport: t},
-			Host:   prefix,
+			Client: &http.Client{
+				Transport: t,
+				Timeout:   30 * time.Second,
+			},
+			Host: prefix,
 		},
 
 		apiVersion: apiVersion,

--- a/registry/client.go
+++ b/registry/client.go
@@ -48,7 +48,7 @@ func NewClient(prefix string, apiVersion string, version string,
 		DefaultRequestDoer: DefaultRequestDoer{
 			Client: &http.Client{
 				Transport: t,
-				Timeout:   30 * time.Second,
+				Timeout:   time.Minute,
 			},
 			Host: prefix,
 		},


### PR DESCRIPTION
This implements a patch to address issue #210.

I've set up a 1 second timeout for the Dial and a 30s timeout for actual requests.

@jbowes @ianlivingstone do you think 30s is good enough for actual requests or should we consider something else?

**Note:** this depends on #207 to be merged in. [This](https://github.com/jelmersnoeck/torus-cli/compare/jelmer/123-windows-support...jelmersnoeck:jelmer/210-transport-timeout?expand=1) is the actual diff whilst that one isn't merged in yet.

closes #210