### PR TITLE
Wrap secret value with multiple words in quotes using view command

### DIFF
--- a/cmd/view.go
+++ b/cmd/view.go
@@ -81,10 +81,14 @@ func writeEnvFormat(w io.Writer, secrets []apitypes.CredentialEnvelope, path str
 	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
 
 	for _, secret := range secrets {
-		value := (*secret.Body).GetValue()
+		value := (*secret.Body).GetValue().String()
 		name := (*secret.Body).GetName()
 		key := strings.ToUpper(name)
-		fmt.Fprintf(w, "%s=%s\n", key, value.String())
+		if strings.Contains(value, " ") {
+			fmt.Fprintf(tw, "%s=%q\n", key, value)
+		} else {
+			fmt.Fprintf(tw, "%s=%s\n", key, value)
+		}
 	}
 
 	return tw.Flush()
@@ -95,11 +99,15 @@ func writeVerboseFormat(w io.Writer, secrets []apitypes.CredentialEnvelope, path
 
 	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
 	for _, secret := range secrets {
-		value := (*secret.Body).GetValue()
+		value := (*secret.Body).GetValue().String()
 		name := (*secret.Body).GetName()
 		key := strings.ToUpper(name)
 		spath := (*secret.Body).GetPathExp().String() + "/" + name
-		fmt.Fprintf(w, "%s=%s\t%s\n", key, value.String(), spath)
+		if strings.Contains(value, " ") {
+			fmt.Fprintf(tw, "%s=%q\t%s\n", key, value, spath)
+		} else {
+			fmt.Fprintf(tw, "%s=%s\t%s\n", key, value, spath)
+		}
 	}
 
 	return tw.Flush()

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -15,6 +15,7 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
+	"github.com/manifoldco/torus-cli/hints"
 )
 
 func init() {
@@ -73,6 +74,8 @@ func viewCmd(ctx *cli.Context) error {
 	default:
 		return errs.NewUsageExitError("Unknown format: "+format, ctx)
 	}
+
+	hints.Display(hints.Link, hints.Run)
 
 	return err
 }

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -23,7 +23,7 @@ func TestWriteEnvFormat(t *testing.T) {
 	err := writeEnvFormat(w, creds, path)
 
 	expected := `FOO=bar
-BAZ=two words
+BAZ="two words"
 `
 	w.Flush()
 	got := string(buf.Bytes())
@@ -48,7 +48,7 @@ func TestWriteVerboseFormat(t *testing.T) {
 	expected := `Credential path: /o/p/e/s/*/i
 
 FOO=bar	/o/p/e/s/*/i/foo
-BAZ=two words	/o/p/e/s/*/i/baz
+BAZ="two words"	/o/p/e/s/*/i/baz
 `
 	w.Flush()
 	got := string(buf.Bytes())

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/pathexp"
+)
+
+type secretPair struct {
+	key   string
+	value string
+}
+
+func TestWriteEnvFormat(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	creds, path := viewCredentialsHelper(t)
+
+	err := writeEnvFormat(w, creds, path)
+
+	expected := `FOO=bar
+BAZ=two words
+`
+	w.Flush()
+	got := string(buf.Bytes())
+
+	if err != nil {
+		t.Errorf("writeEnvFormat() expected no errors, got %s", err)
+	}
+
+	if expected != got {
+		t.Errorf("writeEnvFormat() expected\n%q\ngot\n%q\n", expected, got)
+	}
+}
+
+func TestWriteVerboseFormat(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	creds, path := viewCredentialsHelper(t)
+
+	err := writeVerboseFormat(w, creds, path)
+
+	expected := `Credential path: /o/p/e/s/*/i
+
+FOO=bar	/o/p/e/s/*/i/foo
+BAZ=two words	/o/p/e/s/*/i/baz
+`
+	w.Flush()
+	got := string(buf.Bytes())
+
+	if err != nil {
+		t.Errorf("writeVerboseFormat() expected no errors, got %s", err)
+	}
+
+	if expected != got {
+		t.Errorf("writeVerboseFormat() expected\n%qgot\n%q", expected, got)
+	}
+}
+
+func TestWriteJSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	creds, path := viewCredentialsHelper(t)
+
+	err := writeJSONFormat(w, creds, path)
+
+	expected := `{
+  "baz": "two words",
+  "foo": "bar"
+}
+`
+	w.Flush()
+	got := string(buf.Bytes())
+
+	if err != nil {
+		t.Errorf("writeJSONFormat() expected no errors, got %s", err)
+	}
+
+	if expected != got {
+		t.Errorf("writeJSONFormat() expected\n%qgot\n%q", expected, got)
+	}
+}
+
+func viewCredentialsHelper(t *testing.T) ([]apitypes.CredentialEnvelope, string) {
+	var creds []apitypes.CredentialEnvelope
+
+	pairs := []secretPair{
+		{key: "foo", value: "bar"},
+		{key: "baz", value: "two words"},
+	}
+
+	path := "/o/p/e/s/*/i"
+	exp, err := pathexp.Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, s := range pairs {
+		val := map[string]interface{}{
+			"version": 2,
+			"body": map[string]interface{}{
+				"type":  "string",
+				"value": s.value,
+			},
+		}
+
+		cval, err := interfaceToCredentialValue(t, val)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var cBody apitypes.Credential
+		cBodyV2 := apitypes.CredentialV2{
+			State: "set",
+			BaseCredential: apitypes.BaseCredential{
+				Name:    s.key,
+				PathExp: exp,
+				Value:   cval,
+			},
+		}
+		cBody = &cBodyV2
+		cred := apitypes.CredentialEnvelope{Body: &cBody}
+		creds = append(creds, cred)
+	}
+
+	return creds, path
+}

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -47,8 +47,8 @@ func TestWriteVerboseFormat(t *testing.T) {
 
 	expected := `Credential path: /o/p/e/s/*/i
 
-FOO=bar	/o/p/e/s/*/i/foo
-BAZ="two words"	/o/p/e/s/*/i/baz
+FOO=bar          /o/p/e/s/*/i/foo
+BAZ="two words"  /o/p/e/s/*/i/baz
 `
 	w.Flush()
 	got := string(buf.Bytes())


### PR DESCRIPTION
Closes #265

I changed the printXXXFormat APIs to accept an `io.Writer` instead of always using `os.Stdout`. Makes easier to test and we can combine with another writers if needed.

I also removed the hint from the view command because the text is added to the output file when redirecting. 
Eg: `torus view > secret.env` has at the end:

```
[1mProtip: [0mDefine an organization and project for your current working directory using `torus link`
```

Probably a better approach would be to disable hints whenever stdout is not printing to the terminal.