### PR TITLE
 Introduce `tfvars` format to torus export 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ _Unreleased_
 
 ## v0.27.0
 
-_2017-10-08_
+_2017-11-08_
 
 **Notable Changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ _Unreleased_
 - Encryption keys, user passwords, and machine secret tokens are now stored in
   secure and guarded memory making it more difficult to extract data from a
   running process.
-- Added command `torus list` to display credentials and project structure.
-- Removed `torus ls`
+- Replace `torus ls` with `torus list` making it easy to list and search for secrets within a project.
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _Unreleased_
 - Introduced the `torus export` command making it easy to export secrets from a
   specific environment and service. As a result the `torus view` `--format, -f`
   flas has been deprecated and will be removed on December 31st 2017.
+- Using `torus export`, you can now export secrets to [terraform's](https://terraform.io) `tfvars` file format.
 - Encryption keys, user passwords, and machine secret tokens are now stored in
   secure and guarded memory making it more difficult to extract data from a
   running process.

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -13,7 +13,7 @@ import (
 	"github.com/manifoldco/torus-cli/errs"
 )
 
-var formatValues = []string{"env", "bash", "powershell", "fish", "cmd", "json"}
+var formatValues = []string{"env", "bash", "powershell", "fish", "cmd", "json", "tfvars"}
 var formatDescription = "Format of exported secrets (" + strings.Join(formatValues, ", ") + ")"
 
 type mod int
@@ -92,6 +92,8 @@ func exportCmd(ctx *cli.Context) error {
 		err = writeFormat(w, secrets, "set %s=%s\n", quotes)
 	case "fish":
 		err = writeFormat(w, secrets, "set -x %s %s;\n", quotes)
+	case "tfvars":
+		err = writeFormat(w, secrets, "%s = %s\n", quotes)
 	case "json":
 		err = writeJSONFormat(w, secrets)
 	default:

--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -129,7 +129,7 @@ Credential mysql_url has been set at /myorg/myproject/production/default/*/*/MYS
 ## export
 ###### Added [v0.28.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
-`torus export [file-path]` or using stdout redirection (e.g. `torus export -e production > config.env`) exports the secrets for a specific project, environment, and service to a file or stdout. The output format can be specified using the `--format, -f` flag supporting `env`, `bash`, `powershell`, `cmd` (windows command prompt), `fish`, and `json`.
+`torus export [file-path]` or using stdout redirection (e.g. `torus export -e production > config.env`) exports the secrets for a specific project, environment, and service to a file or stdout. The output format can be specified using the `--format, -f` flag supporting `env`, `bash`, `powershell`, `cmd` (windows command prompt), `fish`, `json`, `tfvars` (for exporting to [terraform](https://terraform.io) variable files).
 
 **Examples**
 
@@ -157,6 +157,9 @@ mysql://user:password@host.com:3306/db
 
 # Exporting secrets from a specific environment and service into a powershell
 $ torus export -e prod -s api -f powershell
+
+# Exporting secrets to a tfvars file
+$ torus export -e prod -s api -f tfvars secrets.tfvars && terraform plan -var-file=secrets.tfvars
 ```
 
 ## view
@@ -225,8 +228,8 @@ $ torus list secret1
 /org/project/
     env1/
         ser1/
-            secret1      
-        ser2/          
+            secret1
+        ser2/
     env2/
         ser1/
             secret1
@@ -247,7 +250,7 @@ $ torus list -s ser1
 /org/project/
     env1/
         ser1/
-            secret1               
+            secret1
     env2/
         ser1/
             secret1


### PR DESCRIPTION
A user can now export secrets from torus to the `tfvars` file format.

Related #318