### PR TITLE
fixed a small typo for the TeamMembers hint. the suggested command 't…

### DIFF
--- a/hints/hints.go
+++ b/hints/hints.go
@@ -94,7 +94,7 @@ func init() {
 			"Start your process with your decrypted secrets using `torus run`",
 		},
 		TeamMembers: {
-			"Display current members of your organization with `torus members member`",
+			"Display current members of your organization with `torus teams members member`",
 		},
 		View: {
 			"View secret values which have been set using `torus view`",


### PR DESCRIPTION
the suggested command `torus members member` should be `torus teams members member`

Signed-off-by: Matthew Roseman <mroseman95@gmail.com>