### PR TITLE
Add optional SSL for Gatekeeper

### DIFF
--- a/cmd/gatekeeper.go
+++ b/cmd/gatekeeper.go
@@ -14,6 +14,11 @@ import (
 	"github.com/manifoldco/torus-cli/gatekeeper"
 )
 
+var (
+	certFlag = newPlaceholder("cert, c", "CERT", "Certificate for SSL", "", "TORUS_GATEKEEPER_CERT", false)
+	keyFlag  = newPlaceholder("key, k", "KEY", "Certificate key for SSL", "", "TORUS_GATEKEEPER_CERT_KEY", false)
+)
+
 func init() {
 	gatekeeper := cli.Command{
 		Name:     "gatekeeper",
@@ -26,6 +31,12 @@ func init() {
 				Action: chain(ensureDaemon, ensureSession, loadDirPrefs,
 					loadPrefDefaults, startGatekeeperCmd,
 				),
+				Flags: []cli.Flag{
+					orgFlag("Use this organization by default in Gatekeeper", false),
+					roleFlag("Use this role.", false),
+					certFlag,
+					keyFlag,
+				},
 			},
 		},
 	}
@@ -42,9 +53,10 @@ func startGatekeeperCmd(ctx *cli.Context) error {
 		return errs.NewErrorExitError("Failed to load config.", err)
 	}
 
-	gatekeeper, err := gatekeeper.New(ctx.String("org"), ctx.String("team"), cfg)
+	gatekeeper, err := gatekeeper.New(ctx.String("org"), ctx.String("role"), ctx.String("cert"), ctx.String("key"), cfg)
 	if err != nil {
 		log.Printf("Error starting a new Gatekeeper instance: %s", err)
+		return err
 	}
 
 	log.Printf("v%s of the Gatekeeper is now listeneing on %s", cfg.Version, gatekeeper.Addr())

--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -47,6 +47,10 @@ func authProviderFlag(usage string, required bool) cli.Flag {
 	return newPlaceholder("auth, a", "AUTHPROVIDER", usage, "", "TORUS_AUTH_PROVIDER", required)
 }
 
+func caFlag(usage string, required bool) cli.Flag {
+	return newPlaceholder("ca", "CA_BUNDLE", usage, "", "TORUS_BOOTSTRAP_CA", required)
+}
+
 func init() {
 	machines := cli.Command{
 		Name:      "machines",
@@ -143,6 +147,7 @@ func init() {
 					roleFlag("Role the machine will belong to", true),
 					machineFlag("Machine name to bootstrap", false),
 					orgFlag("Org the machine will belong to", false),
+					caFlag("CA Bundle to use for certificate verification. Uses system if none is provided", false),
 				},
 				Action: chain(checkRequiredFlags, bootstrapCmd),
 			},
@@ -437,6 +442,7 @@ func bootstrapCmd(ctx *cli.Context) error {
 		ctx.String("machine"),
 		ctx.String("org"),
 		ctx.String("role"),
+		ctx.String("ca"),
 	)
 	if err != nil {
 		return fmt.Errorf("bootstrap provision failed: %s", err)

--- a/gatekeeper/bootstrap/aws/bootstrap.go
+++ b/gatekeeper/bootstrap/aws/bootstrap.go
@@ -17,9 +17,12 @@ const (
 )
 
 // Bootstrap bootstraps a the AWS instance into a role to a given Gatekeeper instance
-func Bootstrap(url, name, org, role string) (*apitypes.BootstrapResponse, error) {
+func Bootstrap(url, name, org, role, caFile string) (*apitypes.BootstrapResponse, error) {
 	var err error
-	client := client.NewClient(url)
+	client, err := client.NewClient(url, caFile)
+	if err != nil {
+		return nil, fmt.Errorf("cannot initialize bootstrap client: %s", err)
+	}
 
 	identity, err := metadata()
 	if err != nil {

--- a/gatekeeper/bootstrap/bootstrap.go
+++ b/gatekeeper/bootstrap/bootstrap.go
@@ -17,10 +17,10 @@ const (
 )
 
 // Do will execute the bootstrap request for the given provider
-func Do(provider Provider, url, name, org, role string) (*apitypes.BootstrapResponse, error) {
+func Do(provider Provider, url, name, org, role, caFile string) (*apitypes.BootstrapResponse, error) {
 	switch provider {
 	case AWSPublic:
-		return aws.Bootstrap(url, name, org, role)
+		return aws.Bootstrap(url, name, org, role, caFile)
 
 	default:
 		return nil, fmt.Errorf("invalid provider: %s", provider)

--- a/gatekeeper/gatekeeper.go
+++ b/gatekeeper/gatekeeper.go
@@ -9,9 +9,12 @@ import (
 )
 
 // New returns a new Gatekeeper
-func New(org, team string, cfg *config.Config) (g *http.Gatekeeper, err error) {
+func New(org, team, certpath, keypath string, cfg *config.Config) (g *http.Gatekeeper, err error) {
 	api := api.NewClient(cfg)
-	http := http.NewGatekeeper(org, team, cfg, api)
+	http, err := http.NewGatekeeper(org, team, certpath, keypath, cfg, api)
+	if err != nil {
+		return nil, err
+	}
 
 	return http, nil
 }


### PR DESCRIPTION
This pull request starts to add optional SSL for the Gatekeeper bootstrap tool. This would start progress on #248.

This adds --cert, --key (`TORUS_GATEKEEPER_CERT` and `TORUS_GATEKEEPER_CERT_KEY`) to the `torus gatekeeper start` command, and `--ca` (`TORUS_BOOTSTRAP_CA`) to the `torus machines bootstrap` to start the service with TLS.

Some considerations: the certificate would need to be signed by a CA in the bootstrapping system's CA bundle. There may be cases where a user would use a self-signed cert, or a cert signed by an internal CA. In that case, the certificates would need to be added to the system's certificate bundle, or else the bootstrapping will fail on a bad certificate. The `--ca` flag will override using the system's certificate bundle.

It might be something to explore to do some automatic TLS through something like LetsEncrypt, if no certificates are provided, so that Gatekeeper is always over SSL.