### PR TITLE
Introduce the ability to delete a policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ _Unreleased_
 
 - Introduced `torus policies attach` allowing a user to attach a policy to
   multiple teams or machine roles.
+- Introduced `torus policies delete` allowing a user to delete a policy and all
+  of it's attachment from an org. System policies cannot be deleted.
 - When generating a policy using `torus allow` or `torus deny` you can now
   specify it's name and description using the `--name` and `--description`
   flags.

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -20,6 +20,7 @@ import (
 	"github.com/manifoldco/torus-cli/identity"
 	"github.com/manifoldco/torus-cli/pathexp"
 	"github.com/manifoldco/torus-cli/primitive"
+	"github.com/manifoldco/torus-cli/validate"
 )
 
 func init() {
@@ -79,6 +80,20 @@ func init() {
 			},
 
 			{
+				Name:      "delete",
+				Usage:     "Delete a policy from the organization",
+				ArgsUsage: "<name>",
+				Flags: []cli.Flag{
+					stdAutoAcceptFlag,
+					orgFlag("The org the policy belongs to", true),
+				},
+				Action: chain(
+					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+					setUserEnv, checkRequiredFlags, deletePolicyCmd,
+				),
+			},
+
+			{
 				Name:      "test",
 				Usage:     "Test a user's access to a path",
 				ArgsUsage: "<c|r|u|d|l> <username> <path>",
@@ -98,6 +113,7 @@ func init() {
 
 const policyDetachFailed = "Could not detach policy."
 const policyAttachFailed = "Could not attach policy."
+const policyDeleteFailed = "Could not delete policy."
 
 func attachPolicyCmd(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
@@ -114,6 +130,13 @@ func attachPolicyCmd(ctx *cli.Context) error {
 
 	policyName := args[0]
 	teamName := args[1]
+
+	if err := validate.Slug(policyName, "policy", nil); err != nil {
+		return errs.NewUsageExitError("Invalid policy name provided", ctx)
+	}
+	if err := validate.Slug(teamName, "team", nil); err != nil {
+		return errs.NewUsageExitError("Invalid team name provided", ctx)
+	}
 
 	client := api.NewClient(cfg)
 	c := context.Background()
@@ -209,6 +232,13 @@ func detachPolicyCmd(ctx *cli.Context) error {
 	policyName := args[0]
 	teamName := args[1]
 
+	if err := validate.Slug(policyName, "policy", nil); err != nil {
+		return errs.NewUsageExitError("Invalid policy name provided", ctx)
+	}
+	if err := validate.Slug(teamName, "team", nil); err != nil {
+		return errs.NewUsageExitError("Invalid team name provided", ctx)
+	}
+
 	client := api.NewClient(cfg)
 	c := context.Background()
 
@@ -239,6 +269,59 @@ func detachPolicyCmd(ctx *cli.Context) error {
 }
 
 const policyListFailed = "Could not list policies."
+
+func deletePolicyCmd(ctx *cli.Context) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(cfg)
+	c := context.Background()
+
+	args := ctx.Args()
+	if len(args) != 1 {
+		return errs.NewUsageExitError("A policy name must be provided", ctx)
+	}
+
+	policyName := args[0]
+	if err := validate.Slug(policyName, "policy", nil); err != nil {
+		return errs.NewUsageExitError("Invalid policy name provided", ctx)
+	}
+
+	org, err := client.Orgs.GetByName(c, ctx.String("org"))
+	if err != nil {
+		return errs.NewErrorExitError(policyDeleteFailed, err)
+	}
+	if org == nil {
+		return errs.NewExitError("Org not found.")
+	}
+
+	policies, err := client.Policies.List(c, org.ID, policyName)
+	if err != nil {
+		return errs.NewErrorExitError(policyDeleteFailed, err)
+	}
+
+	if len(policies) == 0 {
+		return errs.NewExitError("Policy not found.")
+	}
+
+	policy := policies[0]
+	preamble := fmt.Sprintf("You are about to delete the %s policy and all "+
+		"of it's attachments. This cannot be undone.", policyName)
+	err = ConfirmDialogue(ctx, nil, &preamble, "", true) // Will error if user does not confirm
+	if err != nil {
+		return err
+	}
+
+	err = client.Policies.Delete(c, policy.ID)
+	if err != nil {
+		return errs.NewErrorExitError(policyDeleteFailed, err)
+	}
+
+	fmt.Printf("\nPolicy %s and all of it's attachments have been deleted.\n", policyName)
+	return nil
+}
 
 func listPoliciesCmd(ctx *cli.Context) error {
 	cfg, err := config.LoadConfig()
@@ -345,6 +428,11 @@ func viewPolicyCmd(ctx *cli.Context) error {
 		return errs.NewUsageExitError(msg, ctx)
 	}
 
+	policyName := args[0]
+	if err := validate.Slug(policyName, "policy", nil); err != nil {
+		return errs.NewUsageExitError("Invalid policy name provided", ctx)
+	}
+
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		return err
@@ -361,13 +449,13 @@ func viewPolicyCmd(ctx *cli.Context) error {
 		return errs.NewExitError("Org not found.")
 	}
 
-	policies, err := client.Policies.List(c, org.ID, args[0])
+	policies, err := client.Policies.List(c, org.ID, policyName)
 	if err != nil {
 		return errs.NewExitError("Unable to list policies.")
 	}
 
 	if len(policies) < 1 {
-		return errs.NewExitError("Policy '" + args[0] + "' not found.")
+		return errs.NewExitError("Policy '" + policyName + "' not found.")
 	}
 
 	policy := policies[0]

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -89,6 +89,7 @@ func init() {
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
 					setUserEnv, checkRequiredFlags, testPolicies,
 				),
+				Hidden: true,
 			},
 		},
 	}

--- a/docs/commands/access-control.md
+++ b/docs/commands/access-control.md
@@ -15,6 +15,14 @@ The creator of the organization is automatically added to all three teams. Anyon
 
 Only users who are a member of the "admin" team can manage resources within an organization.
 
+### Command Options
+
+All teams commands accept the following flags:
+
+  Option | Description
+  ---- | ----
+  --org, ORG, -o ORG | The org the team or teams belong to
+
 ### create
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
@@ -62,6 +70,14 @@ environment.
 
 Each command within this group must be supplied an Organization flag using `--org <name>`, or `-o <name>` for short. The organization can also be supplied by executing these commands within a [linked directory](./project-structure.md#link).
 
+### Command Options
+
+All policies commands accept the following flags:
+
+  Option | Description
+  ---- | ----
+  --org, ORG, -o ORG | The org the policy or policies belong to
+
 ### list
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
@@ -76,6 +92,13 @@ Each row has a name, type (system or member), and list of teams and machine role
 
 Each row has the effect (allow or deny), the list of actions (crudl - create, read, update, delete, list), and the resource path.
 
+### attach
+###### Added [v0.26.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
+
+`torus policies attach <name> <team|machine-role>` attaches the policy (identified by the poliy name) to the given team (or machine role).
+
+This enables you to re-use policies by attaching one to multiple teams and machine roles.
+
 ### detach
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
@@ -83,12 +106,20 @@ Each row has the effect (allow or deny), the list of actions (crudl - create, re
 
 This enables you to lift restrictions (or grants) from a team.
 
-### attach
-###### [v0.26.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
+### delete
+###### Added [v0.26.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus policies attach <name> <team|machine-role>` attaches the policy (identified by the poliy name) to the given team (or machine role).
+`torus policies delete <name>` deletes a policy and all of it's attachments (identified by name) from the given org.
 
-This enables you to re-use policies by attaching one to multiple teams and machine roles.
+This enables you to permanently delete a policy from an organization.
+
+#### Command Options
+
+The delete command accepts the following additional flags:
+
+  Option | Description
+  ----   | -----
+  --yes, -y | Automatically accept the confirm dialog
 
 ## allow
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
@@ -101,8 +132,11 @@ If a name (`--name` flag) is not provided, one will be automatically generated.
 
 #### Command Options
 
+The `allow` command accepts the following flags:
+
   Option | Description
   ----   | -----
+  --org ORG, -o ORG | The org to generate the policy for
   --name NAME, -n NAME | The name to give the generated policy (e.g. allow-prod-env)
   --description DESCRIPTION, -d DESCRIPTION | A sentence or two explaining the purpose of the policy
 
@@ -126,8 +160,11 @@ If a name (`--name` flag) is not provided, one will be automatically generated.
 
 #### Command Options
 
+The `deny` command accepts the following flags:
+
   Option | Description
   ----   | -----
+  --org ORG, -o ORG | The org to generate the policy for
   --name NAME, -n NAME | The name to give the generated policy (e.g. allow-prod-env)
   --description DESCRIPTION, -d DESCRIPTION | A sentence or two explaining the purpose of the policy
 

--- a/registry/policies.go
+++ b/registry/policies.go
@@ -33,6 +33,12 @@ func (p *PoliciesClient) Create(ctx context.Context, policy *primitive.Policy) (
 	return &res, err
 }
 
+// Delete destroys the policy for the given ID
+func (p *PoliciesClient) Delete(ctx context.Context, policyID *identity.ID) error {
+	url := "/policies/" + policyID.String()
+	return p.client.RoundTrip(ctx, "DELETE", url, nil, nil, nil)
+}
+
 // List retrieves relevant policiies by orgID and/or name
 func (p *PoliciesClient) List(ctx context.Context, orgID *identity.ID, name string) ([]envelope.Policy, error) {
 	v := &url.Values{}


### PR DESCRIPTION
Using `torus policies delete` a user can now delete a policy and all of
it's attachments inside an organization.

**Example**

```bash
$ torus policies delete --yes read-production

Policy read-production and all of it's attachments have been deleted.
```