### PR TITLE
Fix bugs in version checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ _Unreleased_
 **Fixes**
 
 - Daemon will no longer crash if it fails to retrieve the latest version
-- Update checking is now on by default
+- Update checking is now on by default after being disabled in `v0.24.2`
+- Daemon will now check for updates on startup along with every day at 6am
 
 ## v0.24.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+_Unreleased_
+
+**Fixes**
+
+- Daemon will no longer crash if it fails to retrieve the latest version
+- Update checking is now on by default
+
 ## v0.24.2
 
 _2017-10-25_

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	LastUpdatePath    string
 
 	RegistryURI *url.URL
+	ManifestURI *url.URL
 	CABundle    *x509.CertPool
 	PublicKey   *prefs.PublicKey
 }
@@ -61,6 +62,11 @@ func NewConfig(torusRoot string) (*Config, error) {
 		return nil, fmt.Errorf("invalid registry_uri")
 	}
 
+	manifestURI, err := url.Parse(preferences.Core.ManifestURI)
+	if err != nil {
+		return nil, fmt.Errorf("invalid manifest_uri")
+	}
+
 	_, _, err = net.SplitHostPort(preferences.Core.GatekeeperAddress)
 	if err != nil {
 		return nil, fmt.Errorf("invalid gatekeeper listener address")
@@ -77,6 +83,7 @@ func NewConfig(torusRoot string) (*Config, error) {
 		LastUpdatePath:    path.Join(torusRoot, "last_update"),
 
 		RegistryURI:       registryURI,
+		ManifestURI:       manifestURI,
 		GatekeeperAddress: preferences.Core.GatekeeperAddress,
 		CABundle:          caBundle,
 		PublicKey:         publicKey,

--- a/daemon/socket/proxy.go
+++ b/daemon/socket/proxy.go
@@ -2,14 +2,12 @@ package socket
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/facebookgo/httpdown"
@@ -73,14 +71,6 @@ func NewAuthProxy(c *config.Config, sess session.Session, db *db.DB, t *http.Tra
 		logic:   logic,
 		updates: updates,
 	}, nil
-}
-
-// CreateHTTPTransport creates and configures the
-func CreateHTTPTransport(cfg *config.Config) *http.Transport {
-	return &http.Transport{TLSClientConfig: &tls.Config{
-		ServerName: strings.Split(cfg.RegistryURI.Host, ":")[0],
-		RootCAs:    cfg.CABundle,
-	}}
 }
 
 // Listen starts the main loop of the AuthProxy. It returns on error, or when

--- a/daemon/updates/updates.go
+++ b/daemon/updates/updates.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	url              = "https://get.torus.sh/manifest.json"
 	releaseHourCheck = 6 // Check updates at 6am
 )
 
@@ -223,13 +222,12 @@ func (e *Engine) getLastCheck() error {
 }
 
 func (e *Engine) getLatestVersion() (string, error) {
-	resp, err := http.Get(url)
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
+	resp, err := http.Get(e.config.ManifestURI.String())
 	if err != nil {
-		return "", fmt.Errorf("cannot get info: %s", err)
+		return "", fmt.Errorf("cannot get info from %s: %s", e.config.ManifestURI, err)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("unsuccessful response: %d", resp.StatusCode)
 	}

--- a/daemon/updates/updates_test.go
+++ b/daemon/updates/updates_test.go
@@ -22,6 +22,7 @@ func makeEngine(uri string) *Engine {
 	return &Engine{
 		config: &config.Config{
 			ManifestURI: u,
+			Version:     "0.1.0",
 		},
 	}
 }
@@ -205,6 +206,44 @@ func TestGetLatestCheck(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "cannot get info from") {
 			t.Errorf("received different error than expected: %s", err)
+		}
+	})
+}
+
+func TestNeedsUpdate(t *testing.T) {
+	t.Run("current newer than target", func(t *testing.T) {
+		e := makeEngine(fakeUrl)
+		e.targetVersion = "0.0.1"
+
+		if e.needsUpdate() != false {
+			t.Error("should not need to update")
+		}
+	})
+
+	t.Run("current same as target", func(t *testing.T) {
+		e := makeEngine(fakeUrl)
+		e.targetVersion = e.config.Version
+
+		if e.needsUpdate() != false {
+			t.Error("should not need to update")
+		}
+	})
+
+	t.Run("current older than target", func(t *testing.T) {
+		e := makeEngine(fakeUrl)
+		e.targetVersion = "0.2.0"
+
+		if e.needsUpdate() != true {
+			t.Error("should need to update")
+		}
+	})
+
+	t.Run("target is unknown", func(t *testing.T) {
+		e := makeEngine(fakeUrl)
+		e.targetVersion = "unknown"
+
+		if e.needsUpdate() != false {
+			t.Error("should not need to update")
 		}
 	})
 }

