### PR TITLE
Use docker-ce instead of docker-engine for Docker on Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 - docker
 before_install:
 - sudo apt-get update
-- sudo apt-get -o Dpkg::Options::="--force-confnew" install -y --force-yes docker-engine
+- sudo apt-get -o Dpkg::Options::="--force-confnew" install -y --force-yes docker-ce
 cache:
   apt: true
   directories:


### PR DESCRIPTION
On June 21st Travis CI updated their Ubuntu Trusty installations (https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2 and https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch), which seems to have changed the `docker-engine` package to be `docker-ce` based on Docker's updated naming scheme.

This PR changes to apt-get to install `docker-ce` instead of `docker-engine`