### PR TITLE
Leverage memguard to securely store keys and tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ _Unreleased_
 
 **Notable Changes**
 
-- Introduced command `orgs members --org ORG` to list all members within an organization.
-- Changed the output style of `teams members` to match the output style of `orgs members --org ORG`.
+- Introduced command `orgs members --org ORG` to list all members within an
+  organization.
+- Changed the output style of `teams members` to match the output style of
+  `orgs members --org ORG`.
+- Encryption keys, user passwords, and machine secret tokens are now stored in
+  secure and guarded memory making it more difficult to extract data from a
+  running process.
 
 **Fixes**
 

--- a/daemon/crypto/secure/secure.go
+++ b/daemon/crypto/secure/secure.go
@@ -1,0 +1,138 @@
+// Package secure is a wrapper package around memguard for managing data which
+// must not be swapped to disk or easily read via a memory scanner.
+package secure
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/awnumar/memguard"
+)
+
+// ErrSecretNotFound occurs when a secret could not be found
+var ErrSecretNotFound = errors.New("Could not find secret to remove it")
+
+var lock *sync.Mutex
+var current *Guard
+
+func init() {
+	lock = &sync.Mutex{}
+	memguard.DisableUnixCoreDumps()
+}
+
+// Guard is a controller of guarded memory which contains many different
+// secrets. Only one guard can exist at a time.
+type Guard struct {
+	secrets []*Secret
+	lock    *sync.Mutex
+}
+
+// Secret represent a specific guraded piece of memory
+type Secret struct {
+	guard  *Guard
+	buffer *memguard.LockedBuffer
+}
+
+// NewGuard returns a Guard instance or errors if a guard already exists.
+func NewGuard() *Guard {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if current != nil {
+		return current
+	}
+
+	current = &Guard{
+		secrets: []*Secret{},
+		lock:    &sync.Mutex{},
+	}
+
+	return current
+}
+
+func (g *Guard) remove(s *Secret) error {
+	if s == nil {
+		panic("received a nil secret; should not be possible")
+	}
+
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	placement := -1
+	for i, v := range g.secrets {
+		if *v == *s {
+			placement = i
+			break
+		}
+	}
+
+	if placement == -1 {
+		return ErrSecretNotFound
+	}
+
+	g.secrets = append(g.secrets[:placement], g.secrets[placement+1:]...)
+
+	return nil
+}
+
+// Destroy removes all secrets and cleans up everything up appropriately.
+func (g *Guard) Destroy() {
+	lock.Lock()
+	defer lock.Unlock()
+
+	for _, s := range g.secrets {
+		s.Destroy()
+	}
+
+	current = nil
+}
+
+// Secret returns a new secret for the given value, the given byte slice will
+// be wiped *after* the secret has been moved into secure memory.
+func (g *Guard) Secret(v []byte) (*Secret, error) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	b, err := memguard.NewMutableFromBytes(v)
+	if err != nil {
+		return nil, err
+	}
+
+	s := Secret{
+		buffer: b,
+		guard:  g,
+	}
+
+	g.secrets = append(g.secrets, &s)
+	return &s, nil
+}
+
+// Random returns a new secret of the given length in bytes.
+func (g *Guard) Random(size int) (*Secret, error) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	b, err := memguard.NewImmutableRandom(size)
+	if err != nil {
+		return nil, err
+	}
+
+	s := Secret{
+		buffer: b,
+		guard:  g,
+	}
+
+	g.secrets = append(g.secrets, &s)
+	return &s, nil
+}
+
+// Buffer returns an array of bytes referencing the underlying secure memory.
+func (s *Secret) Buffer() []byte {
+	return s.buffer.Buffer()
+}
+
+// Destroy properly dispenses of the underlying secret stored in secure memory.
+func (s *Secret) Destroy() {
+	defer s.buffer.Destroy()
+	s.guard.remove(s)
+}

