### PR TITLE
Change `hints.Display` to receive constant list

### DIFF
--- a/cmd/invites_list.go
+++ b/cmd/invites_list.go
@@ -102,6 +102,6 @@ func invitesList(ctx *cli.Context) error {
 	w.Flush()
 	fmt.Println("")
 
-	hints.Display([]string{"invites approve", "teams members"})
+	hints.Display(hints.InvitesApprove, hints.TeamMembers)
 	return nil
 }

--- a/cmd/invites_send.go
+++ b/cmd/invites_send.go
@@ -106,6 +106,6 @@ TeamSearch:
 	fmt.Println("\n\t" + strings.Join(matchTeams, "\n\t"))
 	fmt.Println("\nThey will receive an e-mail with instructions.")
 
-	hints.Display([]string{"invites approve", "teams members"})
+	hints.Display(hints.InvitesApprove, hints.TeamMembers)
 	return nil
 }

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -142,6 +142,6 @@ func linkCmd(ctx *cli.Context) error {
 		fmt.Printf("Warning: context is disabled. Use '%s prefs' to enable it.\n", ctx.App.Name)
 	}
 
-	hints.Display([]string{"context", "set", "run", "view"})
+	hints.Display(hints.Context, hints.Set, hints.Run, hints.View)
 	return nil
 }

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -171,7 +171,7 @@ func listObjects(ctx *cli.Context) error {
 		fmt.Println(p)
 	}
 
-	hints.Display([]string{"path", "view"})
+	hints.Display(hints.Path, hints.View)
 	return nil
 }
 

--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -504,7 +504,7 @@ func createMachineRole(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Role %s created.\n", teamName)
-	hints.Display([]string{"allow", "deny", "policies"})
+	hints.Display(hints.Allow, hints.Deny, hints.Policies)
 	return nil
 }
 
@@ -595,7 +595,7 @@ func createMachine(ctx *cli.Context) error {
 	fmt.Fprintf(w, "Machine Token Secret:\t%s\n", tokenSecret)
 
 	w.Flush()
-	hints.Display([]string{"allow", "deny"})
+	hints.Display(hints.Allow, hints.Deny)
 	return nil
 }
 

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -85,7 +85,7 @@ func orgsCreate(ctx *cli.Context) error {
 		return err
 	}
 
-	hints.Display([]string{"invites send", "projects", "link"})
+	hints.Display(hints.InvitesSend, hints.Projects, hints.Link)
 	return nil
 }
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -62,7 +62,7 @@ func setCmd(ctx *cli.Context) error {
 	pe := (*cred.Body).GetPathExp()
 	fmt.Printf("\nCredential %s has been set at %s/%s\n", name, pe, name)
 
-	hints.Display([]string{"view", "run"})
+	hints.Display(hints.View, hints.Run)
 	return nil
 }
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -364,7 +364,7 @@ func createTeamCmd(ctx *cli.Context) error {
 
 	fmt.Printf("Team %s created.\n", teamName)
 
-	hints.Display([]string{"allow", "deny"})
+	hints.Display(hints.Allow, hints.Deny)
 	return nil
 }
 

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -72,7 +72,7 @@ func viewCmd(ctx *cli.Context) error {
 		return errs.NewUsageExitError("Unknown format: "+format, ctx)
 	}
 
-	hints.Display([]string{"link", "run"})
+	hints.Display(hints.Link, hints.Run)
 	return err
 }
 

--- a/hints/hints.go
+++ b/hints/hints.go
@@ -7,29 +7,57 @@ import (
 	"github.com/manifoldco/torus-cli/ui"
 )
 
-type Hint int
+// Cmd represents a command that has hints available
+type Cmd int
 
 const (
-	Allow Hint = iota
+	// Allow command adds hint to `torus allow`
+	Allow Cmd = iota
+
+	// Context adds hint to application context
 	Context
+
+	// Deny command adds hint to `torus deny`
 	Deny
+
+	// InvitesApprove command adds hint to `torus invites approve`
 	InvitesApprove
+
+	// InvitesSend command adds hint to `torus invites send`
 	InvitesSend
+
+	// Link command adds hint to `torus link`
 	Link
+
+	// Ls command adds hint to `torus ls`
 	Ls
+
+	// Path adds hint about the path expression
 	Path
+
+	// Policies command adds hint to `torus policies`
 	Policies
+
+	// Projects command adds hint to `torus projects`
 	Projects
+
+	// Run command adds hint to `torus run`
 	Run
+
+	// Set command adds hint to `torus set`
 	Set
+
+	// TeamMembers command adds hint to `torus members`
 	TeamMembers
+
+	// View command adds hint to `torus view`
 	View
 )
 
