### PR TITLE
Update Changelog, Error Messages, and Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 _Unreleased_
 
+**Notable Changes**
+
+- `torus set` now supports `name=path` syntax (e.g. `torus set foo=bar` or `torus set /org/project/env/*/*/*/foo=bar`)
+
+**Thanks**
+
+- Luiz Branco
+
 ## v0.23.0
 
 _2017-05-17_

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -74,12 +74,12 @@ func parseSetArgs(args []string) (key string, value string, errMsg string) {
 
 	switch len(args) {
 	case 0, 1:
-		errMsg = "name and value are required."
+		errMsg = "A secret name and value must be supplied."
 	case 2:
 		key = args[0]
 		value = args[1]
 	default:
-		errMsg = "Too many arguments provided."
+		errMsg = "Too many arguments were provided."
 	}
 	return key, value, errMsg
 }

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -11,9 +11,9 @@ func TestParseArgs(t *testing.T) {
 	}
 
 	testCases := []tc{
-		{args: []string{}, err: "name and value are required."},
-		{args: []string{"foo"}, err: "name and value are required."},
-		{args: []string{"foo", "bar", "baz"}, err: "Too many arguments provided."},
+		{args: []string{}, err: "A secret name and value must be supplied."},
+		{args: []string{"foo"}, err: "A secret name and value must be supplied."},
+		{args: []string{"foo", "bar", "baz"}, err: "Too many arguments were provided."},
 		{args: []string{"foo", "bar"}, key: "foo", val: "bar"},
 		{args: []string{"foo=bar"}, key: "foo", val: "bar"},
 		{args: []string{"foo=bar=="}, key: "foo", val: "bar=="},

--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -20,7 +20,8 @@ Torus exposes your decrypted secrets to your process through environment variabl
 ## set
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus set <name|path> <value>` sets a value for the specified name (or [path](../concepts/path.md)).
+`torus set <name|path> <value>` or `torus set <name|path>=<value>` sets a value
+for the specified name (or [path](../concepts/path.md)).
 
 This is how all secrets are stored in Torus.
 


### PR DESCRIPTION
With the acceptance of #234, we needed to update the changelog, `torus
set` documentation and clarify a few of the new error messages.