### PR TITLE
Add dep prune options to dep manifest

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,3 +128,7 @@ required = [
 [[constraint]]
   name = "github.com/google/go-github"
   revision = "466070b0580728e63bd1a415e0019639e55d7148"
+
+[prune]
+  non-go = true
+  go-tests = true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ platform:
 environment:
   GOPATH: c:\gopath
   GOVERSION: 1.9.1
-  DEPVERSION: 0.3.2
+  DEPVERSION: 0.4.1
 
 init:
   - git config --global core.autocrlf input


### PR DESCRIPTION
With 0.4.0, dep now runs `prune` automatically when when using `ensure`.
Dep will check in the manifest for what options are needed for pruning.

This commit sets the prune settings to remove non-go files (exlcuding
LICENSE and AUTHORS), go test files. Unused (non-imported) packages need
to be included because of the tools/ package.