--- a/daemon/updates/updates_test.go
+++ b/daemon/updates/updates_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/manifoldco/torus-cli/config"
 )
 
-var fakeUrl = "http://hellothisdomaincantexistright:54432/test.json"
+var fakeURL = "http://hellothisdomaincantexistright:54432/test.json"
 
 func makeEngine(uri string) *Engine {
 	u, err := url.Parse(uri)
@@ -24,6 +24,7 @@ func makeEngine(uri string) *Engine {
 			ManifestURI: u,
 			Version:     "0.1.0",
 		},
+		client: http.DefaultClient,
 	}
 }
 
@@ -197,7 +198,7 @@ func TestGetLatestCheck(t *testing.T) {
 	})
 
 	t.Run("cannot reach server", func(t *testing.T) {
-		e := makeEngine(fakeUrl)
+		e := makeEngine(fakeURL)
 
 		_, err := e.getLatestVersion()
 		if err == nil {
@@ -212,7 +213,7 @@ func TestGetLatestCheck(t *testing.T) {
 
 func TestNeedsUpdate(t *testing.T) {
 	t.Run("current newer than target", func(t *testing.T) {
-		e := makeEngine(fakeUrl)
+		e := makeEngine(fakeURL)
 		e.targetVersion = "0.0.1"
 
 		if e.needsUpdate() != false {
@@ -221,7 +222,7 @@ func TestNeedsUpdate(t *testing.T) {
 	})
 
 	t.Run("current same as target", func(t *testing.T) {
-		e := makeEngine(fakeUrl)
+		e := makeEngine(fakeURL)
 		e.targetVersion = e.config.Version
 
 		if e.needsUpdate() != false {
@@ -230,7 +231,7 @@ func TestNeedsUpdate(t *testing.T) {
 	})
 
 	t.Run("current older than target", func(t *testing.T) {
-		e := makeEngine(fakeUrl)
+		e := makeEngine(fakeURL)
 		e.targetVersion = "0.2.0"
 
 		if e.needsUpdate() != true {
@@ -239,7 +240,7 @@ func TestNeedsUpdate(t *testing.T) {
 	})
 
 	t.Run("target is unknown", func(t *testing.T) {
-		e := makeEngine(fakeUrl)
+		e := makeEngine(fakeURL)
 		e.targetVersion = "unknown"
 
 		if e.needsUpdate() != false {

--- a/daemon/updates/updates_test.go
+++ b/daemon/updates/updates_test.go
@@ -1,9 +1,30 @@
 package updates
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/manifoldco/torus-cli/config"
 )
+
+var fakeUrl = "http://hellothisdomaincantexistright:54432/test.json"
+
+func makeEngine(uri string) *Engine {
+	u, err := url.Parse(uri)
+	if err != nil {
+		panic("could not parse url")
+	}
+
+	return &Engine{
+		config: &config.Config{
+			ManifestURI: u,
+		},
+	}
+}
 
 type nextCheckExample struct {
 	now       time.Time
@@ -91,4 +112,99 @@ func TestNextCheck(t *testing.T) {
 			t.Fatalf("expected %s, got %s", example.expected, d)
 		}
 	}
+}
+
+func TestGetLatestCheck(t *testing.T) {
+	t.Run("200 valid json response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.Header().Add("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusOK)
+			rw.Write([]byte(`{"version":"0.24.1","released":"2017-09-25T04:06:19-03:00"}`))
+		}))
+		defer srv.Close()
+
+		e := makeEngine(srv.URL)
+
+		v, err := e.getLatestVersion()
+		if err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+
+		if v != "0.24.1" {
+			t.Errorf("expected `0.24.1` got %s", v)
+		}
+	})
+
+	t.Run("200 invalid json response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.Header().Add("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusOK)
+			rw.Write([]byte(`{"version":"0.24.1","released":"2017-09-25T04:06:19-03:00`))
+		}))
+		defer srv.Close()
+
+		e := makeEngine(srv.URL)
+
+		_, err := e.getLatestVersion()
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "cannot decode response body") {
+			t.Errorf("received different error than expected: %s", err)
+		}
+	})
+
+	t.Run("200 with no body response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.Header().Add("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusOK)
+			rw.Write([]byte{})
+		}))
+		defer srv.Close()
+
+		e := makeEngine(srv.URL)
+
+		_, err := e.getLatestVersion()
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "cannot decode response body") {
+			t.Errorf("received different error than expected: %s", err)
+		}
+	})
+
+	t.Run("non-200 response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.Header().Add("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusNotFound)
+			rw.Write([]byte{})
+		}))
+		defer srv.Close()
+
+		e := makeEngine(srv.URL)
+
+		_, err := e.getLatestVersion()
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "unsuccessful response") {
+			t.Errorf("received different error than expected: %s", err)
+		}
+	})
+
+	t.Run("cannot reach server", func(t *testing.T) {
+		e := makeEngine(fakeUrl)
+
+		_, err := e.getLatestVersion()
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "cannot get info from") {
+			t.Errorf("received different error than expected: %s", err)
+		}
+	})
 }

