### PR TITLE
Introduce 'torus policies attach'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 _Unreleased_
 
+**Notable Changes**
+
+- Introduced `torus policies attach` allowing a user to attach a policy to
+  multiple teams or machine roles.
+
 ## v0.25.2
 
 _2017-1019_

--- a/docs/commands/access-control.md
+++ b/docs/commands/access-control.md
@@ -53,7 +53,7 @@ A policy contains rules about which actions can be taken on specific resources. 
 
 Each default team has its own default policy, and can have additional policies attached to the team. You can view the [complete default policies here](../concepts/policies.md), in short:
 
-**Member team:** cannot manage resources, can set credentials in their own "dev-username" environment and share credentials through the "dev-\*"  
+**Member team:** cannot manage resources, can set credentials in their own "dev-username" environment and share credentials through the "dev-\*"
 environment.
 
 **Admin team:** has mostly full access. Can manage all resources: teams, policies, projects, environments, etc. Cannot add members to "owner" team.
@@ -66,33 +66,40 @@ Each command within this group must be supplied an Organization flag using `--or
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
 `torus policies list` displays all available policies for the specified organization.
-  
-Each row has a name, type (system or member), and list of teams the policy is attached to.  
+
+Each row has a name, type (system or member), and list of teams and machine roles the policy is attached to.
 
 ### view
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus policies view <name>` displays all of the rules within the named policy.  
+`torus policies view <name>` displays all of the rules within the named policy.
 
 Each row has the effect (allow or deny), the list of actions (crudl - create, read, update, delete, list), and the resource path.
 
 ### detach
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus policies detach <name> <team|role>` detaches the policy (identified by name) from the given team (or role).
+`torus policies detach <name> <team|machine-role>` detaches the policy (identified by name) from the given team (or machine role).
 
 This enables you to lift restrictions (or grants) from a team.
+
+### attach
+###### [v0.26.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
+
+`torus policies attach <name> <team|machine-role>` attaches the policy (identified by the poliy name) to the given team (or machine role).
+
+This enables you to re-use policies by attaching one to multiple teams and machine roles.
 
 ## allow
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus allow <crudl> <path> <team|role>` generates a new policy and attaches it to the given team (or role). The policy created is given a generated name.
+`torus allow <crudl> <path> <team|machine-role>` generates a new policy and attaches it to the given team (or machine role). The policy created is given a generated name.
 
 CRUDL (create, read, update, delete, list) represents the actions that are being granted. The supplied Path represents the resource that you are enabling the aforementioned actions on.
 
 ## deny
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus deny <crudl> <path> <team|role>` generates a new policy and attaches it to the given team (or role). The policy created is given a generated name.
+`torus deny <crudl> <path> <team|machine-role>` generates a new policy and attaches it to the given team (or machine role). The policy created is given a generated name.
 
 CRUDL (create, read, update, delete, list) represents the actions that are being denied (or restricted). The supplied Path represents the resource that you are disabling the aforementioned actions on.

--- a/docs/commands/organizations.md
+++ b/docs/commands/organizations.md
@@ -108,7 +108,7 @@ Machines are a method of authenticating systems which are not owned by an indivi
 
 Each machine is given an ID and Token value which are synonymous with a user’s email and password. These are used to authenticate the CLI on a per-system basis.
 
-Roles are assigned to each machine for [access control](./access-control.md).
+Machine roles are assigned to each machine for [access control](./access-control.md).
 
 ### create
 ###### Added [v0.15.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
@@ -122,7 +122,7 @@ A machine is given a unique name within the organization that adheres to the sys
 
 `torus machines list` displays all available machines for the specified organization.
 
-The Machine listing can be filtered using the role or destroyed command options.
+The Machine listing can be filtered using the `--role` or `--destroyed` command options.
 
 ### view
 ###### Added [v0.15.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
@@ -137,16 +137,16 @@ The Machine listing can be filtered using the role or destroyed command options.
 ### roles
 Machines are given roles (similar to how users are added to teams) which enable you to finely control what a machine has access to when deployed.
 
-Once created a role can have any number of policies attached to it.
+Once created a machine role can have any number of policies attached to it.
 
 #### create
 ###### Added [v0.16.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus machines roles create <name>` creates a new role for the specified organization.
+`torus machines roles create <name>` creates a new machine role for the specified organization.
 
-A role is given a unique name within the organization’s roles that adheres to the system naming scheme.
+A machine role is given a unique name within an organization that adheres to the system naming scheme.
 
 #### list
 ###### Added [v0.16.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus machines roles list` displays all available roles for the specified organization.
+`torus machines roles list` displays all available machine roles for the specified organization.

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -1,7 +1,8 @@
 # Policies
 Torus CLI has resource-based policies for access control. In order to facilitate the basics of secret sharing we include three default policies.
 
-Policies are attached to teams and roles to construct what the members are entitled to access.
+Policies are attached to teams and machine roles to construct what the members are entitled to access.
+
 ## Default Policies
 The three default teams each have their own default policy.
 
@@ -32,7 +33,7 @@ allow crudl /${org}/*/*/*/*/*/*
 ```
 
 ### Owner
-Based on the admin policy, owners are given full access to their Torus organization; however, by default they are the only ones permitted to add users to the "owner" team.  
+Based on the admin policy, owners are given full access to their Torus organization; however, by default they are the only ones permitted to add users to the "owner" team.
 
 ```
 allow crudl teams:*
@@ -46,4 +47,4 @@ allow crudl /${org}/*/*/*/*/*/*
 ```
 
 ## Machines
-Unlike users, machines are not automatically given access through default policies. A machine starts out with zero permissions and must have policies attached to its role to open its access.
+Unlike users, machines are not automatically given access through default policies. A machine starts out with zero permissions and must have policies attached to its machine role to open its access.

--- a/internal/qa.md
+++ b/internal/qa.md
@@ -81,6 +81,8 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 - [ ]   System policies cannot be detached
 - [ ]   `torus policies view [name]` displays statements contained within the
         policy
+- [ ]   A policy can be attached to multiple teams via `torus policies attach`
+- [ ]   A policy can be detached and reattached to a team
 
 ### Worklog/Keyring Versioning
 


### PR DESCRIPTION
This commit introduces the new `torus policies attach` command allowing
users to attach a policy to multiple teams and machine roles within an
organization.

Included is a small update to the documentation to clarify that a `role`
is a `machine-role`.