### PR TITLE
Separate unseal and unbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 _Unreleased_
 
+**Notable Changes**
+
+- Significant performance increases when secrets are sourced from multiple
+  keyrings. For example if a secret is brought in from `dev-*` and `dev-user`
+  Torus will no longer unseal the private encryption key twice which leads to a
+  signficiant reduction in decryption time. Users should notice this
+  improvement when using `torus view` and `torus run`.
+
 **Fixes**
 
 - Request timeout to the server has been increased from 6s to 60s.

--- a/daemon/logic/credential_graph_key_index.go
+++ b/daemon/logic/credential_graph_key_index.go
@@ -1,0 +1,44 @@
+package logic
+
+import (
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/registry"
+)
+
+// credentialGraphKeyIndex holds credential graphs and indexes them by the
+// encryption key used to include the given identity into the ring as a member.
+type credentialGraphKeyIndex struct {
+	authID identity.ID
+
+	graphs map[identity.ID][]registry.CredentialGraph
+}
+
+func newCredentialGraphKeyIndex(authID identity.ID) *credentialGraphKeyIndex {
+	return &credentialGraphKeyIndex{
+		authID: authID,
+		graphs: make(map[identity.ID][]registry.CredentialGraph),
+	}
+}
+
+func (cgi *credentialGraphKeyIndex) Add(graphs ...registry.CredentialGraph) error {
+	for _, g := range graphs {
+		krm, _, err := g.FindMember(&cgi.authID)
+		if err != nil {
+			return err
+		}
+
+		id := *(krm.EncryptingKeyID)
+		if _, ok := cgi.graphs[id]; !ok {
+			cgi.graphs[id] = []registry.CredentialGraph{g}
+			continue
+		}
+
+		cgi.graphs[id] = append(cgi.graphs[id], g)
+	}
+
+	return nil
+}
+
+func (cgi *credentialGraphKeyIndex) GetIndex() map[identity.ID][]registry.CredentialGraph {
+	return cgi.graphs
+}