--- a/daemon/crypto/secure/secure_test.go
+++ b/daemon/crypto/secure/secure_test.go
@@ -1,0 +1,104 @@
+package secure
+
+import (
+	"testing"
+
+	gm "github.com/onsi/gomega"
+)
+
+func TestGuard(t *testing.T) {
+	t.Run("can create guard and get secret back", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		g := NewGuard()
+		defer g.Destroy()
+		gm.Expect(g).To(gm.Equal(current))
+
+		b := []byte("hello")
+		c := append([]byte{}, b...)
+		s, err := g.Secret(b)
+
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(s).ToNot(gm.BeNil())
+
+		gm.Expect(b).To(gm.Equal([]byte{0, 0, 0, 0, 0}))
+		gm.Expect(s.Buffer()).To(gm.Equal(c))
+	})
+
+	t.Run("guard acts as a singleton", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		g := NewGuard()
+		g2 := NewGuard()
+		defer g.Destroy()
+		defer g2.Destroy()
+
+		gm.Expect(*g).To(gm.Equal(*g2))
+	})
+
+	t.Run("can create secret and destroy it", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		g := NewGuard()
+		defer g.Destroy()
+
+		b := []byte("hello")
+		s, err := g.Secret(b)
+		gm.Expect(err).To(gm.BeNil())
+
+		s.Destroy()
+		v := s.Buffer()
+
+		gm.Expect(len(v)).To(gm.Equal(0))
+		gm.Expect(cap(v)).To(gm.Equal(0))
+		gm.Expect(len(g.secrets)).To(gm.Equal(0))
+	})
+
+	t.Run("can create random secret and access it", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		g := NewGuard()
+		defer g.Destroy()
+
+		s, err := g.Random(16)
+		gm.Expect(err).To(gm.BeNil())
+
+		v := s.Buffer()
+		gm.Expect(len(v)).To(gm.Equal(16))
+		gm.Expect(v).ToNot(gm.Equal([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}))
+	})
+
+	t.Run("can create many secrets and destroy guard", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		g := NewGuard()
+
+		b := []byte("hi")
+		b2 := []byte("hello")
+		c := append([]byte{}, b...)
+		c2 := append([]byte{}, b2...)
+
+		s, err := g.Secret(b)
+		gm.Expect(err).To(gm.BeNil())
+
+		s2, err := g.Secret(b2)
+		gm.Expect(err).To(gm.BeNil())
+
+		gm.Expect(s.Buffer()).To(gm.Equal(c))
+		gm.Expect(s2.Buffer()).To(gm.Equal(c2))
+
+		g.Destroy()
+
+		gm.Expect(len(g.secrets)).To(gm.Equal(0))
+
+		v := s.Buffer()
+		v2 := s.Buffer()
+
+		gm.Expect(len(v)).To(gm.Equal(0))
+		gm.Expect(cap(v)).To(gm.Equal(0))
+		gm.Expect(len(v2)).To(gm.Equal(0))
+		gm.Expect(cap(v2)).To(gm.Equal(0))
+
+		gm.Expect(current).To(gm.BeNil())
+	})
+}

--- a/daemon/logic/machine.go
+++ b/daemon/logic/machine.go
@@ -80,12 +80,12 @@ func (m *Machine) CreateToken(ctx context.Context, notifier *observer.Notifier,
 
 	// Create an "empty" machine session in order to create a Crypto engine on
 	// behalf of the machine for deriving and uploading these keys.
-	sess := session.NewSession()
-	err = sess.Set(apitypes.MachineSession, machine, token, *secret, "")
+	sess := session.NewSession(m.engine.guard)
+	err = sess.Set(apitypes.MachineSession, machine, token, *secret, []byte("hello"))
 	if err != nil {
 		return nil, err
 	}
-	c := crypto.NewEngine(sess)
+	c := crypto.NewEngine(sess, m.engine.guard)
 
 	n.Notify(observer.Progress, "Generating token keypairs", true)
 	kp, err := c.GenerateKeyPairs(ctx)

--- a/daemon/logic/session.go
+++ b/daemon/logic/session.go
@@ -60,7 +60,7 @@ func (s *Session) Login(ctx context.Context, creds apitypes.LoginCredential) err
 		return err
 	}
 
