### PR TITLE
Introduce ability to name and describe a policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ _Unreleased_
 
 - Introduced `torus policies attach` allowing a user to attach a policy to
   multiple teams or machine roles.
+- When generating a policy using `torus allow` or `torus deny` you can now
+  specify it's name and description using the `--name` and `--description`
+  flags.
 
 ## v0.25.2
 

--- a/cmd/deny.go
+++ b/cmd/deny.go
@@ -12,7 +12,11 @@ func init() {
 		Usage:     "Decrease access given to a team or role by creating and attaching a new policy",
 		ArgsUsage: "<crudl> <path> <team|machine-role>",
 		Category:  "ACCESS CONTROL",
-		Action:    chain(ensureDaemon, ensureSession, denyCmd),
+		Flags: []cli.Flag{
+			nameFlag("The name to give the generated policy (e.g. allow-prod-env)"),
+			descriptionFlag("A sentence or two explaining what the generated policy does"),
+		},
+		Action: chain(ensureDaemon, ensureSession, denyCmd),
 	}
 
 	Cmds = append(Cmds, deny)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -25,9 +25,20 @@ var (
 	}
 )
 
+// formatFlag creates a new --format cli.Flag with custom usage string
 func formatFlag(defaultValue, description string) cli.Flag {
 	return newPlaceholder("format, f", "FORMAT", description,
 		defaultValue, "TORUS_FORMAT", false)
+}
+
+// nameFlag creates a new --name cli.Flag with custom usage string
+func nameFlag(description string) cli.Flag {
+	return newPlaceholder("name, n", "NAME", description, "", "TORUS_NAME", false)
+}
+
+// descriptionFlag creates a new --description, -d cli.Flag with custom usage string
+func descriptionFlag(description string) cli.Flag {
+	return newPlaceholder("description, d", "DESCRIPTION", description, "", "TORUS_DESCRIPTION", false)
 }
 
 // orgFlag creates a new --org cli.Flag with custom usage string.

--- a/docs/commands/access-control.md
+++ b/docs/commands/access-control.md
@@ -97,9 +97,37 @@ This enables you to re-use policies by attaching one to multiple teams and machi
 
 CRUDL (create, read, update, delete, list) represents the actions that are being granted. The supplied Path represents the resource that you are enabling the aforementioned actions on.
 
+If a name (`--name` flag) is not provided, one will be automatically generated.
+
+#### Command Options
+
+  Option | Description
+  ----   | -----
+  --name NAME, -n NAME | The name to give the generated policy (e.g. allow-prod-env)
+  --description DESCRIPTION, -d DESCRIPTION | A sentence or two explaining the purpose of the policy
+
+**Example**
+
+```bash
+# Create a policy allowing it's subjects to read secrets from prod environment
+# in the api project which belongs to the myorg organization and attach it to
+# the api-prod-machines machine role.
+$ torus allow -n read-api-prod-env rl /myorg/api/prod/*/*/*/* api-prod-machines
+```
+
 ## deny
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
 `torus deny <crudl> <path> <team|machine-role>` generates a new policy and attaches it to the given team (or machine role). The policy created is given a generated name.
 
 CRUDL (create, read, update, delete, list) represents the actions that are being denied (or restricted). The supplied Path represents the resource that you are disabling the aforementioned actions on.
+
+If a name (`--name` flag) is not provided, one will be automatically generated.
+
+#### Command Options
+
+  Option | Description
+  ----   | -----
+  --name NAME, -n NAME | The name to give the generated policy (e.g. allow-prod-env)
+  --description DESCRIPTION, -d DESCRIPTION | A sentence or two explaining the purpose of the policy
+

--- a/internal/qa.md
+++ b/internal/qa.md
@@ -83,6 +83,7 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
         policy
 - [ ]   A policy can be attached to multiple teams via `torus policies attach`
 - [ ]   A policy can be detached and reattached to a team
+- [ ]   A policy can be given a name and a description
 
 ### Worklog/Keyring Versioning
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -23,6 +23,15 @@ func Slug(input, fieldName string, errorMessage *string) error {
 	return errors.New(msg)
 }
 
+// Description validates whether the input meets the descriptin requirements
+func Description(input, fieldName string) error {
+	if len(input) <= 500 {
+		return nil
+	}
+
+	return errors.New(fieldName + " descriptions must be less than 500 characters")
+}
+
 // Email validates whether the input is a valid email format
 func Email(input string) error {
 	if govalidator.IsEmail(input) {


### PR DESCRIPTION
When generating a policy using `allow` and `deny` you can now specify a
name and description as optional command line flags.