### PR TITLE
Remove duplicate Claimtree calls while parallelizing fetching of keypairs and claimtree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ _Unreleased_
   Torus will no longer unseal the private encryption key twice which leads to a
   signficiant reduction in decryption time. Users should notice this
   improvement when using `torus view` and `torus run`.
+- Significant reduction in the number of round trips made to the Torus server
+  to fetch an organizations claimtree (web of trust) when decrypting or
+  encrypting secrets. Users should notice this improvement when many different
+  users are contributing secrets to the same keyrings when using `torus view`,
+  `torus run`, `torus set`, or `torus unset`.
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ _Unreleased_
   encrypting secrets. Users should notice this improvement when many different
   users are contributing secrets to the same keyrings when using `torus view`,
   `torus run`, `torus set`, or `torus unset`.
+- Parallelized fetching of keypairs and an orgs claimtree during secret
+  decryption. Users should notice a modest improvement when using `torus view`
+  and `torus run`.
 
 **Fixes**
 

--- a/cmd/keypairs.go
+++ b/cmd/keypairs.go
@@ -98,7 +98,7 @@ func listKeypairs(ctx *cli.Context) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tORG\tKEY TYPE\tVALID\tCREATION DATE")
 	fmt.Fprintln(w, " \t \t \t \t ")
