### PR TITLE
Rename "Name" to "Full Name"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ _Unreleased_
 **Notable Changes**
 
 - `torus set` now supports `name=path` syntax (e.g. `torus set foo=bar` or `torus set /org/project/env/*/*/*/foo=bar`)
+- We now refer to `Name` as `Full Name` to differentiate between a user's full
+  name and username.
 
 **Thanks**
 

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -108,8 +108,8 @@ func debugInfoCmd(ctx *cli.Context) error {
 			fmt.Fprintf(w, "%s\t%s\n", "Machine Name", session.Username())
 		} else {
 			fmt.Fprintf(w, "%s\t%s\n", "User ID", session.ID())
-			fmt.Fprintf(w, "%s\t%s <%s>\n", "Identity", session.Name(), session.Email())
-			fmt.Fprintf(w, "%s\t%s\n", "Username", session.Username())
+			fmt.Fprintf(w, "%s\t%s <%s>\n", "Full Name <Email>", session.Name(), session.Email())
+			fmt.Fprintf(w, "%s\t%s\n", "Identity", session.Username())
 		}
 	}
 

--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -489,7 +489,7 @@ func FullNamePrompt(name string) (string, error) {
 	}
 
 	prompt := promptui.Prompt{
-		Label: "Name",
+		Label: "Full Name",
 		Validate: func(input string) error {
 			err := validate.Name(input)
 			if err == nil {

--- a/docs/commands/account.md
+++ b/docs/commands/account.md
@@ -6,7 +6,7 @@ The Torus CLI can be used to manage your session and profile.
 
 `torus signup` is used to create a new Torus account.
 
-The user will be prompted to enter their name, username, email, and password (twice).
+The user will be prompted to enter their full name, username, email, and password (twice).
 
 After signup the user will be sent an email which contains a verification code, this code must then be pasted into the Verification Code prompt that occurs after signup. If this prompt is aborted, the user can use the verify command to complete verification.
 
@@ -30,14 +30,14 @@ If you have forgotten your password please contact [support@torus.sh](mailto:sup
 `torus logout` will destroy your current session, after doing so you must login again before performing any further actions within your organization.
 
 ## profile
-Your profile contains your name, email and password inside Torus.  
+Your profile contains your name, email and password inside Torus.
 
 ### update
 ###### Added [v0.17.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus profile update` enables you to modify the authenticated user’s name, email or password. 
+`torus profile update` enables you to modify the authenticated user’s full name, email or password.
 
-Currently accounts can only have one email attached to them. In the event of an email change, you will need to re-verify your account. 
+Currently accounts can only have one email attached to them. In the event of an email change, you will need to re-verify your account.
 
 ### view
 ###### Added [v0.17.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)


### PR DESCRIPTION
Throughout, we were referencing both a "Name" and a "Username", with
this change we now differentiate by asking for a "Full Name" and a
"Username".

Closes #233