### PR TITLE
Deprecate concept of instance and identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 _Date_
 
+**Breaking Changes**
+
+The concept of instance and identity as a part of the secret path has been
+deprecated. Existing secrets set with non `*` identity and instance values can
+still be set and unset by providing the full 7 segment path (e.g. `torus set
+/org/project/environment/service/identity/instance/secret`).
+
+Torus will only display the full 7 segment path if identity or instance is a
+non `*` value (e.g. `/org/project/environment/service/machine-api/1/secret`).
+In all other cases, a 5 segment path will be displayed (e.g.
+`/org/project/environment/service/secret`).
+
 **Notable Changes**
 
 - The status of your account is now displayed via `torus profile view`
@@ -14,6 +26,20 @@ _Date_
 - The experimental and hidden `policies test` command has been removed.
 - Added spinners to represent progress. This means fewer lasting print-outs
   for certain commands.
+- The `user`, `machine`, and `instance` flags have been removed from `torus
+  set`, `torus unset`, `torus import`, `torus export`, and `torus view`.
+- Instance and identity values are no longer displayed via `torus status`.
+- `torus allow` and `torus deny` now accept a 5 segment path along with the
+  deprecated 7 path version (e.g. `torus allow crudl
+  /org/project/env/service/secret <team>`).
+- `torus policies view` will only display the full 7 segment path if the
+  `identity` or `identity` components are not a `*`.
+- `torus view` and `torus list` will only display the full 7 segment path in
+  verbose mode if the `instance` and `identity` components are not a `*`.
+
+**Fixes**
+
+- `torus list` did not display secrets which were not set with an instance of `*`.
 
 ## v0.29.0
 

--- a/cmd/allow.go
+++ b/cmd/allow.go
@@ -146,10 +146,15 @@ func doCrudl(ctx *cli.Context, effect primitive.PolicyEffect, extra primitive.Po
 	fmt.Fprintf(w, "Description:\t%s\n", description)
 
 	for _, s := range res.Body.Policy.Statements {
+		rpath, err := displayResourcePath(s.Resource)
+		if err != nil {
+			return errs.NewErrorExitError("Could not parse resource path", err)
+		}
+
 		fmt.Fprintln(w, "")
 		fmt.Fprintf(w, "Effect:\t%s\n", s.Effect.String())
 		fmt.Fprintf(w, "Action(s):\t%s\n", s.Action.String())
-		fmt.Fprintf(w, "Resource:\t%s\n", s.Resource)
+		fmt.Fprintf(w, "Resource:\t%s\n", rpath)
 	}
 	w.Flush()
 
@@ -176,7 +181,7 @@ func parseRawPath(rawPath string) (*pathexp.PathExp, *string, error) {
 		return nil, nil, errs.NewExitError("Invalid secret name " + secret)
 	}
 
-	pe, err := pathexp.Parse(path)
+	pe, err := parsePathExp(path)
 	if err != nil {
 		return nil, nil, errs.NewErrorExitError("Invalid path expression", err)
 	}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -36,9 +36,6 @@ func init() {
 			stdProjectFlag,
 			stdEnvFlag,
 			serviceFlag("Use this service.", "default", true),
-			userFlag("Use this user.", false),
-			machineFlag("Use this machine.", false),
-			stdInstanceFlag,
 			formatFlag(formatValues[0], formatDescription),
 		},
 		Action: chain(

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -70,7 +70,7 @@ func importCmd(ctx *cli.Context) error {
 	for _, cred := range creds {
 		name := (*cred.Body).GetName()
 		pe := (*cred.Body).GetPathExp()
-		fmt.Printf("Credential %s has been set at %s/%s\n", name, pe, name)
+		fmt.Printf("Credential %s has been set at %s/%s\n", name, displayPathExp(pe), name)
 	}
 
 	hints.Display(hints.View, hints.Set)

--- a/cmd/invites.go
+++ b/cmd/invites.go
@@ -18,7 +18,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setSliceDefaults, setUserEnv, checkRequiredFlags, invitesSend,
+					setSliceDefaults, checkRequiredFlags, invitesSend,
 				),
 			},
 			{
@@ -33,7 +33,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, invitesList,
+					checkRequiredFlags, invitesList,
 				),
 			},
 			{
@@ -45,7 +45,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs,
-					loadPrefDefaults, setUserEnv, checkRequiredFlags, invitesApprove,
+					loadPrefDefaults, checkRequiredFlags, invitesApprove,
 				),
 			},
 			{
@@ -57,7 +57,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, loadDirPrefs,
-					loadPrefDefaults, setUserEnv, checkRequiredFlags, invitesAccept,
+					loadPrefDefaults, checkRequiredFlags, invitesAccept,
 				),
 			},
 		},

