### PR TITLE
Fix bug preventing v1 creds from being decrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ _Unreleased_
 - Introduced command `orgs members --org ORG` to list all members within an organization.
 - Changed the output style of `teams members` to match the output style of `orgs members --org ORG`.
 
+**Fixes**
+
+- Fixed a bug preventing old credential values from being decrypted.
+
 ## v0.27.0
 
 _2017-10-08_

--- a/apitypes/credential_test.go
+++ b/apitypes/credential_test.go
@@ -2,6 +2,7 @@ package apitypes
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 )
 
@@ -81,5 +82,22 @@ func TestCredentialValueUnmarshalJSON(t *testing.T) {
 			t.Errorf("wrong value! had: '%s' wanted: '%s'", c.String(), expectedStr)
 		}
 
+	})
+
+	t.Run("quoted json string", func(t *testing.T) {
+		jsonString := strconv.Quote(`{"version":1,"body":{"type":"string","value":"12345678"}}`)
+		c := CredentialValue{}
+		err := json.Unmarshal([]byte(jsonString), &c)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+
+		if c.IsUnset() {
+			t.Error("value is unset")
+		}
+
+		if c.String() != "12345678" {
+			t.Errorf("wrong value! had '%s' wanted '%s'", c.String(), "12345678")
+		}
 	})
 }

--- a/daemon/logic/engine.go
+++ b/daemon/logic/engine.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/manifoldco/go-base64"
@@ -259,11 +260,13 @@ func (e *Engine) RetrieveCredentials(ctx context.Context,
 	// unset credentials.
 	activeGraphs, err := cgs.Prune()
 	if err != nil {
+		log.Printf("error encountered while pruning graph: %s", err)
 		return nil, err
 	}
 
 	creds := []PlaintextCredentialEnvelope{}
 	if len(activeGraphs) == 0 {
+		log.Printf("no active graphs found")
 		return creds, nil
 	}
 
@@ -358,8 +361,9 @@ func (e *Engine) RetrieveCredentials(ctx context.Context,
 						// the credentials.
 						if cred.GetVersion() == 1 {
 							cValue := apitypes.CredentialValue{}
-							err = json.Unmarshal(pt, &cValue)
+							err = json.Unmarshal([]byte(strconv.Quote(string(pt))), &cValue)
 							if err != nil {
+								log.Printf("could not unmarshal credential value from v1 cred: %s", err)
 								return err
 							}
 
@@ -389,6 +393,7 @@ func (e *Engine) RetrieveCredentials(ctx context.Context,
 					return nil
 				})
 				if err != nil {
+					log.Printf("encountered an error while unboxing: %s", err)
 					return err
 				}
 			}
@@ -396,6 +401,7 @@ func (e *Engine) RetrieveCredentials(ctx context.Context,
 			return nil
 		})
 		if err != nil {
+			log.Printf("encountered an error while unsealing: %s", err)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Old credentials that are stored under a v1 Credential data structure
were not being decrypted due to a string quotation bug.

To fix this bug, we now quote the string appropriately before
unmarshalling the credential value to check if it's unset inside the
daemon.