### PR TITLE
Generic listener co-proceeses

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -1,25 +1,9 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"os"
-	"os/signal"
-	"path"
-	"runtime"
-	"syscall"
-	"time"
-
-	"github.com/kardianos/osext"
-	"github.com/natefinch/lumberjack"
-	"github.com/nightlyone/lockfile"
 	"github.com/urfave/cli"
 
-	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/config"
-	"github.com/manifoldco/torus-cli/errs"
-
 	"github.com/manifoldco/torus-cli/daemon"
 )
 
@@ -76,25 +60,7 @@ func daemonStatus(ctx *cli.Context) error {
 		return err
 	}
 
-	proc, err := findDaemon(cfg)
-	if err != nil {
-		return err
-	}
-
-	if proc == nil {
-		fmt.Println("Daemon is not running.")
-		return nil
-	}
-
-	client := api.NewClient(cfg)
-	v, err := client.Version.GetDaemon(context.Background())
-	if err != nil {
-		return errs.NewErrorExitError("Error communicating with the daemon", err)
-	}
-
-	fmt.Printf("Daemon is running. pid: %d version: v%s\n", proc.Pid, v.Version)
-
-	return nil
+	return statusListenerCmd("Daemon", cfg.PidPath)
 }
 
 func spawnDaemonCmd() error {
@@ -103,105 +69,17 @@ func spawnDaemonCmd() error {
 		return err
 	}
 
-	proc, err := findDaemon(cfg)
-	if err != nil {
-		return err
-	}
-
-	if proc != nil {
-		fmt.Println("Daemon is already running.")
-		return nil
-	}
-
-	err = spawnDaemon()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Daemon started.")
-	return nil
-}
-
-func spawnDaemon() error {
-	executable, err := osext.Executable()
-	if err != nil {
-		return errs.NewErrorExitError("Unable to find executable.", err)
-	}
-
-	cmd := daemonCommand(executable)
-
-	// Clone the current env, removing email and password if they exist.
-	// no need to keep those hanging around in a long lived-process!
-	cmd.Env = filterEnv()
-
-	err = cmd.Start()
-	if err != nil {
-		return errs.NewErrorExitError("Unable to start daemon", err)
-	}
-
-	return nil
+	return spawnListenerCmd("Daemon", cfg.PidPath, daemonCommand)
 }
 
 func startDaemon(ctx *cli.Context) error {
-	noPermissionCheck := ctx.Bool("no-permission-check")
-	torusRoot, err := config.CreateTorusRoot(!noPermissionCheck)
-	if err != nil {
-		return errs.NewErrorExitError("Failed to initialize Torus root dir.", err)
-	}
-
-	if ctx.Bool("daemonize") {
-		log.SetOutput(&lumberjack.Logger{
-			Filename:   path.Join(torusRoot, "daemon.log"),
-			MaxSize:    10, // megabytes
-			MaxBackups: 3,
-			MaxAge:     28, // days
+	return startListenerCmd(
+		ctx,
+		"Daemon",
+		"daemon.log",
+		func(cfg *config.Config, noPermissionCheck bool) (Listener, error) {
+			return daemon.New(cfg, noPermissionCheck)
 		})
-	} else {
-		// re-enable logging, as by default its silenced for foreground use.
-		log.SetOutput(os.Stdout)
-	}
-
-	cfg, err := config.NewConfig(torusRoot)
-	if err != nil {
-		return errs.NewErrorExitError("Failed to load config.", err)
-	}
-
-	daemon, err := daemon.New(cfg, noPermissionCheck)
-	if err != nil {
-		return errs.NewErrorExitError("Failed to create daemon.", err)
-	}
-
-	go watch(daemon)
-	defer daemon.Shutdown()
-
-	log.Printf("v%s of the Daemon is now listening on %s", cfg.Version, daemon.Addr())
-	err = daemon.Run()
-	if err != nil {
-		log.Printf("Error while running daemon.\n%s", err)
-	}
-
-	return err
-}
-
-func watch(daemon *daemon.Daemon) {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-	s := <-c
-
-	log.Printf("Caught a signal: %s", s)
-	shutdown(daemon)
-}
-
-func shutdown(daemon *daemon.Daemon) {
-	err := daemon.Shutdown()
-	if err != nil {
-		log.Printf("Did not shutdown cleanly.\n%s", err)
-	}
-
-	if r := recover(); r != nil {
-		log.Printf("Failed shutting down; caught panic.\n%v", r)
-		panic(r)
-	}
 }
 
 func stopDaemonCmd(ctx *cli.Context) error {
@@ -210,90 +88,5 @@ func stopDaemonCmd(ctx *cli.Context) error {
 		return err
 	}
 
-	proc, err := findDaemon(cfg)
-	if err != nil {
-		return err
-	}
-
-	if proc == nil {
-		fmt.Println("Daemon is not running.")
-		return nil
-	}
-
-	graceful, err := stopDaemon(proc)
-	if err != nil {
-		return err
-	}
-
-	if graceful {
-		fmt.Println("Daemon stopped gracefully.")
-	} else {
-
-		fmt.Println("Daemon stopped forcefully.")
-	}
-
-	return nil
-}
-
-// stopDaemon stops the daemon process. It returns a bool indicating if the
-// shutdown was graceful.
-func stopDaemon(proc *os.Process) (bool, error) {
-	err := proc.Signal(syscall.Signal(syscall.SIGTERM))
-
-	if err == nil { // no need to wait for the SIGTERM if the signal failed
-		increment := 50 * time.Millisecond
-		for d := increment; d < 3*time.Second; d += increment {
-			time.Sleep(d)
-			if _, err := findProcess(proc.Pid); err != nil {
-				return true, nil
-			}
-		}
-	}
-
-	err = proc.Kill()
-	if err != nil {
-		return false, errs.NewErrorExitError("Could not stop daemon.", err)
-	}
-
-	return false, nil
-}
-
-// findDaemon returns an os.Process for a running daemon, or nil if it is not
-// running. It returns an error if the pid file location is invalid in the
-// config, or there was an error reading the pid file.
-func findDaemon(cfg *config.Config) (*os.Process, error) {
-	lock, err := lockfile.New(cfg.PidPath)
-	if err != nil {
-		return nil, err
-	}
-
-	proc, err := lock.GetOwner()
-	if err != nil {
-		// happy path cases. the pid doesn't exist, or it contains garbage,
-		// or the previous owner is gone.
-		if os.IsNotExist(err) || err == lockfile.ErrInvalidPid || err == lockfile.ErrDeadOwner {
-			return nil, nil
-		}
-
-		return nil, err
-	}
-
-	return proc, nil
-}
-
-func findProcess(pid int) (*os.Process, error) {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return nil, err
-	}
-
-	// On unix, findprocess does not error. So we have to check for the process.
-	if runtime.GOOS != "windows" {
-		err = proc.Signal(syscall.Signal(0))
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return proc, nil
+	return stopListenerCmd("Daemon", cfg.PidPath)
 }

--- a/cmd/listener.go
+++ b/cmd/listener.go
@@ -93,12 +93,12 @@ func startListenerCmd(
 	go watch(l)
 	defer l.Shutdown()
 
+	log.Printf("v%s of the %s is now listening on %s", cfg.Version, procName, l.Addr())
+
 	err = l.Run()
 	if err != nil {
 		log.Printf("Error while running %s.\n%s", procName, err)
 	}
-
-	log.Printf("v%s of the %s is now listening on %s", cfg.Version, procName, l.Addr())
 
 	return err
 }
@@ -138,7 +138,7 @@ func statusListenerCmd(procName, pidPath string) error {
 	}
 
 	proc, err := findListener(pidPath)
-	if err != nil {
+	if err != nil || proc == nil {
 		fmt.Printf("%s not running\n", procName)
 		return nil
 	}

--- a/cmd/listener.go
+++ b/cmd/listener.go
@@ -219,12 +219,12 @@ func findProcess(pid int) (*os.Process, error) {
 
 // spawnListener spawns a detached Listener instance. Shutdown can be done by
 func spawnListener(listenerCmd func(string) *exec.Cmd) error {
-	exectuable, err := osext.Executable()
+	executable, err := osext.Executable()
 	if err != nil {
 		return errs.NewErrorExitError("Unable to find executable", err)
 	}
 
-	cmd := listenerCmd(exectuable)
+	cmd := listenerCmd(executable)
 	// Clone the current env, removing email and password if they exist.
 	// no need to keep those hanging around in a long lived-process!
 	cmd.Env = filterEnv()

--- a/cmd/listener.go
+++ b/cmd/listener.go
@@ -1,0 +1,15 @@
+package cmd
+
+// Listener is an interface for daemon processes that listen on some socket.
+type Listener interface {
+	// Addr returns the address of the running service. This is a socket in
+	// the case of a daemon, or an TCP port in the case of the Gateway.
+	Addr() string
+
+	// Run starts the Service. This operation will block.
+	Run() error
+
+	// Shutdown shuts the Service, and does any cleanup
+	Shutdown() error
+}
+

--- a/cmd/listener.go
+++ b/cmd/listener.go
@@ -1,6 +1,28 @@
 package cmd
 
-// Listener is an interface for daemon processes that listen on some socket.
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path"
+	"runtime"
+	"syscall"
+	"time"
+
+	"github.com/kardianos/osext"
+	"github.com/natefinch/lumberjack"
+	"github.com/nightlyone/lockfile"
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/torus-cli/api"
+	"github.com/manifoldco/torus-cli/config"
+	"github.com/manifoldco/torus-cli/errs"
+)
+
+// Listener is an interface for daemon co-processes that listen on some socket.
 type Listener interface {
 	// Addr returns the address of the running service. This is a socket in
 	// the case of a daemon, or an TCP port in the case of the Gateway.
@@ -13,3 +35,222 @@ type Listener interface {
 	Shutdown() error
 }
 
+// spawnListenerCmd is the cli.Command helper to spawn a new Listener
+// instance in the background
+func spawnListenerCmd(procName, pidPath string, listenerCmd func(string) *exec.Cmd) error {
+	proc, err := findListener(pidPath)
+	if err != nil {
+		return err
+	}
+
+	if proc != nil {
+		fmt.Println("%s is already running.", procName)
+	}
+
+	if err := spawnListener(listenerCmd); err != nil {
+		errMsg := fmt.Sprintf("Unsable to start %s", procName)
+		return errs.NewErrorExitError(errMsg, err)
+	}
+
+	fmt.Printf("%s started.", procName)
+	return nil
+}
+
+// startListenerCmd is the cli.Command helper to start a Listener co-process
+func startListenerCmd(
+	ctx *cli.Context,
+	procName, logPath string,
+	listenerFunc func(*config.Config, bool) (Listener, error),
+) error {
+	noPermissionCheck := ctx.Bool("no-permission-check")
+	torusRoot, err := config.CreateTorusRoot(!noPermissionCheck)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Bool("daemonize") {
+		log.SetOutput(&lumberjack.Logger{
+			Filename:   path.Join(torusRoot, logPath),
+			MaxSize:    10, // megabytes
+			MaxBackups: 3,  // files
+			MaxAge:     28, //days
+		})
+	} else {
+		log.SetOutput(os.Stdout)
+	}
+
+	cfg, err := config.NewConfig(torusRoot)
+	if err != nil {
+		return errs.NewErrorExitError("Failed to load config", err)
+	}
+
+	l, err := listenerFunc(cfg, noPermissionCheck)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to create %s", procName)
+		return errs.NewErrorExitError(errMsg, err)
+	}
+
+	go watch(l)
+	defer l.Shutdown()
+
+	err = l.Run()
+	if err != nil {
+		log.Printf("Error while running %s.\n%s", procName, err)
+	}
+
+	log.Printf("v%s of the %s is now listening on %s", cfg.Version, procName, l.Addr())
+
+	return err
+}
+
+// stopListenerCmd is the cli.Command helper to send the shutdown signal to
+// the Listener co-process
+func stopListenerCmd(procName, pidPath string) error {
+	proc, err := findListener(pidPath)
+	if err != nil {
+		return err
+	}
+
+	if proc == nil {
+		fmt.Printf("%s not running", procName)
+		return nil
+	}
+
+	graceful, err := stopProcess(proc)
+	if err != nil {
+		return err
+	}
+
+	if graceful {
+		fmt.Printf("%s stopped gracefully.", procName)
+	} else {
+		fmt.Printf("%s stopped forcefully.", procName)
+	}
+
+	return nil
+}
+
+// statusCmd returns the status of the Listener co-process, as well as the Daemon version for API
+func statusListenerCmd(procName, pidPath string) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	proc, err := findListener(pidPath)
+	if err != nil {
+		fmt.Println("%s not running", procName)
+		return nil
+	}
+
+	client := api.NewClient(cfg)
+	v, err := client.Version.GetDaemon(context.Background())
+	if err != nil {
+		return errs.NewErrorExitError("Error communicating with the daemon", err)
+	}
+
+	fmt.Printf("%s is running. pid: %d version: v%s\n", procName, proc.Pid, v.Version)
+
+	return nil
+}
+
+// watch watches for OS signals to trigger shutdown
+func watch(l Listener) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	s := <-c
+
+	log.Printf("Caught shutdown signal %s", s)
+	shutdown(l)
+}
+
+// Shutdown shuts the listener down, or panics on failure
+func shutdown(l Listener) {
+	err := l.Shutdown()
+	if err != nil {
+		log.Printf("Did not shutdown cleanly.\n%s", err)
+	}
+
+	if r := recover(); r != nil {
+		log.Printf("Failed shutting down; caught panic.\n%v", r)
+		panic(r)
+	}
+}
+
+// findListener finds and returns the OS Process for the listener. findListener
+// returns nil if it is not running, and throws an error if the pid is invalid,
+// or there was an issue reading the pid file.
+func findListener(pidPath string) (*os.Process, error) {
+	lock, err := lockfile.New(pidPath)
+	if err != nil {
+		return nil, err
+	}
+
+	proc, err := lock.GetOwner()
+	if err != nil {
+		if os.IsNotExist(err) || err == lockfile.ErrInvalidPid || err == lockfile.ErrDeadOwner {
+			// cases are OK
+			return nil, nil
+		}
+
+		return nil, err // we couldn't get the pid, but it should exist, has an owner and is valid
+	}
+
+	return proc, nil
+}
+
+// findProcess finds the OS process for the corresponding PID
+func findProcess(pid int) (*os.Process, error) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	// On unix, findprocess does not error. So we have to check for the process.
+	if runtime.GOOS != "windows" {
+		err = proc.Signal(syscall.Signal(0))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return proc, nil
+}
+
+// spawnListener spawns a detached Listener instance. Shutdown can be done by
+func spawnListener(listenerCmd func(string) *exec.Cmd) error {
+	exectuable, err := osext.Executable()
+	if err != nil {
+		return errs.NewErrorExitError("Unable to find executable", err)
+	}
+
+	cmd := listenerCmd(exectuable)
+	// Clone the current env, removing email and password if they exist.
+	// no need to keep those hanging around in a long lived-process!
+	cmd.Env = filterEnv()
+
+	return cmd.Start()
+}
+
+// stopProcess stops the given OS process. It returns a bool indicating if the
+// shutdown was graceful.
+func stopProcess(proc *os.Process) (bool, error) {
+	err := proc.Signal(syscall.Signal(syscall.SIGTERM))
+
+	if err == nil { // no need to wait for the SIGTERM if the signal failed
+		increment := 50 * time.Millisecond
+		for d := increment; d < 3*time.Second; d += increment {
+			time.Sleep(d)
+			if _, err := findProcess(proc.Pid); err != nil {
+				return true, nil
+			}
+		}
+	}
+
+	err = proc.Kill()
+	if err != nil {
+		return false, errs.NewErrorExitError("Could not stop daemon.", err)
+	}
+
+	return false, nil
+}

--- a/cmd/listener.go
+++ b/cmd/listener.go
@@ -44,7 +44,7 @@ func spawnListenerCmd(procName, pidPath string, listenerCmd func(string) *exec.C
 	}
 
 	if proc != nil {
-		fmt.Println("%s is already running.", procName)
+		fmt.Printf("%s is already running.\n", procName)
 	}
 
 	if err := spawnListener(listenerCmd); err != nil {
@@ -52,7 +52,7 @@ func spawnListenerCmd(procName, pidPath string, listenerCmd func(string) *exec.C
 		return errs.NewErrorExitError(errMsg, err)
 	}
 
-	fmt.Printf("%s started.", procName)
+	fmt.Printf("%s started.\n", procName)
 	return nil
 }
 
@@ -112,7 +112,7 @@ func stopListenerCmd(procName, pidPath string) error {
 	}
 
 	if proc == nil {
-		fmt.Printf("%s not running", procName)
+		fmt.Printf("%s not running\n", procName)
 		return nil
 	}
 
@@ -122,9 +122,9 @@ func stopListenerCmd(procName, pidPath string) error {
 	}
 
 	if graceful {
-		fmt.Printf("%s stopped gracefully.", procName)
+		fmt.Printf("%s stopped gracefully.\n", procName)
 	} else {
-		fmt.Printf("%s stopped forcefully.", procName)
+		fmt.Printf("%s stopped forcefully.\n", procName)
 	}
 
 	return nil
@@ -139,7 +139,7 @@ func statusListenerCmd(procName, pidPath string) error {
 
 	proc, err := findListener(pidPath)
 	if err != nil {
-		fmt.Println("%s not running", procName)
+		fmt.Printf("%s not running\n", procName)
 		return nil
 	}
 

--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -47,7 +47,7 @@ func ensureDaemon(ctx *cli.Context) error {
 		return err
 	}
 
-	proc, err := findDaemon(cfg)
+	proc, err := findListener(cfg.PidPath)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func ensureDaemon(ctx *cli.Context) error {
 	spawned := false
 
 	if proc == nil {
-		err := spawnDaemon()
+		err := spawnListener(daemonCommand)
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func ensureDaemon(ctx *cli.Context) error {
 	fmt.Println("The daemon version is out of date and is being restarted.")
 	fmt.Println("You will need to login again.")
 
-	_, err = stopDaemon(proc)
+	_, err = stopProcess(proc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Generalize the code for creating a deamon listener co-process to keep things DRY for the Gatekeeper listener.

Mostly move functions from daemon.go to listener.go, added a Listener() interface for running and stopping a Listener process.