### PR TITLE
Allow set cmd to read from a file piped to stdin

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/google/shlex"
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
+	"github.com/urfave/cli"
+)
+
+type secretPair struct {
+	key   string
+	value string
+}
+
+func init() {
+	c := cli.Command{
+		Name:      "import",
+		Usage:     "Import multiple secrets from an env file",
+		ArgsUsage: "<file> or use stdin redirection (eg: torus import < secrets.env)",
+		Category:  "SECRETS",
+		Flags:     setUnsetFlags,
+		Action: chain(
+			ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+			setSliceDefaults, importCmd,
+		),
+	}
+
+	Cmds = append(Cmds, c)
+}
+
+func importCmd(ctx *cli.Context) error {
+	args := ctx.Args()
+	secrets, err := importSecretFile(args)
+
+	if err != nil {
+		return errs.NewUsageExitError(err.Error(), ctx)
+	}
+
+	for _, secret := range secrets {
+		cred, err := setCredential(ctx, secret.key, func() *apitypes.CredentialValue {
+			return apitypes.NewStringCredentialValue(secret.value)
+		})
+
+		if err != nil {
+			return errs.NewErrorExitError("Could not set credential.", err)
+		}
+
+		name := (*cred.Body).GetName()
+		pe := (*cred.Body).GetPathExp()
+		fmt.Printf("\nCredential %s has been set at %s/%s\n", name, pe, name)
+	}
+
+	hints.Display(hints.View, hints.Set)
+	return nil
+}
+
+// importSecretFile returns a list of secret pairs either reading a file
+// provided or from the standard input. It returns an error if there is a
+// problem parsing secrets or stdin fails to read.
+func importSecretFile(args []string) ([]secretPair, error) {
+	switch len(args) {
+	case 0:
+		return readStdin()
+	case 1:
+		return readFile(args[0])
+	default:
+		return nil, errors.New("Too many arguments were provided")
+	}
+}
+
+func readFile(filename string) ([]secretPair, error) {
+	flags := os.O_RDONLY
+	f, err := os.OpenFile(filename, flags, 0644)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s does not exist", filename)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Error reading %s file %s", filename, err)
+	}
+
+	defer f.Close()
+
+	return scanSecrets(f)
+}
+
+func readStdin() ([]secretPair, error) {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("Could not from stdin. %s", err)
+	}
+
+	if (stat.Mode() & os.ModeNamedPipe) != 0 {
+		return nil, errors.New("Could not read from piped input")
+	}
+
+	return scanSecrets(os.Stdin)
+}
+
+// scanSecrets reads secret pairs using an UNIX shell-like syntax parser. Empty
+// lines and comments are ignored.
+func scanSecrets(r io.Reader) ([]secretPair, error) {
+	var pairs []secretPair
+
+	lexer := shlex.NewLexer(r)
+
+	for {
+		word, err := lexer.Next()
+		if err != nil {
+			if err == io.EOF {
+				return pairs, nil
+			}
+			return nil, fmt.Errorf("Error reading input file. %s", err)
+		}
+
+		tokens := strings.SplitN(word, "=", 2)
+		if len(tokens) < 2 {
+			return nil, fmt.Errorf("Error parsing secret %q", word)
+		}
+
+		key := tokens[0]
+		value := tokens[1]
+
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("Error parsing secret %q", word)
+		}
+
+		pairs = append(pairs, secretPair{key: key, value: value})
+	}
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestImportSecretFile(t *testing.T) {
+	t.Run("when argument file exists", func(t *testing.T) {
+		tmpfile, err := ioutil.TempFile("", "secrets.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		file := tmpfile.Name()
+
+		content := `# this is an env file
+FOO=bar
+BAR=value # with comment
+BAZ="multi word"
+`
+
+		err = ioutil.WriteFile(file, []byte(content), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expect := []secretPair{
+			{"FOO", "bar"},
+			{"BAR", "value"},
+			{"BAZ", "multi word"},
+		}
+		got, err := importSecretFile([]string{file})
+
+		if err != nil {
+			t.Errorf("importSecretFile(%v) expected no errors, got %q", file, err)
+		}
+
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("importSecretFile(%v) expected %q, got %q", file, expect, got)
+		}
+	})
+
+	t.Run("when argument file doesn't exist", func(t *testing.T) {
+		file := "torus-secret-missing-file.txt"
+
+		expected := "torus-secret-missing-file.txt does not exist"
+		_, got := importSecretFile([]string{file})
+
+		if got.Error() != expected {
+			t.Errorf("importSecretFile(%v) expected error %q, got %q", file, expected, got)
+		}
+	})
+
+	t.Run("when multiple arguments are provided", func(t *testing.T) {
+		files := []string{"a.env", "b.env"}
+
+		expected := "Too many arguments were provided"
+		_, got := importSecretFile(files)
+
+		if got.Error() != expected {
+			t.Errorf("importSecretFile(%v) expected error %q, got %q", files, expected, got)
+		}
+	})
+}
+
+func TestScanSecrets(t *testing.T) {
+	type tc struct {
+		content string
+		pairs   []secretPair
+		err     string
+	}
+
+	testCases := []tc{
+		{
+			content: `# comment line
+				FOO=BAR
+				bar=baz # comment at the end
+				baz="multi value"
+
+				/org/project/env/service/user/instance/foo=bar
+			`,
+			pairs: []secretPair{
+				{"FOO", "BAR"},
+				{"bar", "baz"},
+				{"baz", "multi value"},
+				{"/org/project/env/service/user/instance/foo", "bar"},
+			},
+		},
+		{
+			content: `FOO=BAR bar=baz # comment at the end`,
+			pairs: []secretPair{
+				{"FOO", "BAR"},
+				{"bar", "baz"},
+			},
+		},
+		{
+			content: `foo`,
+			err:     `Error parsing secret "foo"`,
+		},
+		{
+			content: `foo = bar`,
+			err:     `Error parsing secret "foo"`,
+		},
+		{
+			content: `foo bar`,
+			err:     `Error parsing secret "foo"`,
+		},
+		{
+			content: `foo=`,
+			err:     `Error parsing secret "foo="`,
+		},
+		{
+			content: `=`,
+			err:     `Error parsing secret "="`,
+		},
+		{
+			content: `=bar`,
+			err:     `Error parsing secret "=bar"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		r := strings.NewReader(tc.content)
+		pairs, err := scanSecrets(r)
+
+		if err != nil && tc.err == "" {
+			t.Errorf("scanSecrets(%v) expected no errors, got %q", tc.content, err)
+		}
+
+		if tc.err != "" && err.Error() != tc.err {
+			t.Errorf("scanSecrets(%v) expected error %q, got %q", tc.content, tc.err, err)
+		}
+
+		if !reflect.DeepEqual(tc.pairs, pairs) {
+			t.Errorf("scanSecrets(%v) expected %q, got %q", tc.content, tc.pairs, pairs)
+		}
+	}
+}

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -1,51 +1,53 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestParseArgs(t *testing.T) {
+func TestParseSetArgs(t *testing.T) {
 	type tc struct {
-		args []string
-		key  string
-		val  string
-		err  string
+		args  []string
+		key   string
+		value string
+		err   string
 	}
 
 	testCases := []tc{
-		{args: []string{}, err: "A secret name and value must be supplied."},
-		{args: []string{"foo"}, err: "A secret name and value must be supplied."},
-		{args: []string{"foo", "bar", "baz"}, err: "Too many arguments were provided."},
-		{args: []string{"foo", "bar"}, key: "foo", val: "bar"},
-		{args: []string{"foo=bar"}, key: "foo", val: "bar"},
-		{args: []string{"foo=bar=="}, key: "foo", val: "bar=="},
-		{args: []string{"="}, err: "A secret must have a name and value."},
-		{args: []string{"key="}, key: "key", err: "A secret must have a name and value."},
-		{args: []string{"=sd"}, val: "sd", err: "A secret must have a name and value."},
+		{args: []string{}, err: "A secret name and value must be supplied"},
+		{args: []string{"foo"}, err: "A secret name and value must be supplied"},
+		{args: []string{"foo", "bar", "baz"}, err: "Too many arguments were provided"},
+		{args: []string{"foo", "bar"}, key: "foo", value: "bar"},
+		{args: []string{"foo=bar"}, key: "foo", value: "bar"},
+		{args: []string{"foo=bar=="}, key: "foo", value: "bar=="},
+		{args: []string{"="}, err: "A secret must have a name and value"},
+		{args: []string{"key="}, err: "A secret must have a name and value"},
+		{args: []string{"=sd"}, err: "A secret must have a name and value"},
 		{
-			args: []string{"/org/project/env/service/user/instance/foo", "bar"},
-			key:  "/org/project/env/service/user/instance/foo",
-			val:  "bar",
+			args:  []string{"/org/project/env/service/user/instance/foo", "bar"},
+			key:   "/org/project/env/service/user/instance/foo",
+			value: "bar",
 		},
 		{
-			args: []string{"/org/project/env/service/user/instance/foo=bar"},
-			key:  "/org/project/env/service/user/instance/foo",
-			val:  "bar",
+			args:  []string{"/org/project/env/service/user/instance/foo=bar"},
+			key:   "/org/project/env/service/user/instance/foo",
+			value: "bar",
 		},
 	}
 
 	for _, tc := range testCases {
-		key, val, err := parseSetArgs(tc.args)
+		key, value, err := parseSetArgs(tc.args)
 
-		if err != "" && tc.err == "" {
-			t.Errorf("parseArgs(%v) expected no errors, got %q", tc.args, err)
+		if err != nil && tc.err == "" {
+			t.Errorf("parseSetArgs(%v) expected no errors, got %q", tc.args, err)
 		}
 
-		if tc.err != "" && err != tc.err {
-			t.Errorf("parseArgs(%v) expected error %q, got %q", tc.args, tc.err, err)
+		if tc.err != "" && err.Error() != tc.err {
+			t.Errorf("parseSetArgs(%v) expected error %q, got %q", tc.args, tc.err, err)
 		}
 
-		if key != tc.key || val != tc.val {
-			t.Errorf("parseArgs(%v) expected (%q,%q) pair, got (%q,%q)", tc.args,
-				tc.key, tc.val, key, val)
+		if key != tc.key || value != tc.value {
+			t.Errorf("parseSetArgs(%v) expected (%q,%q) pair, got (%q,%q)", tc.args,
+				tc.key, tc.value, key, value)
 		}
 	}
 }

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/manifoldco/torus-cli/pathexp"
 )
 
-type secretPair struct {
-	key   string
-	value string
-}
-
 func TestWriteEnvFormat(t *testing.T) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: b0a6306ab98dab2450b71557d87519ce7691146d1d1bc685112fd84c8a118aea
-updated: 2017-05-31T21:27:40.814727411-03:00
+hash: c7850fba9a0bf5699e401a7a882b84ede107d56c0b104e53026353199c0a186b
+updated: 2017-06-17T11:54:13.148029547-04:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/aws/aws-sdk-go
-  version: d43439f542aac478e400c879d32e567a406d172b
+  version: 96358b8282b1a3aa66836d2f2fe66216cc419668
   subpackages:
   - aws
   - aws/awserr
@@ -22,6 +22,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/shareddefaults
   - private/protocol
   - private/protocol/query
   - private/protocol/query/queryutil
@@ -49,7 +50,7 @@ imports:
 - name: github.com/fullsailor/pkcs7
   version: eb67e7e564b9eae64dc7d95fae0784d6086a5fc4
 - name: github.com/go-ini/ini
-  version: 36da989cdc560b989d8f195aec46214d33665d20
+  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
 - name: github.com/go-zoo/bone
   version: fd0aebc74e908868b09ac140fb5a53cb363884c1
 - name: github.com/golang/protobuf
@@ -64,6 +65,8 @@ imports:
   version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
   subpackages:
   - query
+- name: github.com/google/shlex
+  version: 6f45313302b9c56850fc17f99e40caebce98c716
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/kardianos/osext
@@ -101,7 +104,6 @@ imports:
   - salsa20
   - salsa20/salsa
   - scrypt
-  - ssh/terminal
   - twofish
 - name: golang.org/x/net
   version: d1e1b351919c6738fdeb9893d5c998b161464f0c

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,3 +44,4 @@ import:
 - package: github.com/manifoldco/go-base32
   version: ^1.0.0
 - package: github.com/fullsailor/pkcs7
+- package: github.com/google/shlex

--- a/hints/hints.go
+++ b/hints/hints.go
@@ -20,6 +20,9 @@ const (
 	// Deny command adds hint to `torus deny`
 	Deny
 
+	// Import command adds hint to `torus import`
+	Import
+
 	// InvitesApprove command adds hint to `torus invites approve`
 	InvitesApprove
 
@@ -49,6 +52,9 @@ const (
 
 	// TeamMembers command adds hint to `torus members`
 	TeamMembers
+
+	// Unset command adds hint to `torus unset
+	Unset
 
 	// View command adds hint to `torus view`
 	View


### PR DESCRIPTION
If no arguments are passed to `set` we try to check if there is any input being piped to stdin. Closes #218 

Given a `file.txt` like:

```
user=root
password=s3cr3t
port=3000
```

We can now do:

```shell
torus set --org example --project mvp < file.txt
```

It is also useful to export all secrets from one organisation / project and add to another one:

```
torus view --org example --project foo > secrets.txt
torus set  --org another --project bar < secrets.txt
```

@ianlivingstone I'm currently doing a round trip to set each secret. I'm not sure if there is a way to send multiple secrets in a single payload.