### PR TITLE
Skip decryption of credentials when listing

### DIFF
--- a/api/credentials.go
+++ b/api/credentials.go
@@ -15,10 +15,11 @@ type CredentialsClient struct {
 	client *apiRoundTripper
 }
 
-// Search returns all credentials at the given pathexp.
+// Search returns all credentials at the given pathexp in an undecrypted state
 func (c *CredentialsClient) Search(ctx context.Context, pathexp string) ([]apitypes.CredentialEnvelope, error) {
 	v := &url.Values{}
 	v.Set("pathexp", pathexp)
+	v.Set("skip-decryption", "true")
 
 	return c.listWorker(ctx, v)
 }

--- a/apitypes/credential_test.go
+++ b/apitypes/credential_test.go
@@ -84,6 +84,16 @@ func TestCredentialValueUnmarshalJSON(t *testing.T) {
 
 	})
 
+	tc("undecrypted", "", func(t *testing.T, c *CredentialValue) {
+		if c.IsUnset() {
+			t.Error("value is unset")
+		}
+
+		if !c.IsUndecrypted() {
+			t.Error("value is undecrypted")
+		}
+	})
+
 	t.Run("quoted json string", func(t *testing.T) {
 		jsonString := strconv.Quote(`{"version":1,"body":{"type":"string","value":"12345678"}}`)
 		c := CredentialValue{}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -145,6 +145,7 @@ func listObjects(ctx *cli.Context) error {
 			pathsErr = err
 			break
 		}
+
 		for _, cred := range creds {
 			body := *cred.Body
 			if body.GetValue() == nil {

--- a/daemon/logic/utils.go
+++ b/daemon/logic/utils.go
@@ -2,7 +2,9 @@ package logic
 
 import (
 	"context"
+	"encoding/json"
 	"log"
+	"strconv"
 	"time"
 
 	"golang.org/x/crypto/ed25519"
@@ -54,6 +56,32 @@ func packageEncryptionKeypair(ctx context.Context, c *crypto.Engine, authID, org
 	}
 
 	return pubenc, privenc, nil
+}
+
+func packagePlaintextCred(c envelope.CredentialInf, value string) PlaintextCredentialEnvelope {
+	state := "set"
+	return PlaintextCredentialEnvelope{
+		ID:      c.GetID(),
+		Version: c.GetVersion(),
+		Body: &PlaintextCredential{
+			Name:      c.Name(),
+			PathExp:   c.PathExp(),
+			ProjectID: c.ProjectID(),
+			OrgID:     c.OrgID(),
+			Value:     value,
+			State:     &state,
+		},
+	}
+}
+
+func extractCredentialValue(pt []byte) (*apitypes.CredentialValue, error) {
+	cValue := &apitypes.CredentialValue{}
+	err := json.Unmarshal([]byte(strconv.Quote(string(pt))), cValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return cValue, nil
 }
 
 // createCredentialGraph generates, signs, and posts a new CredentialGraph

--- a/daemon/routes/credentials.go
+++ b/daemon/routes/credentials.go
@@ -27,6 +27,7 @@ func credentialsGetRoute(engine *logic.Engine, o *observer.Observer) http.Handle
 
 		path := q.Get("path")
 		pathexp := q.Get("pathexp")
+		skip := q.Get("skip-decryption") == "true"
 		if path == "" && pathexp == "" {
 			err = errors.New("missing path or pathexp")
 			log.Printf("Error constructing request: %s", err)
@@ -36,9 +37,9 @@ func credentialsGetRoute(engine *logic.Engine, o *observer.Observer) http.Handle
 
 		var creds []logic.PlaintextCredentialEnvelope
 		if path != "" {
-			creds, err = engine.RetrieveCredentials(ctx, n, &path, nil)
+			creds, err = engine.RetrieveCredentials(ctx, n, &path, nil, skip)
 		} else {
-			creds, err = engine.RetrieveCredentials(ctx, n, nil, &pathexp)
+			creds, err = engine.RetrieveCredentials(ctx, n, nil, &pathexp, skip)
 		}
 		if err != nil {
 			// Rely on logs inside engine for debugging


### PR DESCRIPTION
When a user is listing credentials via `torus ls` we no longer decrypt
each credential. Instead we return a credential with no value and a type
of `undecrypted`.

This is a step to implementing `torus list`.

Related manifoldco/torus-cli#322