--- a/cmd/keypairs.go
+++ b/cmd/keypairs.go
@@ -31,7 +31,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, listKeypairs,
+					checkRequiredFlags, listKeypairs,
 				),
 			},
 			{
@@ -46,7 +46,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, generateKeypairs,
+					checkRequiredFlags, generateKeypairs,
 				),
 			},
 			{
@@ -58,7 +58,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, revokeKeypairs,
+					checkRequiredFlags, revokeKeypairs,
 				),
 				Hidden: true,
 			},

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -49,7 +49,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, orgsRemove,
+					checkRequiredFlags, orgsRemove,
 				),
 			},
 			{

--- a/cmd/policies.go
+++ b/cmd/policies.go
@@ -36,7 +36,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, listPoliciesCmd,
+					checkRequiredFlags, listPoliciesCmd,
 				),
 			},
 			{
@@ -48,7 +48,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, viewPolicyCmd,
+					checkRequiredFlags, viewPolicyCmd,
 				),
 			},
 
@@ -61,7 +61,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, detachPolicyCmd,
+					checkRequiredFlags, detachPolicyCmd,
 				),
 			},
 
@@ -74,7 +74,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, attachPolicyCmd,
+					checkRequiredFlags, attachPolicyCmd,
 				),
 			},
 
@@ -88,7 +88,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, deletePolicyCmd,
+					checkRequiredFlags, deletePolicyCmd,
 				),
 			},
 		},
