### PR TITLE
Fallback to spawn if kexec not available via npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 _Unreleased_
 
+**Fixes**
+
+- Fixed a bug preventing Torus from being used once installed via npm on win32.
+
 ## v0.25.1
 
 _2017-10-16_

--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,9 @@ NPM_DEPS=\
 	builds/npm/LICENSE.md \
 	builds/npm/bin/torus \
 	builds/npm/bin/torus-darwin-amd64 \
-	builds/npm/bin/torus-linux-amd64
+	builds/npm/bin/torus-linux-amd64 \
+	builds/npm/bin/torus.exe
+
 npm: $(NPM_DEPS)
 
 builds/npm builds/npm/bin builds/npm/scripts:
@@ -443,6 +445,9 @@ builds/npm/bin/torus-darwin-amd64: builds/bin/$(VERSION)/darwin/amd64/torus buil
 	cp $< $@
 
 builds/npm/bin/torus-linux-amd64: builds/bin/$(VERSION)/linux/amd64/torus builds/npm/bin
+	cp $< $@
+
+builds/npm/bin/torus.exe: builds/bin/$(VERSION)/windows/amd64/torus.exe builds/npm/bin
 	cp $< $@
 
 builds/torus-npm-$(VERSION).tar.gz: npm

--- a/packaging/npm/package.json.in
+++ b/packaging/npm/package.json.in
@@ -33,9 +33,9 @@
   ],
   "logo": "https://s3.amazonaws.com/manifold.co/torus_logo.png",
   "license": "BSD-3-Clause",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {},
+  "optionalDependencies": {
     "kexec": "^3.0.0"
-  },
-  "devDependencies": {
   }
 }

--- a/packaging/npm/passthrough.js
+++ b/packaging/npm/passthrough.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 var path = require('path');
-var kexec = require('kexec');
 
 // os and arch restrictions are handled by the package.json
 var os = process.platform;
@@ -10,4 +9,27 @@ var arch = 'amd64';
 // arguments. This is a true exec(3), which will take over the pid, env, and
 // file descriptors.
 var torusPath = path.join(__dirname, '../bin/torus-' + os + '-' + arch);
-kexec(torusPath, process.argv.slice(2));
+if (os === 'win32') {
+  torusPath = path.join(__dirname, '../bin/torus.exe');
+}
+
+try {
+  var kexec = require('kexec');
+  kexec(torusPath, process.argv.slice(2));
+} catch (err) {
+  if (err.code !== 'MODULE_NOT_FOUND') {
+    console.error('Could not leverage kexec due to error: ' + err.message);
+  }
+
+  var spawn = require('child_process').spawn;
+  var proc = spawn(torusPath, process.argv.slice(2), { stdio: 'inherit' });
+  proc.on('exit', function (code, signal) {
+    process.on('exit', function () {
+      if (signal) {
+        process.kill(process.pid, signal);
+      } else {
+        process.exit(code);
+      }
+    });
+  });
+}


### PR DESCRIPTION
If a user installs `torus` but fails to install `kexec` then
`passthrough.js` will fallback to spawning torus in a child process
instead of having it inherit the current process.

Conditional installation of `kexec` is handled by the
`optionalDependencies` section of the `package.json`.

Closes #284