### PR TITLE
Fix machine name check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ _Unreleased_
 **Fixes**
 
 - Correct the help message for `invites accept`'s org flag.
+- Fixed a problem where machine's with a name containing `machine-` (but as a
+  prefix) could not interact with credential.
 
 **Thanks**
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -183,7 +183,7 @@ func identityString(identityType, identity string) (string, error) {
 		return identity, nil
 	}
 
-	if strings.Contains(identity, "machine-") {
+	if strings.HasPrefix(identity, "machine-") {
 		return "", errs.NewExitError(
 			"Do not prepend 'machine-' when using --machine")
 	}


### PR DESCRIPTION
A naive "strings.Contains" was used instead of "HasPrefix" for checking
whether or not a machine identity was valid.

Closes manifoldco/torus-cli#222