### PR TITLE
Fix bug preventing credential graph creation

### DIFF
--- a/daemon/logic/utils.go
+++ b/daemon/logic/utils.go
@@ -96,8 +96,8 @@ func createCredentialGraph(ctx context.Context, credBody *PlaintextCredential,
 	for _, subject := range subjects {
 		for _, id := range subject.KeyOwnerIDs() {
 			// For this user/mtoken, find their public encryption key
-			enc, err := ct.Find(&id, true)
-			if err == registry.ErrKeyNotFound {
+			enc, err := ct.FindActive(&id, primitive.EncryptionKeyType)
+			if err == registry.ErrMissingKeyForOwner {
 				// If we didn't find an active key, don't encode this
 				// user/token in the keyring, but keep going.
 				continue


### PR DESCRIPTION
While introducing the claimtree in #314, a bug was introduced preventing
an identities active encryption key from being found. This prevented
creation and encoding of users into keyrings.