### PR TITLE
Improve validation errors displayed to users

### DIFF
--- a/cmd/allow.go
+++ b/cmd/allow.go
@@ -92,9 +92,10 @@ func doCrudl(ctx *cli.Context, effect primitive.PolicyEffect, extra primitive.Po
 			time.Now().Format(time.RFC822Z), session.Username())
 	}
 
-	if err := validate.Slug(name, "policy", nil); err != nil {
+	if err := validate.PolicyName(name); err != nil {
 		return errs.NewErrorExitError("Invalid name provided.", err)
 	}
+
 	if err := validate.Description(description, "policy"); err != nil {
 		return errs.NewErrorExitError("Invalid description provided.", err)
 	}

--- a/cmd/invites_accept.go
+++ b/cmd/invites_accept.go
@@ -10,6 +10,7 @@ import (
 	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
 	"github.com/manifoldco/torus-cli/promptui"
+	"github.com/manifoldco/torus-cli/validate"
 )
 
 const acceptInviteFailed = "Could not accept invitation to org, please try again."
@@ -66,7 +67,7 @@ func invitesAccept(ctx *cli.Context) error {
 
 	email := args[0]
 	code := args[1]
-	err = validateInviteCode(code)
+	err = validate.InviteCode(code)
 	if err != nil {
 		return err
 	}

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"text/tabwriter"
 
-	"github.com/urfave/cli"
 	"github.com/juju/ansiterm"
+	"github.com/urfave/cli"
 
 	"github.com/manifoldco/torus-cli/api"
 	"github.com/manifoldco/torus-cli/apitypes"
@@ -133,10 +133,10 @@ func attachPolicyCmd(ctx *cli.Context) error {
 	policyName := args[0]
 	teamName := args[1]
 
-	if err := validate.Slug(policyName, "policy", nil); err != nil {
+	if err := validate.PolicyName(policyName); err != nil {
 		return errs.NewUsageExitError("Invalid policy name provided", ctx)
 	}
-	if err := validate.Slug(teamName, "team", nil); err != nil {
+	if err := validate.TeamName(teamName); err != nil {
 		return errs.NewUsageExitError("Invalid team name provided", ctx)
 	}
 
@@ -234,10 +234,10 @@ func detachPolicyCmd(ctx *cli.Context) error {
 	policyName := args[0]
 	teamName := args[1]
 
-	if err := validate.Slug(policyName, "policy", nil); err != nil {
+	if err := validate.PolicyName(policyName); err != nil {
 		return errs.NewUsageExitError("Invalid policy name provided", ctx)
 	}
-	if err := validate.Slug(teamName, "team", nil); err != nil {
+	if err := validate.TeamName(teamName); err != nil {
 		return errs.NewUsageExitError("Invalid team name provided", ctx)
 	}
 
@@ -287,7 +287,7 @@ func deletePolicyCmd(ctx *cli.Context) error {
 	}
 
 	policyName := args[0]
-	if err := validate.Slug(policyName, "policy", nil); err != nil {
+	if err := validate.PolicyName(policyName); err != nil {
 		return errs.NewUsageExitError("Invalid policy name provided", ctx)
 	}
 
@@ -425,7 +425,7 @@ func viewPolicyCmd(ctx *cli.Context) error {
 	}
 
 	policyName := args[0]
-	if err := validate.Slug(policyName, "policy", nil); err != nil {
+	if err := validate.PolicyName(policyName); err != nil {
 		return errs.NewUsageExitError("Invalid policy name provided", ctx)
 	}
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,26 +1,89 @@
 package validate
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/asaskevich/govalidator"
+
+	"github.com/manifoldco/torus-cli/promptui"
 )
 
 const slugPattern = "^[a-z][a-z0-9\\-\\_]{0,63}$"
 const namePattern = "^[a-zA-Z\\s,\\.'\\-pL]{3,64}$"
+const inviteCodePattern = "(?i)^[0-9a-ht-zjkmnpqr]{10}$"
+const verifyCodePattern = "(?i)^[0-9a-ht-zjkmnpqr]{9}$"
 
-// Slug validates whether the input meets slug requirements
-func Slug(input, fieldName string, errorMessage *string) error {
-	if govalidator.StringMatches(input, slugPattern) {
+const slugErrorPattern = "%s must be between 1 and 64 characters in length and only contain letters in the alphabet, numbers, hyphens, and underscores"
+const nameErrorPattern = "%s must be between 3 and 64 characters in length and only contain letters, commas, periods, apostraphes, and hyphens"
+
+// ProjectName validates whether the input meets the project name requirements
+var ProjectName ValidateFunc
+
+// OrgName validates whether the input meets the org name requirements
+var OrgName ValidateFunc
+
+// TeamName validates whether the input meets the team name requirements
+var TeamName ValidateFunc
+
+// PolicyName validates whether the input meets the policy name requirements
+var PolicyName ValidateFunc
+
+// Username validates whether the input meets the username requirements
+var Username ValidateFunc
+
+func init() {
+	ProjectName = SlugValidator("Project names")
+	OrgName = SlugValidator("Org names")
+	TeamName = SlugValidator("Team names")
+	Username = SlugValidator("Usernames")
+	PolicyName = SlugValidator("Policy names")
+}
+
+// ValidationError represents an error encountered when validating a field
+type ValidationError struct {
+	msg string
+}
+
+// Error returns the error message completing the Error interface
+func (e *ValidationError) Error() string {
+	return e.msg
+}
+
+// NewValidationError returns a validation error
+func NewValidationError(msg string) error {
+	return &ValidationError{msg: msg}
+}
+
+// ValidateFunc represents a validation function
+type ValidateFunc promptui.ValidateFunc
+
+// SlugValidator returns a validation function
+func SlugValidator(fieldName string) ValidateFunc {
+	return func(input string) error {
+		if govalidator.StringMatches(input, slugPattern) {
+			return nil
+		}
+
+		return NewValidationError(fmt.Sprintf(slugErrorPattern, fieldName))
+	}
+}
+
+// InviteCode validates whether the input meets the invite code requirements
+func InviteCode(input string) error {
+	if govalidator.StringMatches(input, inviteCodePattern) {
 		return nil
 	}
-	var msg string
-	if errorMessage != nil {
-		msg = *errorMessage
-	} else {
-		msg = fieldName + " names can only use a-z, 0-9, hyphens and underscores"
+
+	return NewValidationError("Please enter a valid invite code. Make sure to copy the entire code from the email!")
+}
+
+// VerificationCode validates whether the input meets the verification code requirements
+func VerificationCode(input string) error {
+	if govalidator.StringMatches(input, verifyCodePattern) {
+		return nil
 	}
-	return errors.New(msg)
+
+	return NewValidationError("Please enter a valid verification code. Make sure to copy the entire code from the email!")
 }
 
 // Description validates whether the input meets the descriptin requirements
@@ -29,7 +92,7 @@ func Description(input, fieldName string) error {
 		return nil
 	}
 
-	return errors.New(fieldName + " descriptions must be less than 500 characters")
+	return NewValidationError(fieldName + " descriptions must be less than 500 characters")
 }
 
 // Email validates whether the input is a valid email format
@@ -37,7 +100,8 @@ func Email(input string) error {
 	if govalidator.IsEmail(input) {
 		return nil
 	}
-	return errors.New("Please enter a valid email address")
+
+	return NewValidationError("Please enter a valid email address")
 }
 
 // Name validates whether the input meets first name last name requirements
@@ -45,13 +109,8 @@ func Name(input string) error {
 	if govalidator.StringMatches(input, namePattern) {
 		return nil
 	}
-	return errors.New("Please enter a valid name")
-}
 
-// Username validates whether the input meets username requirements
-func Username(input string) error {
-	message := "Please enter a valid username"
-	return Slug(input, "username", &message)
+	return NewValidationError(fmt.Sprintf(nameErrorPattern, "Names"))
 }
 
 // Password ensures the input meets password requirements
@@ -61,8 +120,25 @@ func Password(input string) error {
 		return nil
 	}
 	if length > 0 {
-		return errors.New("Passwords must be at least 8 characters")
+		return NewValidationError("Passwords must be at least 8 characters")
 	}
 
-	return errors.New("Please enter your password")
+	return NewValidationError("Please enter a password")
+}
+
+// ConfirmPassword ensures the input meets the password requirements and
+// matches the previously provided password
+func ConfirmPassword(previous string) ValidateFunc {
+	return func(input string) error {
+		err := Password(input)
+		if err != nil {
+			return err
+		}
+
+		if input != previous {
+			return NewValidationError("The password you provided does not match the previous password you provided!")
+		}
+
+		return nil
+	}
 }


### PR DESCRIPTION
We now return more informative errors to the user when validating slugs
and names across the cli.

At the same time as doing this, I refactored to reduce repetition across
our usage of promptui.

Closes #342