--- a/daemon/utils/utils.go
+++ b/daemon/utils/utils.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+)
+
+// CreateHTTPTransport creates and configures the
+func CreateHTTPTransport(caBundle *x509.CertPool, hostname string) *http.Transport {
+	return &http.Transport{TLSClientConfig: &tls.Config{
+		ServerName: hostname,
+		RootCAs:    caBundle,
+	}}
+}

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -16,6 +16,7 @@ import (
 const (
 	rcFilename        = ".torusrc"
 	registryURI       = "https://registry.arigato.sh"
+	manifestURI       = "https://get.torus.sh/manifest.json"
 	gatekeeperAddress = "0.0.0.0:8200"
 )
 
@@ -47,6 +48,7 @@ type Core struct {
 	PublicKeyFile      string `ini:"public_key_file,omitempty"`
 	CABundleFile       string `ini:"ca_bundle_file,omitempty"`
 	RegistryURI        string `ini:"registry_uri,omitempty"`
+	ManifestURI        string `ini:"manifest_uri,omitempty"`
 	GatekeeperAddress  string `ini:"gatekeeper_address"`
 	Context            bool   `ini:"context,omitempty"`
 	AutoConfirm        bool   `ini:"auto_confirm,omitempty"`
@@ -129,6 +131,7 @@ func NewPreferences() (*Preferences, error) {
 	prefs := &Preferences{
 		Core: Core{
 			RegistryURI:        registryURI,
+			ManifestURI:        manifestURI,
 			GatekeeperAddress:  gatekeeperAddress,
 			Context:            true,
 			EnableHints:        true,

--- a/primitive/zz_generated_primitive.go
+++ b/primitive/zz_generated_primitive.go
@@ -62,13 +62,13 @@ func (t *BaseKeyring) MarshalJSON() ([]byte, error) {
 	return b, nil
 }
 
-// Type returns the enumerated byte representation of User.
-func (t *User) Type() byte {
+// Type returns the enumerated byte representation of UserV1.
+func (t *UserV1) Type() byte {
 	return 0x01
 }
 
-// Type returns the enumerated byte representation of UserV1.
-func (t *UserV1) Type() byte {
+// Type returns the enumerated byte representation of User.
+func (t *User) Type() byte {
 	return 0x01
 }
 
@@ -276,69 +276,6 @@ func (t *Claim) Type() byte {
 	return 0x08
 }
 
-// MarshalJSON implements the json.Marshaler interface for Keyring.
-func (t *Keyring) MarshalJSON() ([]byte, error) {
-	var ob []byte
-	var err error
-	b := []byte{'{'}
-
-	b = append(b, []byte(`"created_at":`)...)
-	ob, err = json.Marshal(t.Created)
-	if err != nil {
-		return nil, err
-	}
-	b = append(b, ob...)
-
-	b = append(b, ',')
-	b = append(b, []byte(`"org_id":`)...)
-	ob, err = json.Marshal(t.OrgID)
-	if err != nil {
-		return nil, err
-	}
-	b = append(b, ob...)
-
-	b = append(b, ',')
-	b = append(b, []byte(`"pathexp":`)...)
-	ob, err = json.Marshal(t.PathExp)
-	if err != nil {
-		return nil, err
-	}
-	b = append(b, ob...)
-
-	b = append(b, ',')
-	b = append(b, []byte(`"previous":`)...)
-	ob, err = json.Marshal(t.Previous)
-	if err != nil {
-		return nil, err
-	}
-	b = append(b, ob...)
-
-	b = append(b, ',')
-	b = append(b, []byte(`"project_id":`)...)
-	ob, err = json.Marshal(t.ProjectID)
-	if err != nil {
-		return nil, err
-	}
-	b = append(b, ob...)
-
-	b = append(b, ',')
-	b = append(b, []byte(`"version":`)...)
-	ob, err = json.Marshal(t.KeyringVersion)
-	if err != nil {
-		return nil, err
-	}
-	b = append(b, ob...)
-
-	b = append(b, '}')
-
-	return b, nil
-}
-
-// Type returns the enumerated byte representation of Keyring.
-func (t *Keyring) Type() byte {
-	return 0x09
-}
-
 // MarshalJSON implements the json.Marshaler interface for KeyringV1.
 func (t *KeyringV1) MarshalJSON() ([]byte, error) {
 	var ob []byte
@@ -399,6 +336,69 @@ func (t *KeyringV1) MarshalJSON() ([]byte, error) {
 
 // Type returns the enumerated byte representation of KeyringV1.
 func (t *KeyringV1) Type() byte {
+	return 0x09
+}
+
+// MarshalJSON implements the json.Marshaler interface for Keyring.
+func (t *Keyring) MarshalJSON() ([]byte, error) {
+	var ob []byte
+	var err error
+	b := []byte{'{'}
+
+	b = append(b, []byte(`"created_at":`)...)
+	ob, err = json.Marshal(t.Created)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, ob...)
+
+	b = append(b, ',')
+	b = append(b, []byte(`"org_id":`)...)
+	ob, err = json.Marshal(t.OrgID)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, ob...)
+
+	b = append(b, ',')
+	b = append(b, []byte(`"pathexp":`)...)
+	ob, err = json.Marshal(t.PathExp)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, ob...)
+
+	b = append(b, ',')
+	b = append(b, []byte(`"previous":`)...)
+	ob, err = json.Marshal(t.Previous)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, ob...)
+
+	b = append(b, ',')
+	b = append(b, []byte(`"project_id":`)...)
+	ob, err = json.Marshal(t.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, ob...)
+
+	b = append(b, ',')
+	b = append(b, []byte(`"version":`)...)
+	ob, err = json.Marshal(t.KeyringVersion)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, ob...)
+
+	b = append(b, '}')
+
+	return b, nil
+}
+
+// Type returns the enumerated byte representation of Keyring.
+func (t *Keyring) Type() byte {
 	return 0x09
 }
 

--- a/tools/primitive-boilerplate/main.go
+++ b/tools/primitive-boilerplate/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"go/ast"
 	"go/format"
 	"go/parser"
@@ -61,9 +62,21 @@ type field struct {
 
 type sortData []data
 
-func (d sortData) Len() int           { return len(d) }
-func (d sortData) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
-func (d sortData) Less(i, j int) bool { return strings.Compare(d[i].Byte, d[j].Byte) < 0 }
+func (d sortData) Len() int      { return len(d) }
+func (d sortData) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d sortData) Less(i, j int) bool {
+	v := strings.Compare(d[i].Byte, d[j].Byte)
+	switch v {
+	case -1:
+		return true
+	case 0:
+		return d[i].Version < d[j].Version
+	case 1:
+		return false
+	default:
+		panic(fmt.Sprintf("unknown value: %d", v))
+	}
+}
 
 type sortFields []field
 
@@ -74,9 +87,11 @@ func (s sortFields) Less(i, j int) bool { return strings.Compare(s[i].Name, s[j]
 // sortDataByVersion sorts data by schema version, for envelope output.
 type sortDataByVersion []data
 
-func (d sortDataByVersion) Len() int           { return len(d) }
-func (d sortDataByVersion) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
-func (d sortDataByVersion) Less(i, j int) bool { return d[i].Version < d[j].Version }
+func (d sortDataByVersion) Len() int      { return len(d) }
+func (d sortDataByVersion) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d sortDataByVersion) Less(i, j int) bool {
+	return d[i].Version < d[j].Version
+}
 
 // envTmplData is the data passed for populating the envelope package template
 // file, defined here for convenience.


### PR DESCRIPTION
This pull request contains several changes to fix various bigs inside the version checking code.

- The daemon will no longer crash if it cannot talk to `get.torus.sh` for any reason
- The daemon will check for the latest version at start up *and* its regular interval
- The daemon now leverages the CABundle for retrieving the manifest from `get.torus.sh`

Closes manifoldco/torus-cli#261