### PR TITLE
Advertise torus installation via npm on win32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 _Unreleased_
 
+**Notable Changes**
+
+- Windows is now advertised as a supported platform via npm installation.
+
 **Fixes**
 
 - Daemon will no longer crash if it fails to retrieve the latest version

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ sudo tee /etc/apt/sources.list.d/torus.list <<< "deb https://get.torus.sh/$DISTR
 - [npm](https://www.npmjs.com): `npm install -g torus-cli`
 - bare zip archives per release version are available on https://get.torus.sh/
 
-### Windows (Preview)
+### Windows (Alpha)
+
+Install torus via npm using `npm install -g torus-cli` or manally using the
+steps below!
 
 - Get the desired version on [https://get.torus.sh/](https://get.torus.sh/)
 - Unzip the file

--- a/packaging/npm/package.json.in
+++ b/packaging/npm/package.json.in
@@ -9,7 +9,7 @@
   "os": [
     "darwin",
     "linux",
-    "!win32"
+    "win32"
   ],
   "cpu": [
     "x64"


### PR DESCRIPTION
Now that we have a win32 alpha client, let's advertise it's support on
win32 via npm! Conventiantly, this also gives us an installation
mechanism for the windows alpha!