--- a/daemon/logic/credential_graph_key_index_test.go
+++ b/daemon/logic/credential_graph_key_index_test.go
@@ -1,0 +1,177 @@
+package logic
+
+import (
+	"testing"
+
+	gm "github.com/onsi/gomega"
+
+	"github.com/manifoldco/torus-cli/envelope"
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
+	"github.com/manifoldco/torus-cli/registry"
+)
+
+func addMembership(cg registry.CredentialGraph, authID, encKeyID *identity.ID, revoked bool) {
+	krm := &envelope.KeyringMember{
+		Version: 2,
+		Body: &primitive.KeyringMember{
+			EncryptingKeyID: encKeyID,
+			OwnerID:         authID,
+		},
+	}
+	krmID, err := identity.NewImmutable(krm.Body, "haha")
+	if err != nil {
+		panic(err)
+	}
+	krm.ID = &krmID
+
+	mek := &envelope.MEKShare{
+		Body: &primitive.MEKShare{
+			KeyringMemberID: krm.ID,
+			OwnerID:         authID,
+		},
+	}
+
+	mekID, err := identity.NewImmutable(mek.Body, "yoyo")
+	if err != nil {
+		panic(err)
+	}
+	mek.ID = &mekID
+
+	cgv2 := cg.(*registry.CredentialGraphV2)
+	cgv2.Members = append(cgv2.Members, registry.KeyringMember{
+		Member:   krm,
+		MEKShare: mek,
+	})
+
+	if revoked {
+		cgv2.Claims = append(cgv2.Claims, envelope.KeyringMemberClaim{
+			Version: 1,
+			Body: &primitive.KeyringMemberClaim{
+				KeyringMemberID: krm.ID,
+				ClaimType:       primitive.RevocationClaimType,
+			},
+		})
+	}
+}
+
+func TestCredentialGraphKeyIndex(t *testing.T) {
+	t.Run("can index graph", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		cgA := buildGraph("/o/p/e/s/u/i", 1)
+		cgB := buildGraph("/o/p/e/s/u2/i", 1)
+
+		userA, err := identity.NewMutable(&primitive.User{})
+		gm.Expect(err).To(gm.BeNil())
+
+		keyA, err := identity.NewImmutable(&primitive.PublicKey{}, "hi")
+		gm.Expect(err).To(gm.BeNil())
+
+		addMembership(cgA, &userA, &keyA, false)
+		addMembership(cgB, &userA, &keyA, false)
+
+		userB, err := identity.NewMutable(&primitive.User{})
+		gm.Expect(err).To(gm.BeNil())
+
+		keyB, err := identity.NewImmutable(&primitive.PublicKey{}, "yo")
+		gm.Expect(err).To(gm.BeNil())
+
+		addMembership(cgA, &userB, &keyB, false)
+		addMembership(cgB, &userB, &keyB, false)
+
+		idx := newCredentialGraphKeyIndex(userA)
+		idx.Add(cgA, cgB)
+
+		keyMap := idx.GetIndex()
+		gm.Expect(len(keyMap)).To(gm.Equal(1))
+
+		_, ok := keyMap[keyB]
+		gm.Expect(ok).To(gm.BeFalse(), "User B should not be in the idx")
+
+		graphs, ok := keyMap[keyA]
+		gm.Expect(ok).To(gm.BeTrue())
+		gm.Expect(len(graphs)).To(gm.Equal(2))
+	})
+
+	t.Run("returns error if auth id can't be found", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		cgA := buildGraph("/o/p/e/s/u/i", 1)
+
+		userA, err := identity.NewMutable(&primitive.User{})
+		gm.Expect(err).To(gm.BeNil())
+
+		idx := newCredentialGraphKeyIndex(userA)
+		err = idx.Add(cgA)
+
+		gm.Expect(err).ToNot(gm.BeNil())
+		gm.Expect(err).To(gm.Equal(registry.ErrMemberNotFound))
+	})
+
+	t.Run("handles case where user has multiple keys encoded in ring", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		cgA := buildGraph("/o/p/e/s/u/i", 1)
+
+		userA, err := identity.NewMutable(&primitive.User{})
+		gm.Expect(err).To(gm.BeNil())
+
+		keyA, err := identity.NewImmutable(&primitive.PublicKey{}, "hi")
+		gm.Expect(err).To(gm.BeNil())
+
+		keyB, err := identity.NewImmutable(&primitive.PublicKey{}, "hey")
+		gm.Expect(err).To(gm.BeNil())
+
+		addMembership(cgA, &userA, &keyA, false)
+		addMembership(cgA, &userA, &keyB, false)
+
+		idx := newCredentialGraphKeyIndex(userA)
+		err = idx.Add(cgA)
+		gm.Expect(err).To(gm.BeNil())
+
+		gm.Expect(len(idx.GetIndex())).To(gm.Equal(1), "Expected stable selection of key")
+	})
+
+	t.Run("handles case where users key is revoked", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		cgA := buildGraph("/o/p/e/s/u/i", 2)
+
+		userA, err := identity.NewMutable(&primitive.User{})
+		gm.Expect(err).To(gm.BeNil())
+
+		keyA, err := identity.NewImmutable(&primitive.PublicKey{}, "hi")
+		gm.Expect(err).To(gm.BeNil())
+
+		addMembership(cgA, &userA, &keyA, true)
+
+		idx := newCredentialGraphKeyIndex(userA)
+		err = idx.Add(cgA)
+
+		gm.Expect(err).ToNot(gm.BeNil())
+		gm.Expect(err).To(gm.Equal(registry.ErrMemberNotFound))
+	})
+
+	t.Run("handles case with child graphs", func(t *testing.T) {
+		cgA := buildGraph("/o/p/e/s/u/i", 1)
+		cgB := buildGraph("/o/p/e/s/u/i", 2)
+
+		userA, err := identity.NewMutable(&primitive.User{})
+		gm.Expect(err).To(gm.BeNil())
+
+		keyA, err := identity.NewImmutable(&primitive.PublicKey{}, "hi")
+		gm.Expect(err).To(gm.BeNil())
+
+		addMembership(cgA, &userA, &keyA, false)
+		addMembership(cgB, &userA, &keyA, false)
+
+		idx := newCredentialGraphKeyIndex(userA)
+		err = idx.Add(cgA, cgB)
+		gm.Expect(err).To(gm.BeNil())
+
+		keyMap := idx.GetIndex()
+		gm.Expect(len(keyMap)).To(gm.Equal(1))
+		gm.Expect(len(keyMap[keyA])).To(gm.Equal(2))
+	})
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: c7850fba9a0bf5699e401a7a882b84ede107d56c0b104e53026353199c0a186b
-updated: 2017-06-17T11:54:13.148029547-04:00
+hash: 69bc17d0eb97e74bcefec393a8f35aed1496c478c83e990d13fd00d448ab512d
+updated: 2017-11-06T20:49:25.635505694-04:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/aws/aws-sdk-go
-  version: 96358b8282b1a3aa66836d2f2fe66216cc419668
+  version: d46843b92a3a8e377d7fe24b4d70fca37f923d00
   subpackages:
   - aws
   - aws/awserr
