### PR TITLE
Use gometalinter --install to acquire linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,13 @@ ci: binary $(LINTERS) cmdlint test
 #################################################
 
 BOOTSTRAP=\
-	github.com/golang/lint/golint \
 	github.com/jteeuwen/go-bindata/... \
-	github.com/client9/misspell/cmd/misspell \
-	github.com/gordonklaus/ineffassign \
-	github.com/tsenart/deadcode \
 	github.com/alecthomas/gometalinter
 
 $(BOOTSTRAP):
 	go get -u $@
 bootstrap: $(BOOTSTRAP)
+	gometalinter --install
 	glide -v || curl http://glide.sh/get | sh
 
 .PHONY: bootstrap $(BOOTSTRAP)


### PR DESCRIPTION
gometalinter recently switched from using go's built in `go vet` tool to
a fork to fix several bugs that their users have experienced. However as
a result this broke the Torus build as we were not using `gometalinter
--install` to bring in the various linters.

To fix this in the short term, I've switched our bootstrap setup to use
`gometalinter --install` and opened an issue for properly vendoring our
bootstrap dependencies (#286).

Ref Discussion: https://github.com/alecthomas/gometalinter/pull/375