### PR TITLE
Dont ask to enable hints, add link protip to signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ _Unreleased_
 **Fixes**
 
 - Users are now reminded to keep their password safe and secure during `torus signup`.
+- No longer prompt to enable or disable hints during signup, instead always enable them.
+- Actually set the default value of the `core.check_updates` preference to `true`
+- Add a tip after signup to generate a `.torus.json` file using `torus link`
 
 ## v0.26.0
 

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
-	"github.com/manifoldco/torus-cli/promptui"
+	"github.com/manifoldco/torus-cli/hints"
 	"github.com/manifoldco/torus-cli/ui"
 
 	"github.com/urfave/cli"
@@ -85,25 +85,6 @@ func signup(ctx *cli.Context, subCommand bool) error {
 		return err
 	}
 
-	// Whether we should enable tool hints
-	label := "Enable hints"
-	preamble := "Would you like to enable hints on how to use Torus?\nThey can be disabled at any time using `torus prefs`."
-	enableHints := ConfirmDialogue(ctx, &label, &preamble, "y", false)
-	prefValue := "true"
-	if enableHints != nil {
-		// Abort if they interrupt
-		if enableHints == promptui.ErrInterrupt {
-			return enableHints
-		}
-		prefValue = "false"
-	}
-	// Store the preference value
-	prefErr := setPrefByName("core.hints", prefValue)
-	// Alert the user we failed to disable them, but continue with signup
-	if prefErr != nil {
-		fmt.Printf("Failed to set core.hints. Run `torus prefs set core.hints %s` to try again.\n", prefValue)
-	}
-
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		return err
@@ -164,6 +145,8 @@ func signup(ctx *cli.Context, subCommand bool) error {
 			return err
 		}
 	}
+
+	hints.Display(hints.GettingStarted)
 
 	return nil
 }

--- a/hints/hints.go
+++ b/hints/hints.go
@@ -20,6 +20,9 @@ const (
 	// Deny command adds hint to `torus deny`
 	Deny
 
+	// GettingStarted displays helpful hints when a user signs up
+	GettingStarted
+
 	// Import command adds hint to `torus import`
 	Import
 
@@ -66,6 +69,9 @@ func init() {
 	commandHints = map[Cmd][]string{
 		Allow: {
 			"Grant additional access to secrets for a team or role using `torus allow`",
+		},
+		GettingStarted: {
+			"Link your code repository to an org and project by generating a .torus.json file using the `torus link` command! Share this linking with your teammates by committing to the repository.",
 		},
 		Context: {
 			"Your linked organization and project are found in .torus.json after running `torus link`",

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -136,7 +136,7 @@ func NewPreferences() (*Preferences, error) {
 			Context:            true,
 			EnableHints:        true,
 			EnableProgress:     true,
-			EnableCheckUpdates: false,
+			EnableCheckUpdates: true,
 		},
 	}
 


### PR DESCRIPTION
No longer ask to enable hints, do it by default and remind the user
about `torus link` at the end of the signup flow!

Finally, actually enable check updates :)