### PR TITLE
Fix bug copying same value for each cred

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -50,9 +50,11 @@ func importCmd(ctx *cli.Context) error {
 
 	makers := valueMakers{}
 	for _, secret := range secrets {
-		makers[secret.key] = func() *apitypes.CredentialValue {
-			return apitypes.NewStringCredentialValue(secret.value)
-		}
+		makers[secret.key] = func(value string) valueMaker {
+			return func() *apitypes.CredentialValue {
+				return apitypes.NewStringCredentialValue(value)
+			}
+		}(secret.value)
 	}
 
 	creds, err := setCredentials(ctx, path, makers)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -155,7 +155,8 @@ func determinePathFromFlags(ctx *cli.Context) (*pathexp.PathExp, error) {
 	)
 }
 
-type valueMakers map[string](func() *apitypes.CredentialValue)
+type valueMaker func() *apitypes.CredentialValue
+type valueMakers map[string]valueMaker
 
 func setCredentials(ctx *cli.Context, pe *pathexp.PathExp, makers valueMakers) ([]apitypes.CredentialEnvelope, error) {
 	cfg, err := config.LoadConfig()

--- a/daemon/logic/engine.go
+++ b/daemon/logic/engine.go
@@ -173,7 +173,7 @@ func (e *Engine) AppendCredentials(ctx context.Context, notifier *observer.Notif
 		// Derive a key for the credential using the keyring master key
 		// and use the derived key to encrypt the credential
 		cekNonce, ctNonce, ct, err := e.crypto.BoxCredential(
-			ctx, []byte(cred.Body.Value), *mekshare.Key.Value, *mekshare.Key.Nonce,
+			ctx, []byte(c.Body.Value), *mekshare.Key.Value, *mekshare.Key.Nonce,
 			&kp.Encryption, *encryptingKey.Key.Value)
 		if err != nil {
 			log.Printf("Error encrypting credential: %s", err)


### PR DESCRIPTION
During import (or any situation where multiple credentials were being
submitted) the value of the first credential would be set for all
subsequent credentials.