### PR TITLE
Support `torus set KEY=value` syntax

### DIFF
--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import "testing"
+
+func TestParseArgs(t *testing.T) {
+	type tc struct {
+		args []string
+		key  string
+		val  string
+		err  string
+	}
+
+	testCases := []tc{
+		{args: []string{}, err: "name and value are required."},
+		{args: []string{"foo"}, err: "name and value are required."},
+		{args: []string{"foo", "bar", "baz"}, err: "Too many arguments provided."},
+		{args: []string{"foo", "bar"}, key: "foo", val: "bar"},
+		{args: []string{"foo=bar"}, key: "foo", val: "bar"},
+		{args: []string{"foo=bar=="}, key: "foo", val: "bar=="},
+		{
+			args: []string{"/org/project/env/service/user/instance/foo", "bar"},
+			key:  "/org/project/env/service/user/instance/foo",
+			val:  "bar",
+		},
+		{
+			args: []string{"/org/project/env/service/user/instance/foo=bar"},
+			key:  "/org/project/env/service/user/instance/foo",
+			val:  "bar",
+		},
+	}
+
+	for _, tc := range testCases {
+		key, val, err := parseSetArgs(tc.args)
+
+		if err != "" && tc.err == "" {
+			t.Errorf("parseArgs(%v) expected no errors, got %q", tc.args, err)
+		}
+
+		if tc.err != "" && err != tc.err {
+			t.Errorf("parseArgs(%v) expected error %q, got %q", tc.args, tc.err, err)
+		}
+
+		if key != tc.key || val != tc.val {
+			t.Errorf("parseArgs(%v) expected (%q,%q) pair, got (%q,%q)", tc.args,
+				tc.key, tc.val, key, val)
+		}
+	}
+}


### PR DESCRIPTION
Hey, my first instinct while use `torus set` is to use the export variable syntax `KEY=value` instead of `KEY value`. This PR allows that when only one argument is passed.

Some scenarios are described in the test cases. Let me know if there is something else that needs to be covered.

Closes https://github.com/manifoldco/torus-cli/issues/219