### PR TITLE
Filter out nil errors when returning multiple

### DIFF
--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/urfave/cli"
 	"github.com/juju/ansiterm"
+	"github.com/urfave/cli"
 
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/apitypes"
@@ -135,7 +135,7 @@ func orgsListCmd(ctx *cli.Context) error {
 	if session.Type() == apitypes.UserSession {
 		for i, o := range orgs {
 			if o.Body.Name == session.Username() {
-				fmt.Printf("%s %s\n", o.Body.Name, "(" + ui.Faint("personal") + ")")
+				fmt.Printf("%s %s\n", o.Body.Name, "("+ui.Faint("personal")+")")
 				withoutPersonal = append(orgs[:i], orgs[i+1:]...)
 			}
 		}
@@ -323,7 +323,7 @@ func orgsMembersListCmd(ctx *cli.Context) error {
 
 	getMembersTeamsSession.Wait()
 	if tErr != nil || mErr != nil || sErr != nil {
-		return cli.NewMultiError(
+		return errs.MultiError(
 			tErr,
 			mErr,
 			sErr,

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -200,7 +200,7 @@ func getOrgPolicyAndTeam(ctx context.Context, client *api.Client, orgName,
 
 	waitPolicy.Wait()
 	if tErr != nil || pErr != nil {
-		return nil, nil, nil, cli.NewMultiError(
+		return nil, nil, nil, errs.MultiError(
 			tErr,
 			pErr,
 		)
@@ -368,7 +368,7 @@ func listPoliciesCmd(ctx *cli.Context) error {
 	}()
 
 	if aErr != nil || pErr != nil || tErr != nil {
-		return cli.NewMultiError(
+		return errs.MultiError(
 			pErr,
 			aErr,
 			tErr,
@@ -525,7 +525,7 @@ func testPolicies(ctx *cli.Context) error {
 	wg.Wait()
 
 	if teamsErr != nil || policiesErr != nil {
-		return cli.NewMultiError(teamsErr, policiesErr,
+		return errs.MultiError(teamsErr, policiesErr,
 			errs.NewExitError(policyTestFailed))
 	}
 
@@ -606,7 +606,7 @@ func getTeamsForUser(c context.Context, client *api.Client, userName *string,
 	wg.Wait()
 
 	if userErr != nil || teamErr != nil {
-		return nil, cli.NewMultiError(userErr, teamErr,
+		return nil, errs.MultiError(userErr, teamErr,
 			errs.NewExitError(policyTestFailed),
 		)
 	}
@@ -680,7 +680,7 @@ func getPoliciesAndAttachments(c context.Context, client *api.Client,
 	wg.Wait()
 
 	if aErr != nil || pErr != nil {
-		return nil, nil, cli.NewMultiError(pErr, aErr,
+		return nil, nil, errs.MultiError(pErr, aErr,
 			errs.NewExitError(policyTestFailed))
 	}
 	return policies, attachments, nil

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/urfave/cli"
 	"github.com/juju/ansiterm"
+	"github.com/urfave/cli"
 
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/apitypes"
@@ -157,7 +157,7 @@ func teamsListCmd(ctx *cli.Context) error {
 			continue
 		}
 
-		numTeams += 1;
+		numTeams += 1
 
 		isMember := ""
 		displayTeamType := ""
@@ -427,7 +427,7 @@ func teamsRemoveCmd(ctx *cli.Context) error {
 
 	wait.Wait()
 	if uErr != nil || oErr != nil || tErr != nil {
-		return cli.NewMultiError(
+		return errs.MultiError(
 			oErr,
 			uErr,
 			tErr,
@@ -527,7 +527,7 @@ func teamsAddCmd(ctx *cli.Context) error {
 
 	wait.Wait()
 	if uErr != nil || oErr != nil || tErr != nil {
-		return cli.NewMultiError(
+		return errs.MultiError(
 			oErr,
 			uErr,
 			tErr,


### PR DESCRIPTION
In several places we were not filtering out nil errors when we needed to
return multiple errors at once.

We now use `errs.MultiError` to filter out nil errors :)