@@ -32,9 +32,9 @@ imports:
   - service/s3
   - service/sts
 - name: github.com/blang/semver
-  version: b38d23b8782a487059e8fc8773e9a5b228a77cb6
+  version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
 - name: github.com/boltdb/bolt
-  version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
+  version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
 - name: github.com/chzyer/readline
   version: 41eea22f717c616615e1e59aa06cf831f9901f35
 - name: github.com/dchest/blake2b
@@ -50,7 +50,7 @@ imports:
 - name: github.com/fullsailor/pkcs7
   version: eb67e7e564b9eae64dc7d95fae0784d6086a5fc4
 - name: github.com/go-ini/ini
-  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
+  version: f280b3ba517bf5fc98922624f21fb0e7a92adaec
 - name: github.com/go-zoo/bone
   version: fd0aebc74e908868b09ac140fb5a53cb363884c1
 - name: github.com/golang/protobuf
@@ -87,10 +87,24 @@ imports:
   version: c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6
 - name: github.com/nightlyone/lockfile
   version: 1d49c987357a327b5b03aa84cbddd582c328615d
+- name: github.com/onsi/gomega
+  version: 334b8f472b3af5d541c5642701c1e29e2126f486
+  subpackages:
+  - format
+  - internal/assertion
+  - internal/asyncassertion
+  - internal/oraclematcher
+  - internal/testingtsupport
+  - matchers
+  - matchers/support/goraph/bipartitegraph
+  - matchers/support/goraph/edge
+  - matchers/support/goraph/node
+  - matchers/support/goraph/util
+  - types
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/urfave/cli
-  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: golang.org/x/crypto
   version: 9ef620b9ca2f82b55030ffd4f41327fa9e77a92c
   subpackages:
@@ -125,4 +139,6 @@ imports:
   - urlfetch
 - name: gopkg.in/oleiade/reflections.v1
   version: 2b6ec3da648e3e834dc41bad8d9ed7f2dc6a9496
-testImports: []
+testImports:
+- name: gopkg.in/yaml.v2
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,3 +45,4 @@ import:
   version: ^1.0.0
 - package: github.com/fullsailor/pkcs7
 - package: github.com/google/shlex
+- package: github.com/onsi/gomega


### PR DESCRIPTION
To remove duplication of unsealing of private keys, we've split `Unbox`ing into two explicit composable stages.

In order to leverage these changes, we've begun indexing graphs by the valid keyring membership used to include the targeted user/machine into the underlying ring.

Related #302 