### PR TITLE
Add import documentation and support multi-credential creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ _Unreleased_
 **Notable Changes**
 
 - Windows is now advertised as a supported platform via npm installation.
+- Introducing `torus import`, making it simple to import multiple secrets from
+  a single `.env` file!
 
 **Fixes**
 
@@ -17,6 +19,10 @@ _Unreleased_
 - Daemon will now check for updates on startup along with every day at 6am
 - Torus is now compiled using go1.9.1
 - Torus now supports installation from brew via a bottle on Mac OS X High Sierra
+
+**Thanks**
+
+- Luiz Branco
 
 ## v0.24.2
 

--- a/daemon/routes/credentials.go
+++ b/daemon/routes/credentials.go
@@ -61,10 +61,10 @@ func credentialsGetRoute(engine *logic.Engine, o *observer.Observer) http.Handle
 func credentialsPostRoute(engine *logic.Engine, o *observer.Observer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		cred := &logic.PlaintextCredentialEnvelope{}
+		creds := []*logic.PlaintextCredentialEnvelope{}
 
 		dec := json.NewDecoder(r.Body)
-		err := dec.Decode(cred)
+		err := dec.Decode(&creds)
 		if err != nil {
 			log.Printf("error decoding credential: %s", err)
 			encodeResponseErr(w, err)
@@ -78,7 +78,7 @@ func credentialsPostRoute(engine *logic.Engine, o *observer.Observer) http.Handl
 			return
 		}
 
-		cred, err = engine.AppendCredential(ctx, n, cred)
+		creds, err = engine.AppendCredentials(ctx, n, creds)
 		if err != nil {
 			// Rely on logs inside engine for debugging
 			encodeResponseErr(w, err)
@@ -88,7 +88,7 @@ func credentialsPostRoute(engine *logic.Engine, o *observer.Observer) http.Handl
 		n.Notify(observer.Finished, "Completed Operation", true)
 
 		enc := json.NewEncoder(w)
-		err = enc.Encode(cred)
+		err = enc.Encode(creds)
 		if err != nil {
 			log.Printf("error encoding credential create resp: %s", err)
 			encodeResponseErr(w, err)

--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -3,7 +3,7 @@ The Torus CLI is used to set and access secrets and config. Each value is encryp
 
 A secret is a single piece of configuration which should be encrypted.
 
-Torus exposes your decrypted secrets to your process through environment variables. This means that anything you can store in an environment variable, you can set in Torus. Support for file storage (such as certificates) is planned, but not currently supported.  
+Torus exposes your decrypted secrets to your process through environment variables. This means that anything you can store in an environment variable, you can set in Torus. Support for file storage (such as certificates) is planned, but not currently supported.
 
 ### Command Options
 
@@ -30,10 +30,36 @@ This is how all secrets are stored in Torus.
 
 `torus unset <name|path>` unsets the value for the specified name (or [path](../concepts/path.md)).
 
+## import
+###### Added [v0.25.0](https://github.com/manifoldco/torus-cli/blob/v0.25.0/CHANGELOG.md)
+
+`torus import <file>` or using stdin redirection (e.g. `torus import -e production <prod.env`) imports the contents of an `.env` file to the specified path.
+
+**Example**
+
+```
+$ cat prod.env
+PORT=4000
+DOMAIN=mydomain.co
+MYSQL_URL=mysql://user:pass@host.com:4321/mydb
+
+$ torus import -e production test.env
+
+Credentials retrieved
+Keypairs retrieved
+Encrypting key retrieved
+Credential encrypted
+Credential encrypted
+Completed Operation
+
+Credential x has been set at /myorg/myproject/production/default/*/*/PORT
+Credential b has been set at /myorg/myproject/production/default/*/*/MYSQL_URL
+```
+
 ## view
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus view` displays secrets in the current [context](./project-structure.md#link). 
+`torus view` displays secrets in the current [context](./project-structure.md#link).
 
 By default items are displayed in environment variable format.
 

--- a/internal/qa.md
+++ b/internal/qa.md
@@ -174,3 +174,4 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
         the command
 - [ ]   `torus run <command>` without a service defaults to "default" service
 - [ ]   `torus unset [key] —service [service]` will unset the variable
+- [ ]   `torus import` imports multiple secrets from a file

--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -13,8 +13,8 @@ type Credentials struct {
 }
 
 // Create creates the provided credential in the registry.
-func (c *Credentials) Create(ctx context.Context, credential *envelope.Credential) (*envelope.Credential, error) {
-	resp := &envelope.Credential{}
-	err := c.client.RoundTrip(ctx, "POST", "/credentials", nil, credential, &resp)
+func (c *Credentials) Create(ctx context.Context, creds []envelope.CredentialInf) ([]*envelope.Credential, error) {
+	resp := []*envelope.Credential{}
+	err := c.client.RoundTrip(ctx, "POST", "/credentials", nil, creds, &resp)
 	return resp, err
 }


### PR DESCRIPTION
To speed up `torus import`, we now send multiple credentials to the
server in a single request.