### PR TITLE
policies test cmd initial implementation

### DIFF
--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -580,3 +580,16 @@ func policyTouchesPathPredicate(pathExp *pathexp.PathExp) PolicyPredicate {
 		return false
 	}
 }
+
+// Create a predicate to filter (include) policies that implement the specified
+// policy-action ([crudl]) in any one of their statements.
+func policyImplementsActionPredicate(action primitive.PolicyAction) PolicyPredicate {
+	return func(policy envelope.Policy) bool {
+		for _, s := range policy.Body.Policy.Statements {
+			if s.Action&action > 0 {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -559,3 +559,24 @@ func policyAttachedToTeamsPredicate(teams []envelope.Team,
 		return false
 	}
 }
+
+// Create a predicate to filter (exclude) policies that do not apply to the
+// specified path. A policy applies to a path if any of its resources (paths)
+// are equivalent to the specified path. The secret portion of the path is
+// ignored.
+func policyTouchesPathPredicate(pathExp *pathexp.PathExp) PolicyPredicate {
+	return func(policy envelope.Policy) bool {
+		for _, s := range policy.Body.Policy.Statements {
+			rp, err := parseRawPath(s.Resource)
+			if err != nil {
+				// TODO Log this
+				continue
+			}
+			// I'm pretty sure this is wrong...
+			if rp.Equal(pathExp) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -328,6 +328,11 @@ func viewPolicyCmd(ctx *cli.Context) error {
 
 const policyTestFailed = "Could not test policy."
 
+var permissionString = map[bool]string{
+	true:  "yes",
+	false: "no",
+}
+
 func testPolicies(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -383,7 +388,7 @@ func testPolicies(ctx *cli.Context) error {
 	policies = filterPolicies(policies, predicate)
 	allowed := policiesAllowAccess(policies)
 
-	fmt.Printf("User %s has access to %v %v: %v\n", *userName, action.String(), path, false)
+	fmt.Println(permissionString[allowed])
 
 	return nil
 }

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -464,7 +464,7 @@ func getTeamsForUser(c context.Context, client *api.Client, userName *string,
 	teamChan := make(chan envelope.Team, 1)
 	filterTeamsByUser(c, client, teams, user, teamChan, orgID)
 
-	result := make([]envelope.Team, 0)
+	var result []envelope.Team
 	for t := range teamChan {
 		result = append(result, t)
 	}
@@ -551,7 +551,7 @@ func AllPredicate(predicates ...PolicyPredicate) PolicyPredicate {
 }
 
 func filterPolicies(policies []envelope.Policy, predicate PolicyPredicate) []envelope.Policy {
-	result := make([]envelope.Policy, 0)
+	var result []envelope.Policy
 	for _, pol := range policies {
 		if predicate(pol) {
 			result = append(result, pol)

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -490,7 +491,7 @@ func filterTeamsByUser(c context.Context, client *api.Client, teams []envelope.T
 				defer wg.Done()
 				members, err := client.Memberships.List(c, orgID, team.ID, nil)
 				if err != nil {
-					// TODO: Log this!!!
+					log.Printf("Failed to list memberships for team %v: %v. Skipping...\n", team.Body.Name, err)
 					return
 				}
 				for _, m := range members {
@@ -597,7 +598,8 @@ func policyTouchesPathPredicate(pathExp *pathexp.PathExp) PolicyPredicate {
 		for _, s := range policy.Body.Policy.Statements {
 			rp, _, err := parseRawPath(s.Resource)
 			if err != nil {
-				// TODO Log this
+				log.Printf("Failed parse resource %v for policy %v: %v. Skipping...\n",
+					s.Resource, policy.Body.Policy.Name, err)
 				continue
 			}
 			// I'm pretty sure this is wrong...

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -534,3 +534,28 @@ func filterPolicies(policies []envelope.Policy, predicate PolicyPredicate) []env
 	}
 	return result
 }
+
+// Crete a Predicate to filter (exclude) policies that are not attached to any
+// of the specified teams.
+func policyAttachedToTeamsPredicate(teams []envelope.Team,
+	attachments []envelope.PolicyAttachment) PolicyPredicate {
+
+	teamsByID := make(map[identity.ID]envelope.Team)
+	for _, t := range teams {
+		teamsByID[*t.ID] = t
+	}
+
+	attachmentByPolicyID := make(map[identity.ID]envelope.PolicyAttachment, 0)
+	for _, a := range attachments {
+		attachmentByPolicyID[*a.Body.PolicyID] = a
+	}
+
+	return func(policy envelope.Policy) bool {
+		if a, ok := attachmentByPolicyID[*policy.ID]; ok {
+			if _, ok := teamsByID[*a.Body.OwnerID]; ok {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -602,8 +602,8 @@ func policyTouchesPathPredicate(pathExp *pathexp.PathExp) PolicyPredicate {
 					s.Resource, policy.Body.Policy.Name, err)
 				continue
 			}
-			// I'm pretty sure this is wrong...
-			if rp.Equal(pathExp) {
+			// Is this right?
+			if pathExp.Contains(rp) || rp.Contains(pathExp) {
 				return true
 			}
 		}

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -593,3 +593,22 @@ func policyImplementsActionPredicate(action primitive.PolicyAction) PolicyPredic
 		return false
 	}
 }
+
+// Given a set of policies, determine if they allow access (i.e. allow a
+// specific action on a specific path). Returns true if at least one policy
+// allows access AND exactly zero policies deny access. Return false otherwise.
+// This method only make sense if the policies have been previously reduced to
+// those referring to the same resource and action.
+func policiesAllowAccess(policies []envelope.Policy) bool {
+	allow := false
+	for _, p := range policies {
+		for _, s := range p.Body.Policy.Statements {
+			if s.Effect == primitive.PolicyEffectDeny {
+				return false
+			}
+			allow = true
+		}
+	}
+	return allow
+
+}

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -60,6 +60,19 @@ func init() {
 					setUserEnv, checkRequiredFlags, detachPolicies,
 				),
 			},
+
+			{
+				Name:      "test",
+				Usage:     "Test a user's access to a path",
+				ArgsUsage: "<c|r|u|d|l> <username> <path>",
+				Flags: []cli.Flag{
+					orgFlag("org to test policy for", true),
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					setUserEnv, checkRequiredFlags, testPolicies,
+				),
+			},
 		},
 	}
 	Cmds = append(Cmds, policies)
@@ -307,5 +320,9 @@ func viewPolicyCmd(ctx *cli.Context) error {
 	}
 	w.Flush()
 
+	return nil
+}
+
+func testPolicies(ctx *cli.Context) error {
 	return nil
 }

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -324,5 +324,19 @@ func viewPolicyCmd(ctx *cli.Context) error {
 }
 
 func testPolicies(ctx *cli.Context) error {
+	args := ctx.Args()
+	if len(args) < 3 {
+		return errs.NewUsageExitError("Too few arguments", ctx)
+
+	} else if len(args) > 3 {
+		return errs.NewUsageExitError("Too many arguments", ctx)
+	}
+
+	rawAction := args[0]
+	userName := args[1]
+	rawPath := args[2]
+
+	fmt.Printf("User %s has access to %v %v: %v\n", userName, rawAction, rawPath, false)
+
 	return nil
 }

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -509,3 +509,28 @@ func getPoliciesAndAttachments(client *api.Client, orgID *identity.ID) ([]envelo
 	}
 	return policies, attachments, nil
 }
+
+// Test if a Policy satisfies some condition
+type PolicyPredicate func(envelope.Policy) bool
+
+// Compound Predicate: Test of a policy satisfies all predicates
+func AllPredicate(predicates ...PolicyPredicate) PolicyPredicate {
+	return func(policy envelope.Policy) bool {
+		for _, pred := range predicates {
+			if !pred(policy) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func filterPolicies(policies []envelope.Policy, predicate PolicyPredicate) []envelope.Policy {
+	result := make([]envelope.Policy, 0)
+	for _, pol := range policies {
+		if predicate(pol) {
+			result = append(result, pol)
+		}
+	}
+	return result
+}

--- a/pathexp/pathexp.go
+++ b/pathexp/pathexp.go
@@ -525,6 +525,17 @@ func (pe *PathExp) CompareSpecificity(other *PathExp) int {
 	return compareSegmentType(pe.Instances, other.Instances)
 }
 
+// Contains returns whether this path contains the subject. A path Contains
+// another if it resolves to the other or they are equal.
+func (pe *PathExp) Contains(other *PathExp) bool {
+	return pe.Org.Contains(other.Org.String()) &&
+		pe.Project.Contains(other.Project.String()) &&
+		pe.Envs.Contains(other.Envs.String()) &&
+		pe.Services.Contains(other.Services.String()) &&
+		pe.Identities.Contains(other.Identities.String()) &&
+		pe.Instances.Contains(other.Instances.String())
+}
+
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // This will be used in json decoding.
 func (pe *PathExp) UnmarshalText(b []byte) error {


### PR DESCRIPTION
This MR is a first attempt at the `torus policies test` command as specified in Ian's email.

Testing a path to see if all relevant policy allows access to it goes something like this:
- validate input
- fetch org
- fetch user teams
    - fetch user profile
    - fetch all teams for org
    - fetch memberships for each team and filter team by user membership
- fetch all policies for org
- fetch all policy attachments for org
- filter policies
    - by team attachment
    - by path
    - by action
- test access (yes if >= 1 policies allow access and 0 deny access, false otherwise).

Notes:
- I've followed the existing pattern in policies.go and elsewhere in other command implementations that making API calls can be  expensive and should be done in parallel when possible.
- When implementing the above pattern, I used the existing idiom of go routine + closure + WaitGroups. Given more time I might have tried an approached that used channels instead, and seen how the two compared.
- There is a complete lack of automated testing here, unit, integration or otherwise. I'm usually pretty good about writing test (really I am), but given the time scope I skipped this.
- Testing was necessarily manual, and I probably missed some scenarios so my implementation may have logic errors.
- There is some code and idea duplication, both introduced by me and to a lesser extent already existing. Ideally I'd refactor/consolidate to eliminate this, but given the scope of the task I did not take this on.
- There is one part of the implementation I'm pretty sure is wrong; the whole path parsing and comparison bit. For starters the pathexp.PathExp class does not represent secrets so I totally ignored secrets in the implementation  (as is done in cmd.allow.go). I suspect this part is not quite right. Also, I'm pretty sure comparing the specified path with a Policy's Resources is not always right. Fixing this should be simple though for someone more familiar with path expression.

Enjoy!