### PR TITLE
Inject project structure via `torus run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ In all other cases, a 5 segment path will be displayed (e.g.
   `identity` or `identity` components are not a `*`.
 - `torus view` and `torus list` will only display the full 7 segment path in
   verbose mode if the `instance` and `identity` components are not a `*`.
+- The current org, project, environment, and service is now injected into the
+  process started by `torus run`.
 
 **Fixes**
 

--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -193,20 +193,39 @@ Items are displayed in environment variable format.
 
 By prefixing your process execution with `torus run` we are able to fetch, decrypt and inject your secrets into the process environment based on the [context](./project-structure.md#link) of the Torus client.
 
-To ensure that your command’s arguments and options are passed correctly you may need to separate your `torus run` definition from your command definition with `--`, for example:
+To ensure that your command’s arguments and options are passed correctly you may need to separate your `torus run` definition from your command definition with `--`.
+
+Torus will inject the current org, project, environment, and service into the processes through the `TORUS_ORG`, `TORUS_PROJECT`, `TORUS_ENVIRONMENT`, and `TORUS_SERVICE` environment variables.
 
 #### Examples
 
 **Injecting secrets into a process using flags**
 
-```
+```bash
 $ torus run -e production -s www -- node ./bin/www --log_level=error
 ```
 
 **Injecting secrets into a process using environment variables**
 
-```
+```bash
 $ TORUS_ENVIRONMENT=production TORUS_SERVICE=www torus run -- node ./bin/www --log_level=error
+```
+
+**Using the project structure environment variables**
+
+```bash
+$ cat example.sh
+#!/usr/bin/bash
+
+echo "org: $TORUS_ORG"
+echo "project: $TORUS_PROJECT"
+echo "env: $TORUS_ENV"
+echo "service: $TORUS_SERVICE"
+$ torus run -- bash example.sh
+org: test
+project: api
+env: dev-test
+service: default
 ```
 
 ## list

--- a/pathexp/pathexp.go
+++ b/pathexp/pathexp.go
@@ -64,6 +64,7 @@ type PathExp struct {
 type segment interface {
 	String() string
 	Contains(subject string) bool
+	Components() []string
 }
 
 type literal string
@@ -75,10 +76,16 @@ func (l literal) String() string { return string(l) }
 func (l literal) Contains(subject string) bool {
 	return string(l) == subject
 }
+func (l literal) Components() []string {
+	return []string{string(l)}
+}
 
 func (g glob) String() string { return string(g) + "*" }
 func (g glob) Contains(subject string) bool {
 	return strings.Index(subject, string(g)) == 0
+}
+func (g glob) Components() []string {
+	return []string{string(g)}
 }
 
 // GlobContains returns whether a glob, built from the value, contains the subject
@@ -90,6 +97,9 @@ func GlobContains(value, subject string) bool {
 func (f fullglob) String() string { return "*" }
 func (f fullglob) Contains(subject string) bool {
 	return true
+}
+func (f fullglob) Components() []string {
+	return []string{"*"}
 }
 
 func (a alternation) String() string {
@@ -112,6 +122,14 @@ func (a alternation) Contains(subject string) bool {
 		}
 	}
 	return false
+}
+func (a alternation) Components() []string {
+	out := make([]string, len(a))
+	for i, v := range a {
+		out[i] = v.String()
+	}
+
+	return out
 }
 
 // compareSegmentType ranks the segments by their type specificity


### PR DESCRIPTION
Torus will now inject the current org, project, environment, and serivce
when a process is executed via `torus run`. These will be accessible via
`TORUS_ORG`, `TORUS_PROJECT`, `TORUS_ENVIRONMENT`, and `TORUS_SERVICE`.

Closes #258