-	token := authToken.Body.Token
+	token := []byte(authToken.Body.Token)
 	self, err := s.engine.client.Self.Get(ctx, authToken.Body.Token)
 	if err != nil {
 		return err
@@ -178,16 +178,16 @@ func (s *Session) attemptEdDSALogin(ctx context.Context, loginToken *envelope.To
 // Logout destroys the current session if it exists, otherwise, it returns an
 // error that the request could not be completed.
 func (s *Session) Logout(ctx context.Context) error {
-	tok := s.engine.session.Token()
 
-	if tok == "" {
+	if !s.engine.session.HasToken() {
 		return &apitypes.Error{
 			Type: apitypes.UnauthorizedError,
 			Err:  []string{"You must be logged in, to logout!"},
 		}
 	}
 
-	err := s.engine.client.Tokens.Delete(ctx, tok)
+	tok := s.engine.session.Token()
+	err := s.engine.client.Tokens.Delete(ctx, string(tok[:]))
 	switch err := err.(type) {
 	case *apitypes.Error:
 		switch {

--- a/daemon/socket/proxy.go
+++ b/daemon/socket/proxy.go
@@ -85,8 +85,8 @@ func (p *AuthProxy) Listen() error {
 			r.Host = p.u.Host
 			r.URL.Path = r.URL.Path[6:]
 
-			tok := p.sess.Token()
-			if tok != "" {
+			if p.sess.HasToken() {
+				tok := string(p.sess.Token())
 				r.Header["Authorization"] = []string{"Bearer " + tok}
 			}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: 69bc17d0eb97e74bcefec393a8f35aed1496c478c83e990d13fd00d448ab512d
-updated: 2017-11-06T20:49:25.635505694-04:00
+hash: 6734f567020a1f2b8130dfa57da895bd13fb2eaa103c51a47389ee6185a82bd4
+updated: 2017-11-28T17:02:31.032788-04:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
+- name: github.com/awnumar/memguard
+  version: b482b0c828e2eeecbfebb05ca965c8d571afaeff
+  subpackages:
+  - memcall
 - name: github.com/aws/aws-sdk-go
-  version: d46843b92a3a8e377d7fe24b4d70fca37f923d00
+  version: 0c22c3d22be15d3be3d22b8dedabbf5dd4304730
   subpackages:
   - aws
   - aws/awserr
@@ -50,7 +54,7 @@ imports:
 - name: github.com/fullsailor/pkcs7
   version: eb67e7e564b9eae64dc7d95fae0784d6086a5fc4
 - name: github.com/go-ini/ini
-  version: f280b3ba517bf5fc98922624f21fb0e7a92adaec
+  version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
 - name: github.com/go-zoo/bone
   version: fd0aebc74e908868b09ac140fb5a53cb363884c1
 - name: github.com/golang/protobuf
@@ -127,6 +131,10 @@ imports:
   version: 7fdf09982454086d5570c7db3e11f360194830ca
   subpackages:
   - internal
+- name: golang.org/x/sys
+  version: f3918c30c5c2cb527c0b071a27c35120a6c0719a
+  subpackages:
+  - windows
 - name: google.golang.org/appengine
   version: 170382fa85b10b94728989dfcf6cc818b335c952
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -46,3 +46,4 @@ import:
 - package: github.com/fullsailor/pkcs7
 - package: github.com/google/shlex
 - package: github.com/onsi/gomega
+- package: github.com/awnumar/memguard

--- a/registry/client.go
+++ b/registry/client.go
@@ -12,7 +12,8 @@ import (
 
 // TokenHolder holds an authorization token
 type TokenHolder interface {
-	Token() string
+	HasToken() bool
+	Token() []byte
 }
 
 // Client exposes the registry REST API.
@@ -110,8 +111,8 @@ func (rt *registryRoundTripper) NewRequest(method, path string,
 		return nil, err
 	}
 
-	if tok := rt.holder.Token(); tok != "" {
-		req.Header.Set("Authorization", "Bearer "+tok)
+	if rt.holder.HasToken() {
+		req.Header.Set("Authorization", "Bearer "+string(rt.holder.Token()))
 	}
 
 	req.Header.Set("User-Agent", "Torus-Daemon/"+rt.version)


### PR DESCRIPTION
Instead of storing long lived encryption keys in standard memory which
can be swapped to disk or core dumped sensitive data is stored inside
guarded memory using the excellent golang
[memguard](github.com/awnumar/memguard) library.

Some values may be stored in non-secure memory during signup or login.