### PR TITLE
No longer warn if not in .git folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ TARGETS=\
 	$(LINUX) \
 	$(WINDOWS)
 
-VERSION?=$(shell git describe --tags --abbrev=0 | sed 's/^v//')
+VERSION=$(shell [ -d .git ] && git describe --tags --abbrev=0 | sed 's/^v//')
+ifeq (,$(VERSION))
+    VERSION=dev
+endif
 
 LINTERS=\
 	gofmt \
@@ -178,7 +181,7 @@ else ifeq (prod,$(RELEASE_ENV))
 endif
 
 tagcheck:
-ifneq (v$(VERSION),$(shell git describe --tags --dirty))
+ifneq (v$(VERSION),$(shell [ -d .git ] && git describe --tags --dirty))
 	$(error "VERSION $(VERSION) is not git HEAD")
 endif
 


### PR DESCRIPTION
A few components of the Makefile were using `git describe` to figure out
the current tag. However, when the container is built it's done outside
of a git repository leading to a ton of non-important error messages
popping up.

Instead, we only call git describe if we're actually in a `.git` folder.