### PR TITLE
Use the proper name when importing from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ _Unreleased_
 
 **Fixes**
 
+- `torus import` will now use the provided key instead of the value
 - Users are now reminded to keep their password safe and secure during `torus signup`.
 - No longer prompt to enable or disable hints during signup, instead always enable them.
 - Actually set the default value of the `core.check_updates` preference to `true`
 - Add a tip after signup to generate a `.torus.json` file using `torus link`
+
+**Thanks**
+
+- PatDuJour
 
 ## v0.26.0
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -50,7 +50,7 @@ func importCmd(ctx *cli.Context) error {
 
 	makers := valueMakers{}
 	for _, secret := range secrets {
-		makers[secret.value] = func() *apitypes.CredentialValue {
+		makers[secret.key] = func() *apitypes.CredentialValue {
 			return apitypes.NewStringCredentialValue(secret.value)
 		}
 	}


### PR DESCRIPTION
A bug was introduced to the import command where it'd set secrets using
the value instead of the name.

Closes manifoldco/torus-cli#296