### PR TITLE
Introduce torus export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ _Unreleased_
   organization.
 - Changed the output style of `teams members` to match the output style of
   `orgs members --org ORG`.
+- Introduced the `torus export` command making it easy to export secrets from a
+  specific environment and service. As a result the `torus view` `--format, -f`
+  flas has been deprecated and will be removed on December 31st 2017.
 - Encryption keys, user passwords, and machine secret tokens are now stored in
   secure and guarded memory making it more difficult to extract data from a
   running process.

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/torus-cli/apitypes"
+	"github.com/manifoldco/torus-cli/errs"
+)
+
+var formatValues = []string{"env", "bash", "powershell", "fish", "cmd", "json"}
+var formatDescription = "Format of exported secrets (" + strings.Join(formatValues, ", ") + ")"
+
+type mod int
+
+const (
+	_ mod = iota
+	quotes
+	uppercase
+)
+
+func init() {
+	export := cli.Command{
+		Name:      "export",
+		Usage:     "Export secrets for a specific environment and service inside a project",
+		ArgsUsage: "[path to file] or use stdout redirection (e.g. `torus export > config.env`)",
+		Category:  "SECRETS",
+		Flags: []cli.Flag{
+			stdOrgFlag,
+			stdProjectFlag,
+			stdEnvFlag,
+			serviceFlag("Use this service.", "default", true),
+			userFlag("Use this user.", false),
+			machineFlag("Use this machine.", false),
+			stdInstanceFlag,
+			formatFlag(formatValues[0], formatDescription),
+		},
+		Action: chain(
+			ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
+			setUserEnv, checkRequiredFlags, exportCmd,
+		),
+	}
+
+	Cmds = append(Cmds, export)
+}
+
+func exportCmd(ctx *cli.Context) error {
+	args := ctx.Args()
+	filepath := ""
+	if len(args) > 0 {
+		if len(args) != 1 {
+			return errs.NewUsageExitError("Only one argument can be supplied.", ctx)
+		}
+
+		filepath = args[0]
+	}
+
+	secrets, _, err := getSecrets(ctx)
+	if err != nil {
+		return err
+	}
+
+	format := ctx.String("format")
+	if !validFormat(format) {
+		return errs.NewUsageExitError(fmt.Sprintf("Invalid format provided: %s", format), ctx)
+	}
+
+	var w io.Writer = os.Stdout
+	if filepath != "" {
+		fd, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return errs.NewErrorExitError("Could not write to given filepath", err)
+		}
+		defer fd.Close()
+
+		w = fd
+	}
+
+	switch format {
+	case "env":
+		err = writeFormat(w, secrets, "%s=%s\n", uppercase|quotes)
+	case "bash":
+		err = writeFormat(w, secrets, "export %s=%s\n", uppercase|quotes)
+	case "powershell":
+		err = writeFormat(w, secrets, "$Env:%s = \"%s\"\n", uppercase)
+	case "cmd":
+		err = writeFormat(w, secrets, "set %s=%s\n", quotes)
+	case "fish":
+		err = writeFormat(w, secrets, "set -x %s %s;\n", quotes)
+	case "json":
+		err = writeJSONFormat(w, secrets)
+	default:
+		return errs.NewUsageExitError(fmt.Sprintf("Could not find format for %s", format), ctx)
+	}
+
+	if err != nil {
+		return errs.NewErrorExitError(fmt.Sprintf("Could not write format for %s", format), err)
+	}
+
+	return nil
+}
+
+func writeFormat(w io.Writer, secrets []apitypes.CredentialEnvelope, format string, modifier mod) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, secret := range secrets {
+		name := (*secret.Body).GetName()
+		value := (*secret.Body).GetValue().String()
+
+		if modifier&quotes == quotes {
+			value = fmt.Sprintf("%q", value)
+		}
+
+		if (modifier & uppercase) == uppercase {
+			name = strings.ToUpper(name)
+		}
+
+		fmt.Fprintf(tw, format, name, value)
+	}
+
+	return tw.Flush()
+}
+
+func validFormat(format string) bool {
+	for _, v := range formatValues {
+		if v == format {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -23,7 +23,7 @@ func init() {
 	c := cli.Command{
 		Name:      "import",
 		Usage:     "Import multiple secrets from an env file",
-		ArgsUsage: "<file> or use stdin redirection (eg: torus import < secrets.env)",
+		ArgsUsage: "[path to file] or use stdin redirection (e.g. `torus import < secrets.env`)",
 		Category:  "SECRETS",
 		Flags:     setUnsetFlags,
 		Action: chain(

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -75,7 +75,7 @@ func setCmd(ctx *cli.Context) error {
 
 	fmt.Printf("\nCredential %s has been set at %s/%s\n", name, path, name)
 
-	hints.Display(hints.View, hints.Run, hints.Unset, hints.Import)
+	hints.Display(hints.View, hints.Run, hints.Unset, hints.Import, hints.Export)
 	return nil
 }
 

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -66,35 +66,18 @@ func viewCmd(ctx *cli.Context) error {
 
 	switch format {
 	case "env":
-		err = writeEnvFormat(w, secrets, path)
+		err = writeFormat(w, secrets, "%s=%s\r\n", uppercase|quotes)
 	case "verbose":
 		err = writeVerboseFormat(w, secrets, path)
 	case "json":
-		err = writeJSONFormat(w, secrets, path)
+		err = writeJSONFormat(w, secrets)
 	default:
 		return errs.NewUsageExitError("Unknown format: "+format, ctx)
 	}
 
-	hints.Display(hints.Link, hints.Run)
+	hints.Display(hints.Link, hints.Run, hints.Export)
 
 	return err
-}
-
-func writeEnvFormat(w io.Writer, secrets []apitypes.CredentialEnvelope, path string) error {
-	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
-
-	for _, secret := range secrets {
-		value := (*secret.Body).GetValue().String()
-		name := (*secret.Body).GetName()
-		key := strings.ToUpper(name)
-		if strings.Contains(value, " ") {
-			fmt.Fprintf(tw, "%s=%q\n", key, value)
-		} else {
-			fmt.Fprintf(tw, "%s=%s\n", key, value)
-		}
-	}
-
-	return tw.Flush()
 }
 
 func writeVerboseFormat(w io.Writer, secrets []apitypes.CredentialEnvelope, path string) error {
@@ -116,7 +99,7 @@ func writeVerboseFormat(w io.Writer, secrets []apitypes.CredentialEnvelope, path
 	return tw.Flush()
 }
 
-func writeJSONFormat(w io.Writer, secrets []apitypes.CredentialEnvelope, path string) error {
+func writeJSONFormat(w io.Writer, secrets []apitypes.CredentialEnvelope) error {
 	keyMap := make(map[string]interface{})
 
 	for _, secret := range secrets {

--- a/cmd/view_test.go
+++ b/cmd/view_test.go
@@ -9,29 +9,6 @@ import (
 	"github.com/manifoldco/torus-cli/pathexp"
 )
 
-func TestWriteEnvFormat(t *testing.T) {
-	var buf bytes.Buffer
-	w := bufio.NewWriter(&buf)
-
-	creds, path := viewCredentialsHelper(t)
-
-	err := writeEnvFormat(w, creds, path)
-
-	expected := `FOO=bar
-BAZ="two words"
-`
-	w.Flush()
-	got := string(buf.Bytes())
-
-	if err != nil {
-		t.Errorf("writeEnvFormat() expected no errors, got %s", err)
-	}
-
-	if expected != got {
-		t.Errorf("writeEnvFormat() expected\n%q\ngot\n%q\n", expected, got)
-	}
-}
-
 func TestWriteVerboseFormat(t *testing.T) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
@@ -61,9 +38,9 @@ func TestWriteJSONFormat(t *testing.T) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 
-	creds, path := viewCredentialsHelper(t)
+	creds, _ := viewCredentialsHelper(t)
 
-	err := writeJSONFormat(w, creds, path)
+	err := writeJSONFormat(w, creds)
 
 	expected := `{
   "baz": "two words",

--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -126,6 +126,39 @@ Credential port has been set at /myorg/myproject/production/default/*/*/PORT
 Credential mysql_url has been set at /myorg/myproject/production/default/*/*/MYSQL_URL
 ```
 
+## export
+###### Added [v0.28.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
+
+`torus export [file-path]` or using stdout redirection (e.g. `torus export -e production > config.env`) exports the secrets for a specific project, environment, and service to a file or stdout. The output format can be specified using the `--format, -f` flag supporting `env`, `bash`, `powershell`, `cmd` (windows command prompt), `fish`, and `json`.
+
+**Examples**
+
+All examples assumed the command is ran inside a [linked](./project-structure.md#link) directory.
+
+```bash
+# Exporting secrets from a specific environment to stdin
+$ torus export -e prod
+MYSQLDB_URL="mysql://user:password@host.com:3306/db"
+
+# Exporting secrets from a specific environment to stdin for powershell
+$ torus export -e prod
+$Env:MYSQLDB_URL = "mysql://user:password@host.com:3306/db"
+
+# Exporting secrets from a specific environment piped to a file
+$ torus export -e prod > config.env
+
+# Exporting secrets from a specific environment to a file
+$ torus export -e prod config.env
+
+# Exporting secrets from a specific environment into a bash shell
+$ eval "$(torus export -e prod -f bash)"
+$ echo $MYSQLDB_URL
+mysql://user:password@host.com:3306/db
+
+# Exporting secrets from a specific environment and service into a powershell
+$ torus export -e prod -s api -f powershell
+```
+
 ## view
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 

--- a/hints/hints.go
+++ b/hints/hints.go
@@ -20,6 +20,9 @@ const (
 	// Deny command adds hint to `torus deny`
 	Deny
 
+	// Export command adds hints for `torus export`
+	Export
+
 	// GettingStarted displays helpful hints when a user signs up
 	GettingStarted
 
@@ -111,6 +114,9 @@ func init() {
 		View: {
 			"View secret values which have been set using `torus view`",
 			"See the exact path for each secret set using `torus view -v`",
+		},
+		Export: {
+			"Export secrets for a specific environment and service using `torus export`",
 		},
 	}
 }

--- a/internal/qa.md
+++ b/internal/qa.md
@@ -178,3 +178,4 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 - [ ]   `torus run <command>` without a service defaults to "default" service
 - [ ]   `torus unset [key] —service [service]` will unset the variable
 - [ ]   `torus import` imports multiple secrets from a file
+- [ ]   `torus export` exports secrets for a specific env/service to a file and shell


### PR DESCRIPTION
The `export` command makes it easy to export secrets for a specific
environment and service to a file or into a shell environment (such as
fish, bash, powershell, etc).

Closes manifoldco/torus-cli#324