-	for _, keypair := range keypairs {
+	for _, keypair := range keypairs.All() {
 		pk := keypair.PublicKey.Body
 		valid := "YES"
 		if keypair.Revoked() {
@@ -161,7 +161,7 @@ func generateKeypairs(ctx *cli.Context) error {
 			pErr = err
 			break
 		}
-		for _, kp := range keypairs {
+		for _, kp := range keypairs.All() {
 			if kp.Revoked() {
 				continue
 			}
@@ -263,7 +263,7 @@ func revokeKeypairs(ctx *cli.Context) error {
 
 	hasKey := make(map[primitive.KeyType]struct{})
 
-	for _, kp := range keypairs {
+	for _, kp := range keypairs.All() {
 		if kp.Revoked() {
 			continue
 		}

--- a/registry/claimtree.go
+++ b/registry/claimtree.go
@@ -2,12 +2,33 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/envelope"
 	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
 )
+
+// ErrKeyNotFound represents a situation where a key could not be found
+var ErrKeyNotFound = &apitypes.Error{
+	Type: apitypes.NotFoundError,
+	Err:  []string{"Could not locate public key segment for specified key id"},
+}
+
+// ErrMissingKeyForOwner represents a situation where a key of a specific type could not be found for the owner inside an org
+var ErrMissingKeyForOwner = &apitypes.Error{
+	Type: apitypes.NotFoundError,
+	Err:  []string{"Could not locate public key segment in claimtree for target"},
+}
+
+// ErrClaimTreeNotFound represents a situation where a claimtree could not be
+// found
+var ErrClaimTreeNotFound = &apitypes.Error{
+	Type: apitypes.NotFoundError,
+	Err:  []string{"Could not find claim tree for org"},
+}
 
 // ClaimTreeClient represents the `/claimtree` registry endpoint, used for
 // retrieving the public keys and their associated claims for an organization.
@@ -20,6 +41,49 @@ type ClaimTreeClient struct {
 type ClaimTree struct {
 	Org        *envelope.Org               `json:"org"`
 	PublicKeys []apitypes.PublicKeySegment `json:"public_keys"`
+}
+
+// Find returns the PublicKeySegment for the given PublicKeyID. Accepts a
+// boolean for indicating whether or not to enforce that the key must be
+// active.
+//
+// If a key segment could not be found an error is returned.
+func (ct *ClaimTree) Find(id *identity.ID, mustActive bool) (*apitypes.PublicKeySegment, error) {
+	for _, pks := range ct.PublicKeys {
+		if *pks.PublicKey.ID == *id {
+			if mustActive && pks.Revoked() {
+				continue
+			}
+
+			return &pks, nil
+		}
+	}
+
+	return nil, ErrKeyNotFound
+}
+
+// FindActive returns the PublicKeySegment for a non-revoked Public Key for
+// the given owner id.
+//
+// If an active key cannot be found an error is returned
+func (ct *ClaimTree) FindActive(ownerID *identity.ID, t primitive.KeyType) (*apitypes.PublicKeySegment, error) {
+	for _, pks := range ct.PublicKeys {
+		if *pks.PublicKey.Body.OwnerID != *ownerID {
+			continue
+		}
+
+		if pks.PublicKey.Body.KeyType != t {
+			continue
+		}
+
+		if pks.Revoked() {
+			continue
+		}
+
+		return &pks, nil
+	}
+
+	return nil, ErrMissingKeyForOwner
 }
 
 // List returns a list of all claimtrees for a given orgID. If no orgID is
@@ -43,4 +107,27 @@ func (c *ClaimTreeClient) List(ctx context.Context, orgID *identity.ID,
 	var resp []ClaimTree
 	err := c.client.RoundTrip(ctx, "GET", "/claimtree", query, nil, &resp)
 	return resp, err
+}
+
+// Get returns a claimtree for a specific organization by the given orgID.
+//
+// If an ownerID is provided then only public keys and claims related to that
+// user or machine will be returned.
+func (c *ClaimTreeClient) Get(ctx context.Context, orgID *identity.ID,
+	ownerID *identity.ID) (*ClaimTree, error) {
+
+	if orgID == nil {
+		return nil, errors.New("An org id must be provided")
+	}
+
+	cts, err := c.List(ctx, orgID, ownerID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cts) != 1 {
+		return nil, ErrClaimTreeNotFound
+	}
+
+	return &cts[0], nil
 }

--- a/registry/claimtree_test.go
+++ b/registry/claimtree_test.go
@@ -1,0 +1,92 @@
+package registry
+
+import (
+	"testing"
+
+	gm "github.com/onsi/gomega"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
+)
+
+func TestClaimTree(t *testing.T) {
+	orgID, err := identity.NewMutable(&primitive.Org{})
+	if err != nil {
+		t.Fatal("Could not generate org id", err)
+	}
+
+	t.Run("can find pubkey by id", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pks := createPKS(&orgID, primitive.EncryptionKeyType, false)
+		ct := ClaimTree{PublicKeys: []apitypes.PublicKeySegment{pks}}
+
+		found, err := ct.Find(pks.PublicKey.ID, false)
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(*found).To(gm.Equal(pks))
+	})
+
+	t.Run("errors if pubkey is revoked", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pks := createPKS(&orgID, primitive.EncryptionKeyType, true)
+		ct := ClaimTree{PublicKeys: []apitypes.PublicKeySegment{pks}}
+
+		found, err := ct.Find(pks.PublicKey.ID, true)
+		gm.Expect(err).To(gm.Equal(ErrKeyNotFound))
+		gm.Expect(found).To(gm.BeNil())
+	})
+
+	t.Run("can find an active key for user", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pksA := createPKS(&orgID, primitive.EncryptionKeyType, false)
+		pksB := createPKS(&orgID, primitive.SigningKeyType, false)
+
+		ct := ClaimTree{PublicKeys: []apitypes.PublicKeySegment{pksA, pksB}}
+
+		found, err := ct.FindActive(pksA.PublicKey.Body.OwnerID, primitive.EncryptionKeyType)
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(*found).To(gm.Equal(pksA))
+
+		found, err = ct.FindActive(pksB.PublicKey.Body.OwnerID, primitive.SigningKeyType)
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(*found).To(gm.Equal(pksB))
+	})
+
+	t.Run("returns error if an active key cannot be found", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pksA := createPKS(&orgID, primitive.EncryptionKeyType, true)
+
+		ct := ClaimTree{PublicKeys: []apitypes.PublicKeySegment{pksA}}
+
+		found, err := ct.FindActive(pksA.PublicKey.Body.OwnerID, primitive.EncryptionKeyType)
+		gm.Expect(err).To(gm.Equal(ErrMissingKeyForOwner))
+		gm.Expect(found).To(gm.BeNil())
+	})
+
+	t.Run("returns error if segment exists but isnt the right type", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pksA := createPKS(&orgID, primitive.SigningKeyType, false)
+		ct := ClaimTree{PublicKeys: []apitypes.PublicKeySegment{pksA}}
+
+		found, err := ct.FindActive(pksA.PublicKey.Body.OwnerID, primitive.EncryptionKeyType)
+		gm.Expect(err).To(gm.Equal(ErrMissingKeyForOwner))
+		gm.Expect(found).To(gm.BeNil())
+	})
+
+	t.Run("errors if pubkey can't be found", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pubID, err := identity.NewImmutable(&primitive.PublicKey{}, "hi")
+		gm.Expect(err).To(gm.BeNil())
+
+		ct := ClaimTree{PublicKeys: []apitypes.PublicKeySegment{}}
+
+		_, err = ct.Find(&pubID, false)
+		gm.Expect(err).To(gm.Equal(ErrKeyNotFound))
+	})
+}

--- a/registry/keypairs.go
+++ b/registry/keypairs.go
@@ -2,12 +2,114 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"github.com/manifoldco/torus-cli/apitypes"
 	"github.com/manifoldco/torus-cli/envelope"
 	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
 )
+
+// ErrPublicKeyNotFound represents an error where a given public key inside a
+// Keypairs struct could not be found.
+var ErrPublicKeyNotFound = &apitypes.Error{
+	Type: apitypes.NotFoundError,
+	Err:  []string{"Could not find public key"},
+}
+
+// ErrMissingValidKeypair represents an error where a valid signing or
+// encryption keypair could not be found for an organization
+var ErrMissingValidKeypair = &apitypes.Error{
+	Type: apitypes.NotFoundError,
+	Err:  []string{"Missing encryption or signing keypairs"},
+}
+
+// ErrMissingKeysForOrg returns an error where the given org id is not present
+// in the keypairs map
+var ErrMissingKeysForOrg = &apitypes.Error{
+	Type: apitypes.NotFoundError,
+	Err:  []string{"Could not find keypairs for org"},
+}
+
+// Keypairs contains a slice of a users claimed keypairs for many different
+// organizations
+type Keypairs struct {
+	keypairs map[identity.ID][]ClaimedKeyPair
+	idIndex  map[identity.ID]ClaimedKeyPair
+}
+
+// NewKeypairs returns an empty keypairs struct
+func NewKeypairs() *Keypairs {
+	return &Keypairs{
+		keypairs: map[identity.ID][]ClaimedKeyPair{},
+		idIndex:  map[identity.ID]ClaimedKeyPair{},
+	}
+}
+
+// Add adds the given keypairs to the list of keypairs
+func (kp *Keypairs) Add(keypairs ...ClaimedKeyPair) error {
+	for _, k := range keypairs {
+		kp.idIndex[*k.PublicKey.ID] = k
+
+		orgID := *k.PublicKey.Body.OrgID
+		_, ok := kp.keypairs[orgID]
+		if !ok {
+			kp.keypairs[orgID] = []ClaimedKeyPair{k}
+			continue
+		}
+
+		kp.keypairs[orgID] = append(kp.keypairs[orgID], k)
+	}
+
+	return nil
+}
+
+// Get returns the ClaimedKeyPair for the given public key id
+func (kp *Keypairs) Get(publicKeyID *identity.ID) (*ClaimedKeyPair, error) {
+	if publicKeyID == nil {
+		return nil, errors.New("Invalid PublicKeyID provided to get keypair")
+	}
+
+	ckp, ok := kp.idIndex[*publicKeyID]
+	if !ok {
+		return nil, ErrPublicKeyNotFound
+	}
+
+	return &ckp, nil
+}
+
+// Select returns a keypair for the given type inside the specified
+// organization. If a valid key (non-revoked) cannot be found an error is
+// returned.
+func (kp *Keypairs) Select(orgID *identity.ID, t primitive.KeyType) (*ClaimedKeyPair, error) {
+	if orgID == nil {
+		return nil, errors.New("Invalid OrgID Provided to select keypairs")
+	}
+
+	possible, ok := kp.keypairs[*orgID]
+	if !ok {
+		return nil, ErrMissingKeysForOrg
+	}
+
+	for _, k := range possible {
+		if k.PublicKey.Body.KeyType == t && !k.Revoked() {
+			return &k, nil
+		}
+	}
+
+	return nil, ErrMissingValidKeypair
+}
+
+// All returns all keypairs including those which have been revoked.
+func (kp *Keypairs) All() []ClaimedKeyPair {
+	out := []ClaimedKeyPair{}
+	for _, ckp := range kp.idIndex {
+		out = append(out, ckp)
+	}
+
+	return out
+}
 
 // ClaimedKeyPair contains a public/private keypair, and all the Claims made
 // against it (system and user signatures).
@@ -50,7 +152,7 @@ func (k *KeyPairsClient) Create(ctx context.Context, pubKey *envelope.PublicKey,
 
 // List returns all KeyPairs for the logged in user in the given, or all orgs
 // if orgID is nil.
-func (k *KeyPairsClient) List(ctx context.Context, orgID *identity.ID) ([]ClaimedKeyPair, error) {
+func (k *KeyPairsClient) List(ctx context.Context, orgID *identity.ID) (*Keypairs, error) {
 	query := &url.Values{}
 	if orgID != nil {
 		query.Set("org_id", orgID.String())
@@ -58,5 +160,15 @@ func (k *KeyPairsClient) List(ctx context.Context, orgID *identity.ID) ([]Claime
 
 	var resp []ClaimedKeyPair
 	err := k.client.RoundTrip(ctx, "GET", "/keypairs", query, nil, &resp)
-	return resp, err
+	if err != nil {
+		return nil, err
+	}
+
+	kp := NewKeypairs()
+	err = kp.Add(resp...)
+	if err != nil {
+		return nil, err
+	}
+
+	return kp, nil
 }

--- a/registry/keypairs_test.go
+++ b/registry/keypairs_test.go
@@ -1,0 +1,146 @@
+package registry
+
+import (
+	"testing"
+
+	gm "github.com/onsi/gomega"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/envelope"
+	"github.com/manifoldco/torus-cli/identity"
+	"github.com/manifoldco/torus-cli/primitive"
+)
+
+func createCKP(orgID *identity.ID, t primitive.KeyType, revoked bool) ClaimedKeyPair {
+	pubk := &envelope.PublicKey{
+		Version: 1,
+		Body: &primitive.PublicKey{
+			OrgID:   orgID,
+			KeyType: t,
+		},
+	}
+
+	pubkID, err := identity.NewImmutable(pubk.Body, "haha")
+	if err != nil {
+		panic(err)
+	}
+	pubk.ID = &pubkID
+
+	privk := &envelope.PrivateKey{
+		Version: 1,
+		Body: &primitive.PrivateKey{
+			OrgID:       orgID,
+			PublicKeyID: pubk.ID,
+		},
+	}
+	privkID, err := identity.NewImmutable(privk.Body, "sdfs")
+	if err != nil {
+		panic(err)
+	}
+	privk.ID = &privkID
+
+	ckp := ClaimedKeyPair{
+		PublicKeySegment: apitypes.PublicKeySegment{
+			PublicKey: pubk,
+			Claims:    []envelope.Claim{},
+		},
+		PrivateKey: privk,
+	}
+
+	if revoked {
+		ckp.Claims = append(ckp.Claims, envelope.Claim{
+			Version: 1,
+			Body: &primitive.Claim{
+				OrgID:       orgID,
+				PublicKeyID: pubk.ID,
+				ClaimType:   primitive.RevocationClaimType,
+			},
+		})
+	}
+
+	return ckp
+}
+
+func TestKeypairs(t *testing.T) {
+	t.Run("can add keypairs and subsequently find them", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		orgID, err := identity.NewMutable(&primitive.Org{})
+		gm.Expect(err).To(gm.BeNil())
+
+		kp := NewKeypairs()
+		ckp := createCKP(&orgID, primitive.EncryptionKeyType, false)
+
+		err = kp.Add(ckp)
+		gm.Expect(err).To(gm.BeNil())
+
+		found, err := kp.Get(ckp.PublicKey.ID)
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(found.PublicKey.ID).To(gm.Equal(ckp.PublicKey.ID))
+
+		all := kp.All()
+		gm.Expect(len(all)).To(gm.Equal(1))
+		gm.Expect(all[0].PublicKey.ID).To(gm.Equal(ckp.PublicKey.ID))
+	})
+
+	t.Run("can select keypairs", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		orgID, err := identity.NewMutable(&primitive.Org{})
+		gm.Expect(err).To(gm.BeNil())
+
+		kp := NewKeypairs()
+
+		ckpA := createCKP(&orgID, primitive.EncryptionKeyType, false)
+		ckpB := createCKP(&orgID, primitive.SigningKeyType, false)
+		ckpC := createCKP(&orgID, primitive.EncryptionKeyType, true)
+
+		err = kp.Add(ckpA, ckpB, ckpC)
+		gm.Expect(err).To(gm.BeNil())
+
+		found, err := kp.Select(&orgID, primitive.EncryptionKeyType)
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(found.PublicKey.ID).To(gm.Equal(ckpA.PublicKey.ID))
+
+		found, err = kp.Select(&orgID, primitive.SigningKeyType)
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(found.PublicKey.ID).To(gm.Equal(ckpB.PublicKey.ID))
+	})
+
+	t.Run("will not select revoked keypairs", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		orgID, err := identity.NewMutable(&primitive.Org{})
+		gm.Expect(err).To(gm.BeNil())
+
+		kp := NewKeypairs()
+
+		ckpA := createCKP(&orgID, primitive.EncryptionKeyType, true)
+		kp.Add(ckpA)
+
+		_, err = kp.Select(&orgID, primitive.EncryptionKeyType)
+		gm.Expect(err).To(gm.Equal(ErrMissingValidKeypair))
+	})
+
+	t.Run("will error if org does not have keys", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		orgID, err := identity.NewMutable(&primitive.Org{})
+		gm.Expect(err).To(gm.BeNil())
+
+		kp := NewKeypairs()
+		_, err = kp.Select(&orgID, primitive.SigningKeyType)
+		gm.Expect(err).To(gm.Equal(ErrMissingKeysForOrg))
+	})
+
+	t.Run("will error if key does not exist", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pubkID, err := identity.NewImmutable(&primitive.PublicKey{}, "has")
+		gm.Expect(err).To(gm.BeNil())
+
+		kp := NewKeypairs()
+		_, err = kp.Get(&pubkID)
+		gm.Expect(err).To(gm.Equal(ErrPublicKeyNotFound))
+	})
+}


### PR DESCRIPTION
This pull request contains three commits that build ontop of each other to introduce two different performance increases.

1. To make it easier to fetch and find keypairs, I've introduced the Keypairs struct which handles finding active keypairs to use.
2. To make it easier to fetch and pass around all public keys in an org, I've added methods to a Claimtree for finding active public keys for specific types.
3. Using the modularity introduced in 1/2, we can now fetch keypairs and the claimtree in parallel.

These changes touch every single core component of the daemon (worklog, appending and fetching secrets, org invite approval). So we'll need to test Torus exhaustively before doing a release.

Closes manifoldco/torus-cli#302