-var commandHints map[Hint][]string
+var commandHints map[Cmd][]string
 
 func init() {
-	commandHints = map[Hint][]string{
+	commandHints = map[Cmd][]string{
 		Allow: {
 			"Grant additional access to secrets for a team or role using `torus allow`",
 		},
@@ -76,7 +104,7 @@ func init() {
 }
 
 // Display chooses a random hint from the allotted commands and displays it
-func Display(possible ...Hint) {
+func Display(possible ...Cmd) {
 	hint := randHint(possible)
 	if hint != "" {
 		ui.Hint(hint, false)
@@ -84,7 +112,7 @@ func Display(possible ...Hint) {
 }
 
 // randHint returns random hint from chosen command's list
-func randHint(possible []Hint) string {
+func randHint(possible []Cmd) string {
 	l := len(possible)
 	if l == 0 {
 		return ""

--- a/hints/hints.go
+++ b/hints/hints.go
@@ -7,50 +7,68 @@ import (
 	"github.com/manifoldco/torus-cli/ui"
 )
 
-var commandHints map[string][]string
+type Hint int
 
-// Init generates the commandHints map
-func Init() {
-	commandHints = map[string][]string{
-		"allow": {
+const (
+	Allow Hint = iota
+	Context
+	Deny
+	InvitesApprove
+	InvitesSend
+	Link
+	Ls
+	Path
+	Policies
+	Projects
+	Run
+	Set
+	TeamMembers
+	View
+)
+
+var commandHints map[Hint][]string
+
+func init() {
+	commandHints = map[Hint][]string{
+		Allow: {
 			"Grant additional access to secrets for a team or role using `torus allow`",
 		},
-		"context": {
+		Context: {
 			"Your linked organization and project are found in .torus.json after running `torus link`",
 		},
-		"deny": {
+		Deny: {
 			"Restrict access to secrets for a team or role using `torus deny`",
 		},
-		"invites approve": {
+		InvitesApprove: {
 			"Approve multiple invites with `torus worklog resolve`",
 		},
-		"invites send": {
+		InvitesSend: {
 			"Invite another user to join your organization with `torus invites send`",
 		},
-		"link": {
+		Link: {
 			"Define an organization and project for your current working directory using `torus link`",
 		},
-		"ls": {
+		Ls: {
 			"Explore the objects and secrets for your org through `torus ls`",
 		},
-		"path": {
+		Path: {
 			"Each secret path has 7 segments: /org/project/env/service/identity/instance/secret",
 			"Secret paths can contain wildcards, such as `dev-*` for the environment",
 		},
-		"policies": {
+		Policies: {
 			"Display policies for your organization with `torus policies list`",
 			"View details of an existing policy with `torus policies view`",
 		},
-		"projects": {
+		Projects: {
 			"Create a project for your secrets using `torus projects create`",
 		},
-		"run": {
+		Run: {
 			"Start your process with your decrypted secrets using `torus run`",
 		},
-		"teams members": {
+		TeamMembers: {
 			"Display current members of your organization with `torus members member`",
 		},
-		"view": {
+		View: {
 			"View secret values which have been set using `torus view`",
 			"See the exact path for each secret set using `torus view -v`",
 		},
@@ -58,16 +76,29 @@ func Init() {
 }
 
 // Display chooses a random hint from the allotted commands and displays it
-func Display(possible []string) {
+func Display(possible ...Hint) {
+	hint := randHint(possible)
+	if hint != "" {
+		ui.Hint(hint, false)
+	}
+}
+
+// randHint returns random hint from chosen command's list
+func randHint(possible []Hint) string {
+	l := len(possible)
+	if l == 0 {
+		return ""
+	}
+
 	// Seed random integer
 	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
-	i := r.Intn(len(possible))
+	i := r.Intn(l)
 	cmd := possible[i]
 	if hints, ok := commandHints[cmd]; ok {
-		// Display random hint from chosen command's list
 		item := r.Intn(len(hints))
 		if len(hints) > item {
-			ui.Hint(hints[item], false)
+			return hints[item]
 		}
 	}
+	return ""
 }

--- a/hints/hints_test.go
+++ b/hints/hints_test.go
@@ -1,0 +1,50 @@
+package hints
+
+import (
+	"testing"
+)
+
+func TestRandHint(t *testing.T) {
+	type tc struct {
+		desc string
+		cmds []Hint
+		hint string
+	}
+
+	testCases := []tc{
+		{desc: "Empty command list", cmds: []Hint{}, hint: ""},
+		{desc: "Command without hint", cmds: []Hint{Set}, hint: ""},
+		{
+			desc: "Command with one hint",
+			cmds: []Hint{Allow},
+			hint: "Grant additional access to secrets for a team or role using `torus allow`",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := randHint(tc.cmds)
+			if got != tc.hint {
+				t.Errorf("randHint(%v) expected to be %q, got %q", tc.cmds, tc.hint, got)
+			}
+		})
+	}
+
+	t.Run("Command with multiple hints", func(t *testing.T) {
+		got := randHint([]Hint{View})
+		exp1 := "View secret values which have been set using `torus view`"
+		exp2 := "See the exact path for each secret set using `torus view -v`"
+		if got != exp1 && got != exp2 {
+			t.Errorf("randHint(View) expected to be either %q or %q, got %s", exp1, exp2, got)
+		}
+	})
+
+	t.Run("Multiple commands", func(t *testing.T) {
+		got := randHint([]Hint{Allow, Deny})
+		exp1 := "Grant additional access to secrets for a team or role using `torus allow`"
+		exp2 := "Restrict access to secrets for a team or role using `torus deny`"
+		if got != exp1 && got != exp2 {
+			t.Errorf("randHint(Allow, Deny) expected to be either %q or %q, got %s", exp1, exp2, got)
+		}
+	})
+}

--- a/hints/hints_test.go
+++ b/hints/hints_test.go
@@ -7,16 +7,16 @@ import (
 func TestRandHint(t *testing.T) {
 	type tc struct {
 		desc string
-		cmds []Hint
+		cmds []Cmd
 		hint string
 	}
 
 	testCases := []tc{
-		{desc: "Empty command list", cmds: []Hint{}, hint: ""},
-		{desc: "Command without hint", cmds: []Hint{Set}, hint: ""},
+		{desc: "Empty command list", cmds: []Cmd{}, hint: ""},
+		{desc: "Command without hint", cmds: []Cmd{Set}, hint: ""},
 		{
 			desc: "Command with one hint",
-			cmds: []Hint{Allow},
+			cmds: []Cmd{Allow},
 			hint: "Grant additional access to secrets for a team or role using `torus allow`",
 		},
 	}
@@ -31,7 +31,7 @@ func TestRandHint(t *testing.T) {
 	}
 
 	t.Run("Command with multiple hints", func(t *testing.T) {
-		got := randHint([]Hint{View})
+		got := randHint([]Cmd{View})
 		exp1 := "View secret values which have been set using `torus view`"
 		exp2 := "See the exact path for each secret set using `torus view -v`"
 		if got != exp1 && got != exp2 {
@@ -40,7 +40,7 @@ func TestRandHint(t *testing.T) {
 	})
 
 	t.Run("Multiple commands", func(t *testing.T) {
-		got := randHint([]Hint{Allow, Deny})
+		got := randHint([]Cmd{Allow, Deny})
 		exp1 := "Grant additional access to secrets for a team or role using `torus allow`"
 		exp2 := "Restrict access to secrets for a team or role using `torus deny`"
 		if got != exp1 && got != exp2 {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/manifoldco/torus-cli/cmd"
 	"github.com/manifoldco/torus-cli/config"
-	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/prefs"
 	"github.com/manifoldco/torus-cli/ui"
 )
@@ -24,7 +23,6 @@ func main() {
 
 	preferences, _ := prefs.NewPreferences()
 	ui.Init(preferences)
-	hints.Init()
 
 	app := cli.NewApp()
 	app.Name = "torus"


### PR DESCRIPTION
* Create constant list of command hints to avoid misspellings or commands
not defined;
* Change `Display` to accept a variadic list of command hints;
* Rename `Init()` to `init()` since no custom package initialization was
required;
* Create `randHint` function to avoid testing IO from readline.

PS: `Set` doesn't have hints defined yet.