### PR TITLE
Fix bug preventing an error from being mutated

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -268,7 +268,7 @@ func listCmd(ctx *cli.Context) error {
 				credCount++
 				if verbose {
 					credPath := displayPathExp((*cred.Body).GetPathExp()) + "/"
-					fmt.Fprintf(w, "\t\t%s\t(%s)\t\n", c, ui.FaintString(credPath+c))
+					fmt.Fprintf(w, "\t\t%s\t (%s)\t\n", c, ui.FaintString(credPath+c))
 				} else {
 					fmt.Fprintf(w, "\t\t%s\t\t\n", c)
 				}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -33,7 +33,7 @@ func logoutCmd(ctx *cli.Context) error {
 	err = client.Session.Logout(context.Background())
 	if err != nil {
 		if herr, ok := err.(*apitypes.Error); ok {
-			if herr.StatusCode == 404 {
+			if herr.Type == apitypes.NotFoundError {
 				fmt.Println("You are not logged in.")
 				return nil
 			}

--- a/daemon/logic/session.go
+++ b/daemon/logic/session.go
@@ -218,13 +218,14 @@ func (s *Session) Logout(ctx context.Context) error {
 	err := s.engine.client.Tokens.Delete(ctx, string(tok[:]))
 	switch err := err.(type) {
 	case *apitypes.Error:
-		switch {
-		case err.StatusCode >= 500:
+		switch err.Type {
+		case apitypes.InternalServerError:
+
 			// On a 5XX response, we don't know for sure that the server
 			// has successfully removed the auth token. Keep the copy in
 			// the daemon, so the user may try again.
 			return err
-		case err.StatusCode >= 400:
+		case apitypes.NotFoundError, apitypes.BadRequestError, apitypes.UnauthorizedError:
 			// A 4XX error indicates either the token isn't found, or we're
 			// not allowed to remove it (or the server is a teapot).
 			//

--- a/daemon/routes/routes.go
+++ b/daemon/routes/routes.go
@@ -81,7 +81,7 @@ func encodeResponseErr(w http.ResponseWriter, err interface{}) {
 
 	rErr, ok := err.(*apitypes.Error)
 	if ok {
-		w.WriteHeader(rErr.StatusCode)
+		w.WriteHeader(rErr.StatusCode())
 		enc.Encode(rErr)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/daemon/routes/types.go
+++ b/daemon/routes/types.go
@@ -1,8 +1,6 @@
 package routes
 
 import (
-	"net/http"
-
 	"github.com/manifoldco/torus-cli/apitypes"
 )
 
@@ -12,7 +10,6 @@ type errorMsg struct {
 }
 
 var notFoundError = &apitypes.Error{
-	StatusCode: http.StatusNotFound,
-	Type:       apitypes.NotFoundError,
-	Err:        []string{"Not found"},
+	Type: apitypes.NotFoundError,
+	Err:  []string{"Not found"},
 }

--- a/registry/client.go
+++ b/registry/client.go
@@ -133,9 +133,8 @@ func (rt *registryRoundTripper) Do(ctx context.Context, r *http.Request,
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			err = &apitypes.Error{
-				StatusCode: http.StatusRequestTimeout,
-				Type:       "request_timeout",
-				Err:        []string{"Request timed out"},
+				Type: apitypes.RequestTimeoutError,
+				Err:  []string{"Request timed out"},
 			}
 		}
 

--- a/registry/round_tripper.go
+++ b/registry/round_tripper.go
@@ -109,7 +109,7 @@ func checkResponseCode(r *http.Response) error {
 		return nil
 	}
 
-	rErr := &apitypes.Error{StatusCode: r.StatusCode}
+	rErr := &apitypes.Error{Type: apitypes.LookupErrorType(r.StatusCode)}
 	if r.ContentLength != 0 {
 		dec := json.NewDecoder(r.Body)
 		err := dec.Decode(rErr)


### PR DESCRIPTION
In certain circumstances a StatusCode would not be set on an
apitypes.Error. Instead of having to set two properties, I've added a
lookup map for each error type, expanded the error types and added
functionality for converting an error type to a status code nad back.

This should prevent this specific bug from occurring in the future.