@@ -448,7 +448,12 @@ func viewPolicyCmd(ctx *cli.Context) error {
 	w.Flush()
 
 	for _, stmt := range p.Statements {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", stmt.Effect.String(), stmt.Action.ShortString(), stmt.Resource)
+		rpath, err := displayResourcePath(stmt.Resource)
+		if err != nil {
+			return errs.NewErrorExitError("Could not parse resource path", err)
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\n", stmt.Effect.String(), stmt.Action.ShortString(), rpath)
 	}
 	w.Flush()
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,10 +22,7 @@ func init() {
 			stdOrgFlag,
 			stdProjectFlag,
 			stdEnvFlag,
-			userFlag("Use this user.", false),
-			machineFlag("Use this machine.", false),
 			serviceFlag("Use this service.", "default", true),
-			stdInstanceFlag,
 		},
 		Action: chain(
 			ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -23,10 +23,6 @@ var setUnsetFlags = []cli.Flag{
 		"", "TORUS_ENVIRONMENT", true),
 	newSlicePlaceholder("service, s", "SERVICE", "Use this service.",
 		"default", "TORUS_SERVICE", true),
-	newSlicePlaceholder("user, u", "USER", "Use this user.", "*", "TORUS_USER", false),
-	newSlicePlaceholder("machine, m", "MACHINE", "Use this machine.", "*", "TORUS_MACHINE", false),
-	newSlicePlaceholder("instance, i", "INSTANCE", "Use this instance.",
-		"*", "TORUS_INSTANCE", true),
 }
 
 func init() {
@@ -76,7 +72,7 @@ func setCmd(ctx *cli.Context) error {
 		return errs.NewErrorExitError("Could not set credential.", err)
 	}
 
-	fmt.Printf("\nCredential %s has been set at %s/%s\n", name, path, name)
+	fmt.Printf("\nCredential %s has been set at %s/%s\n", name, displayPathExp(path), name)
 
 	hints.Display(hints.View, hints.Run, hints.Unset, hints.Import, hints.Export)
 	return nil
@@ -95,7 +91,7 @@ func parseSetArgs(args []string) (key string, value string, err error) {
 		return "", "", errors.New("Too many arguments were provided")
 	}
 
-	key = args[0]
+	key = strings.ToLower(args[0])
 	value = args[1]
 
 	if key == "" || value == "" {
@@ -118,7 +114,7 @@ func determinePath(ctx *cli.Context, path string) (*pathexp.PathExp, *string, er
 	var err error
 	if idx != -1 {
 		path := path[:idx]
-		pe, err = pathexp.ParsePartial(path)
+		pe, err = parsePathExp(path)
 		if err != nil {
 			return nil, nil, errs.NewExitError(err.Error())
 		}
@@ -143,18 +139,13 @@ func determinePathFromFlags(ctx *cli.Context) (*pathexp.PathExp, error) {
 		return nil, err
 	}
 
-	identity, err := deriveIdentitySlice(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	return pathexp.New(
 		ctx.String("org"),
 		ctx.String("project"),
 		ctx.StringSlice("environment"),
 		ctx.StringSlice("service"),
-		identity,
-		ctx.StringSlice("instance"),
+		[]string{"*"},
+		[]string{"*"},
 	)
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 	"text/tabwriter"
 
-	"github.com/manifoldco/torus-cli/api"
-	"github.com/manifoldco/torus-cli/config"
 	"github.com/manifoldco/torus-cli/errs"
 	"github.com/manifoldco/torus-cli/prefs"
 	"github.com/manifoldco/torus-cli/ui"
@@ -62,19 +59,6 @@ func statusCmd(ctx *cli.Context) error {
 		return errs.NewExitError(msg)
 	}
 
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return err
-	}
-
-	client := api.NewClient(cfg)
-	c := context.Background()
-
-	session, err := client.Session.Who(c)
-	if err != nil {
-		return errs.NewErrorExitError("Error fetching identity", err)
-	}
-
 	err = checkRequiredFlags(ctx)
 	if err != nil {
 		fmt.Printf("You are not inside a linked working directory. "+
@@ -82,27 +66,19 @@ func statusCmd(ctx *cli.Context) error {
 		return nil
 	}
 
-	identity, err := deriveIdentity(ctx, session)
-	if err != nil {
-		return err
-	}
-
 	org := ctx.String("org")
 	project := ctx.String("project")
 	env := ctx.String("environment")
 	service := ctx.String("service")
-	instance := ctx.String("instance")
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "%s:\t%s\n", ui.BoldString("Org"), org)
 	fmt.Fprintf(w, "%s:\t%s\n", ui.BoldString("Project"), project)
 	fmt.Fprintf(w, "%s:\t%s\n", ui.BoldString("Environment"), env)
 	fmt.Fprintf(w, "%s:\t%s\n", ui.BoldString("Service"), service)
-	fmt.Fprintf(w, "%s:\t%s\n", ui.BoldString("Identity"), ui.FaintString(identity))
-	fmt.Fprintf(w, "%s:\t%s\n", ui.BoldString("Instance"), instance)
 	w.Flush()
 
-	parts := []string{"", org, project, env, service, identity, instance}
+	parts := []string{"", org, project, env, service}
 	credPath := strings.Join(parts, "/")
 	fmt.Printf("\n%s: %s\n", ui.BoldString("Credential Path"), credPath)
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -49,7 +49,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, teamsListCmd,
+					checkRequiredFlags, teamsListCmd,
 				),
 			},
 			{
@@ -61,7 +61,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, teamMembersListCmd,
+					checkRequiredFlags, teamMembersListCmd,
 				),
 			},
 			{
@@ -73,7 +73,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, teamsAddCmd,
+					checkRequiredFlags, teamsAddCmd,
 				),
 			},
 			{
@@ -85,7 +85,7 @@ func init() {
 				},
 				Action: chain(
 					ensureDaemon, ensureSession, loadDirPrefs, loadPrefDefaults,
-					setUserEnv, checkRequiredFlags, teamsRemoveCmd,
+					checkRequiredFlags, teamsRemoveCmd,
 				),
 			},
 		},
@@ -181,7 +181,7 @@ func teamsListCmd(ctx *cli.Context) error {
 
 	w.Flush()
 
-	fmt.Printf("\nOrg %s has (%s) member%s\n", org.Body.Name,
+	fmt.Printf("\nOrg %s has (%s) team%s\n", org.Body.Name,
 		ui.FaintString(strconv.Itoa(numTeams)), plural(numTeams))
 
 	return nil

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -46,7 +46,7 @@ func unsetCmd(ctx *cli.Context) error {
 		name = *cname
 	}
 
-	preamble := fmt.Sprintf("You are about to unset \"%s/%s\". This cannot be undone.", pe.String(), name)
+	preamble := fmt.Sprintf("You are about to unset \"%s/%s\". This cannot be undone.", displayPathExp(pe), name)
 
 	success, err := prompts.Confirm(nil, &preamble, true, true)
 	if err != nil {
@@ -69,7 +69,7 @@ func unsetCmd(ctx *cli.Context) error {
 	}
 	s.Stop()
 
-	output := fmt.Sprintf("\nCredential %s has been unset at %s/%s.", name, pe, name)
+	output := fmt.Sprintf("\nCredential %s has been unset at %s/%s.", name, displayPathExp(pe), name)
 	fmt.Println(output)
 
 	return nil

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -85,5 +85,33 @@ func TestTeamPrecedenceSort(t *testing.T) {
 	}
 
 	gm.Expect(foundOrder).Should(gm.Equal(expectedOrder))
+}
 
+func TestPathExpParsing(t *testing.T) {
+	gm.RegisterTestingT(t)
+
+	t.Run("handles **", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pe, err := parsePathExp("/org/silly/**")
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(pe.String()).To(gm.Equal("/org/silly/*/*/*/*"))
+	})
+
+	t.Run("handles no path with instance or identity", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		pe, err := parsePathExp("/org/silly/env/service")
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(pe.String()).To(gm.Equal("/org/silly/env/service/*/*"))
+	})
+
+	t.Run("handles full path", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		path := "/org/silly/env/service/identity/instance"
+		pe, err := parsePathExp(path)
+		gm.Expect(err).To(gm.BeNil())
+		gm.Expect(pe.String()).To(gm.Equal(path))
+	})
 }

--- a/docs/commands/access-control.md
+++ b/docs/commands/access-control.md
@@ -7,6 +7,7 @@ Users in Torus can be grouped into Teams inside an Organization. These teams hav
 Each command within this group must be supplied an Organization flag using `--org <name>`, or `-o <name>` for short. The organization can also be supplied by executing these commands within a [linked directory](./project-structure.md#link).
 
 Organizations have three default teams:
+
 - Member
 - Admin
 - Owner
@@ -19,9 +20,9 @@ Only users who are a member of the "admin" team can manage resources within an o
 
 All teams commands accept the following flags:
 
-  Option | Description
-  ---- | ----
-  --org, ORG, -o ORG | The org the team or teams belong to
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org, ORG, -o ORG | TORUS_ORG | The org the team or teams belong to
 
 ### create
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
@@ -86,9 +87,9 @@ Each command within this group must be supplied an Organization flag using `--or
 
 All policies commands accept the following flags:
 
-  Option | Description
-  ---- | ----
-  --org, ORG, -o ORG | The org the policy or policies belong to
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org, ORG, -o ORG | TORUS_ORG | The org the policy or policies belong to
 
 ### list
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
@@ -146,11 +147,11 @@ If a name (`--name` flag) is not provided, one will be automatically generated.
 
 The `allow` command accepts the following flags:
 
-  Option | Description
-  ----   | -----
-  --org ORG, -o ORG | The org to generate the policy for
-  --name NAME, -n NAME | The name to give the generated policy (e.g. allow-prod-env)
-  --description DESCRIPTION, -d DESCRIPTION | A sentence or two explaining the purpose of the policy
+  Option | Environment Variable | Description
+  ----   | ----- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org to generate the policy for
+  --name NAME, -n NAME | TORUS_NAME | The name to give the generated policy (e.g. allow-prod-env)
+  --description DESCRIPTION, -d DESCRIPTION | TORUS_DESCRIPTION | A sentence or two explaining the purpose of the policy
 
 **Example**
 
@@ -158,7 +159,7 @@ The `allow` command accepts the following flags:
 # Create a policy allowing it's subjects to read secrets from prod environment
 # in the api project which belongs to the myorg organization and attach it to
 # the api-prod-machines machine role.
-$ torus allow -n read-api-prod-env rl /myorg/api/prod/*/*/*/* api-prod-machines
+$ torus allow -n read-api-prod-env rl /myorg/api/prod/** api-prod-machines
 ```
 
 ## deny
@@ -174,9 +175,8 @@ If a name (`--name` flag) is not provided, one will be automatically generated.
 
 The `deny` command accepts the following flags:
 
-  Option | Description
-  ----   | -----
-  --org ORG, -o ORG | The org to generate the policy for
-  --name NAME, -n NAME | The name to give the generated policy (e.g. allow-prod-env)
-  --description DESCRIPTION, -d DESCRIPTION | A sentence or two explaining the purpose of the policy
-
+  Option | Environment Variable | Description
+  ----   | ----- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org to generate the policy for
+  --name NAME, -n NAME | TORUS_NAME | The name to give the generated policy (e.g. allow-prod-env)
+  --description DESCRIPTION, -d DESCRIPTION | TORUS_DESCRIPTION | A sentence or two explaining the purpose of the policy

--- a/docs/commands/organizations.md
+++ b/docs/commands/organizations.md
@@ -21,16 +21,32 @@ Each organization name is globally unique and must adhere to the system naming s
 
 `torus orgs remove [username]` removes the specified user from the specified organization.
 
+#### Command Options
+
+`torus orgs removes` accepts the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org to remove the user from
+
 ### members
 ###### Added [v0.28.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
 `torus orgs members` lists all members within an organization, including their username, name and all the teams they belong to.
 
-**Example**
+#### Command Options
+
+`torus orgs members` accepts the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org to display users from
+
+#### Examples
 
 ```
 $ torus orgs members
-✔ Select organization: matt
+✔ Org: matt
 
     USERNAME   NAME          TEAM
 *   matt       Matt Wright   owner, admin, member
@@ -56,6 +72,14 @@ The keys are used to sign and encrypt the objects you interact with inside Torus
 
 ## worklog
 Torus worklog facilitates maintenance tasks which are generated as a result of actions taken throughout your organization (for example: a secret needs to be rotated due to a user being removed from the org).
+
+#### Command Options
+
+All worklog commands accept the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org to display users from
 
 ### list
 ###### Added [v0.12.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
@@ -86,6 +110,14 @@ Inviting a user to an organization is a multi-step process:
 3.  Admin must approve the invite and complete their induction to the org
 
 Only organization administrators (including owners) may send invitations.
+
+#### Command Options
+
+All invites commands accept the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org the invite belongs to
 
 ### send
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
@@ -127,6 +159,14 @@ Machines are a method of authenticating systems which are not owned by an indivi
 Each machine is given an ID and Token value which are synonymous with a user’s email and password. These are used to authenticate the CLI on a per-system basis.
 
 Machine roles are assigned to each machine for [access control](./access-control.md).
+
+#### Command Options
+
+All machines commands accept the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ---- | ---- 
+  --org ORG, -o ORG | TORUS_ORG | The org the machine or machine role belongs to
 
 ### create
 ###### Added [v0.15.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)

--- a/docs/commands/project-structure.md
+++ b/docs/commands/project-structure.md
@@ -4,6 +4,14 @@ Torus secrets are part of a hierarchy, which is represented by a [path](../conce
 ## projects
 A project is a grouping of services, environments and secrets typically synonymous with a codebase. It is the first level of segmentation inside of an organization.
 
+#### Command Options
+
+All projects commands accept the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org the project belongs to
+
 ### create
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
@@ -23,6 +31,15 @@ A service is an entity synonymous with an application process.
 
 With the advent of micro-service architectures, projects are having more than one application process and in a lot of cases these need unique configuration.
 
+#### Command Options
+
+All services commands accept the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org the service belongs to
+  --project PROJECT, -p PROJECT | TORUS_PROJECT | The project the service belongs to
+
 ### create
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)
 
@@ -41,6 +58,15 @@ An environment is a grouping of services that live within a project which have t
 By default every user in an organization is given a `dev-$username` environment (where $username is the user’s profile username). This is synonymous will a user’s local environment.
 
 Users are also given access to share credentials across all users using the `dev-*` environment. This is a paradigm that exists through the default [access controls](./access-control.md) (and doesn’t actually exist as an environment object for the organization).
+
+#### Command Options
+
+All envs commands accept the following flags:
+
+  Option | Environment Variable | Description
+  ---- | ---- | ----
+  --org ORG, -o ORG | TORUS_ORG | The org the environment belongs to
+  --project PROJECT, -p PROJECT | TORUS_PROJECT | The project the environment belongs to
 
 ### create
 ###### Added [v0.1.0](https://github.com/manifoldco/torus-cli/blob/master/CHANGELOG.md)

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -7,23 +7,12 @@ Typically this information is passed through command options (also known as flag
 For example, when we want to set a secret we could use:
 
 ```
-torus set -o manifold -p guides -s www -e staging port 80 -u * -i *
+torus set -o manifold -p guides -s www -e staging port 80
 ```
 
 Typing each of these command options for every interaction becomes a pain, so the Torus CLI uses context to help infer which resource you're interacting with.
 
 Context is a cascade of values which ultimately determine which resource you're acting upon. Starting with system defaults, then your linked context followed by any command options.
-
-### System default
-
-Each command has its own system default values, where applicable. A definition of the command options can be found either through `torus help` or in the command's documentation.
-
-For example, with `torus set`:
-
-Command Option | Default Value
----- | ----
-Identity | Currently authenticated username or machine name
-Instance | `*`
 
 ### Preference defaults
 

--- a/docs/concepts/path.md
+++ b/docs/concepts/path.md
@@ -7,30 +7,21 @@ The path begins with a forward slash and has seven slash-delimited segments, mos
 - Project
 - Environment
 - Service
-- Identity
-- Instance
 - Secret  
 
 A complete path:
 
 ```
-/org/project/environment/service/identity/instance/secret
+/org/project/environment/service/secret
 ```
 
-Some segments are unique to the path:
-
-Name | Description | Default value
----- | ---- | ----
-Identity | A globally unique username or machine name | Current authenticated username or machine name
-Instance | Unique ID of the accessing process | `*`
 **For example:**
-`/manifoldco/torus-cli/production/docs/cdn/1/token`
+`/manifoldco/torus-cli/production/docs/token`
 
-Commands that take advantage of the path:
+Commands that accept the path:
 
 - [set](../commands/secrets.md#set)
 - [unset](../commands/secrets.md#unset)
-- [ls](../commands/secrets.md#ls)
 - [allow](../commands/access-control.md#allow)
 - [deny](../commands/access-control.md#deny)
 
@@ -40,7 +31,7 @@ Path segments may contain wildcards (with the exception of Organization and Proj
 Wildcards support prefixes, so that you can namespace objects:
 
 ```
-/org/project/env-*/service/identity/instance/secret
+/org/project/env-*/service/secret
 ```
 
 So the value of "secret" is available to all applicable environments that match the wildcard such as: "env-1", "env-development", "env-ironment".
@@ -53,7 +44,7 @@ The following paths are equivalent when supplied to a command:
 
 ```
 /org/project/**/name
-/org/project/*/*/*/*/name
+/org/project/*/*/name
 ```
 
 ## Alternations
@@ -72,11 +63,11 @@ An alternation for the names "one" and "two" is:
 The following would make "secret" available to the "development" and "staging" environments: 
 
 ```
-/org/project/[development|staging]/service/identity/instance/secret
+/org/project/[development|staging]/service/secret
 ```
 
 We can also use wildcards in a segment making "secret" available to the "development" as well as "dev-\*” environments (such as "dev-jane" and "dev-john"):
 
 ```
-/org/project/[dev-*|development]/service/identity/instance/secret
+/org/project/[dev-*|development]/service/secret
 ```

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -4,20 +4,21 @@ Torus CLI has resource-based policies for access control. In order to facilitate
 Policies are attached to teams and machine roles to construct what the members are entitled to access.
 
 ## Default Policies
+
 The three default teams each have their own default policy.
 
 ### Member
+
 Every user added to an organization is automatically made a member of the "member" team and will be given access according to the policy below.
 
 ```
 allow -r--l /${org}/*/[dev-${username}|dev-@]
 allow crudl /${org}/*/[dev-${username}|dev-@]/*
 allow crudl /${org}/*/[dev-${username}|dev-@]/*/*
-allow crudl /${org}/*/[dev-${username}|dev-@]/*/*/*
-allow crudl /${org}/*/[dev-${username}|dev-@]/*/*/*/*
 ```
 
 ### Admin
+
 Through the default admin policy users are given full access to the Torus organization except for adding users to the Owner team.
 
 ```
@@ -28,11 +29,10 @@ allow crudl /${org}/*
 allow crudl /${org}/*/*
 allow crudl /${org}/*/*/*
 allow crudl /${org}/*/*/*/*
-allow crudl /${org}/*/*/*/*/*
-allow crudl /${org}/*/*/*/*/*/*
 ```
 
 ### Owner
+
 Based on the admin policy, owners are given full access to their Torus organization; however, by default they are the only ones permitted to add users to the "owner" team.
 
 ```
@@ -42,9 +42,8 @@ allow crudl /${org}/*
 allow crudl /${org}/*/*
 allow crudl /${org}/*/*/*
 allow crudl /${org}/*/*/*/*
-allow crudl /${org}/*/*/*/*/*
-allow crudl /${org}/*/*/*/*/*/*
 ```
 
 ## Machines
-Unlike users, machines are not automatically given access through default policies. A machine starts out with zero permissions and must have policies attached to its machine role to open its access.
+
+Unlike users, machines are not automatically given access through any default policies but those attached to their machine role.

--- a/docs/start-here/quickstart.md
+++ b/docs/start-here/quickstart.md
@@ -36,17 +36,18 @@ The `link` command will prompt you to select or create an organization and proje
 
 ```sh
 $ torus link
-? Select organization:
-+  Create a new organization
+? Select an org:
++  Create a new org
  ☞ skywalker [personal]
 ```
 
 ```sh
-✔ Select organization: skywalker
-?  Select project: knotty-buoy
+✔ Org: skywalker
+✔ Project: knotty-buoy
 Project knotty-buoy created.
 
 This directory and its subdirectories have been linked to:
+
 Org:     skywalker
 Project: knotty-buoy
 
@@ -63,7 +64,7 @@ A typical application includes at least one service. In a simple app, a service 
 $ torus services list
   Services
   default
-  
+
   Project /skywalker/knotty-buoy has (1) service
 ```
 
@@ -85,21 +86,21 @@ Use `torus set` to encrypt and store two mission-critical secrets.
 ```sh
 $ torus set HELLO 👋
 
-Credential hello has been set at /skywalker/knotty-buoy/dev-skywalker/default/*/1/hello
+Credential hello has been set at /skywalker/knotty-buoy/dev-skywalker/default/hello
 ```
 
 ```
 $ torus set WORLD 🌎
 
-Credential world has been set at /skywalker/knotty-buoy/dev-skywalker/default/*/1/world
+Credential world has been set at /skywalker/knotty-buoy/dev-skywalker/default/world
 ```
 
 Decrypt and view your new secrets.
 
 ```sh
 $ torus view
-HELLO=👋
-WORLD=🌎
+HELLO = 👋
+WORLD = 🌎
 ```
 
 > 😂  &nbsp;Emojis do not make your secrets more secure, but they do make them more entertaining.
@@ -142,11 +143,13 @@ and member. The (*) denotes teams to which we belong.
 
 ```sh
 $ torus teams list
-* owner  [system]
-* admin  [system]
-* member [system]
 
-(*) member
+   Team       Type
+*  owner      system
+*  admin      system
+*  member     system
+
+Org skywalker has (3) teams
 ```
 
 When a user joins your organization, they become a member and are added to the `member` team, which
@@ -200,9 +203,9 @@ Specify the shared `dev-*` environment instead, this is an environment that ever
 members of your organization has access to.
 
 ```sh
-$ torus set PORT 3001 -e dev-*
+$ torus set -e dev-* PORT 3001
 
-Credential port has been set at /skywalker/knotty-buoy/dev-*/default/*/1/port
+Credential port has been set at /skywalker/knotty-buoy/dev-*/default/port
 ```
 
 `PORT` is now a shared secret with a value of `3001` and is available to any member of our
@@ -210,9 +213,9 @@ organization.
 
 ```sh
 $ torus view
-HELLO=👋
-WORLD=🌎
-PORT=3001
+HELLO = 👋
+WORLD = 🌎
+PORT = 3001
 ```
 
 This is a great way to provide a set of default development secrets for an application, as the `run` command
@@ -243,8 +246,8 @@ Create a new staging environment using the `envs create` command.
 
 ```sh
 $ torus envs create staging
-✔ Org name:         skywalker
-✔ Project name:     knotty-buoy
+✔ Org:         skywalker
+✔ Project:     knotty-buoy
 ✔ Environment name: staging
 
 Environment staging created.
@@ -260,8 +263,8 @@ During the create process we will be asked to select or create a team, we create
 
 ```sh
 $ torus machines create api
-✔ Org name: skywalker
-✔ Select Machine Team: api
+✔ Org: skywalker
+✔ Machine Team: api
 ✔ Enter machine name: api-hw1xd09x
 
 You will only be shown the secret once, please keep it safe.
@@ -277,13 +280,13 @@ We make note of the Token ID and Token Secret as we’ll be using those later wh
 Next, we want to restrict the access that our API machines have. Using `torus allow` we’re able to specify access restrictions for our API machines.
 
 ```sh
-$ torus allow rl /skywalker/knotty-buoy/staging/default/*/*/* api
+$ torus allow rl /skywalker/knotty-buoy/staging/default/* api
 Policy generated and attached to the api team.
 
 
 Effect:    allow
 Action(s): read, list
-Resource:  /skywalker/knotty-buoy/staging/default/*/*/*
+Resource:  /skywalker/knotty-buoy/staging/default/*
 
 
 Necessary permissions (read, list) have also been granted

--- a/internal/qa.md
+++ b/internal/qa.md
@@ -56,8 +56,8 @@ If you have `torus` installed, start fresh `npm uninstall -g torus-cli`
 - [ ]   `torus status` will not display a context outside of a linked directory
 - [ ]   `torus link` prompts you to select or create an org, and project
 - [ ]   `torus link -f` will over-write a previous `torus link`
-- [ ]   `torus status` now displays a valid: org, project, environment, service,
-        instance and path
+- [ ]   `torus status` now displays a valid: org, project, environment,
+          service, and path
 - [ ]   Commands can now be executed without the `—org` and `--project` flags
 
 ### Access Controls

--- a/prompts/select.go
+++ b/prompts/select.go
@@ -174,12 +174,12 @@ func find(values []string, name string) int {
 }
 
 func init() {
-	SelectOrg = selectPrompt("Select an Org", "Org", validate.OrgName)
-	SelectCreateOrg = selectCreatePrompt("Select an Org", "Create an Org", "Org", validate.OrgName)
+	SelectOrg = selectPrompt("Select an org", "Org", validate.OrgName)
+	SelectCreateOrg = selectCreatePrompt("Select an org", "Create a new org", "Org", validate.OrgName)
 	SelectRole = selectPrompt("Select a Role", "Machine Role", validate.RoleName)
-	SelectCreateRole = selectCreatePrompt("Select a Role", "Create a Role", "Machine Role", validate.RoleName)
-	SelectTeam = selectPrompt("Select a Team", "Team", validate.TeamName)
-	SelectCreateTeam = selectCreatePrompt("Select a Team", "Create a Team", "Team", validate.TeamName)
-	SelectProject = selectPrompt("Select a Project", "Project", validate.ProjectName)
-	SelectCreateProject = selectCreatePrompt("Select a Project", "Create a Project", "Project", validate.ProjectName)
+	SelectCreateRole = selectCreatePrompt("Select a role", "Create a new role", "Machine Role", validate.RoleName)
+	SelectTeam = selectPrompt("Select a team", "Team", validate.TeamName)
+	SelectCreateTeam = selectCreatePrompt("Select a team", "Create a new team", "Team", validate.TeamName)
+	SelectProject = selectPrompt("Select a project", "Project", validate.ProjectName)
+	SelectCreateProject = selectCreatePrompt("Select a project", "Create a new project", "Project", validate.ProjectName)
 }


### PR DESCRIPTION
After many discussions with users, we've decided to remove the concept
of instance and identity from the torus secret storage mechanism.

A very small amount of users have ever taken advantage of the
functionality whilst it's added a large level of complexity making it
vastly more difficult for a user to onboard and fully take advantage of
torus.

A user can still set/unset a secret for a specific instance/identity
pair by providing the full seven segment path. If a secret has been set
for this level of specificity the full 7 segment path will be displayed
via `torus view` or `torus list`. However, in all other cases, a 5
segment path will be displayed (e.g. `/org/project/env/sevice/secret`).

To support these changes the docs have been updated and expanded where
necessary.