### PR TITLE
Add confirm prompt to org removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ In all other cases, a 5 segment path will be displayed (e.g.
 
 **Fixes**
 
-- When asking for a user's complete name, we now refer to it as `Full Name` instead of `Fullname`
+- `torus orgs remove` will now prompt the user to confirm the action before proceed
+- `torus machines destroy` and `torus unset` will default to No instead of Yes
+  when prompting the user to confirm the action.
+- When asking for a user's complete name, we now refer to it as `Full Name`
+  instead of `Fullname`
 - `torus list` did not display secrets which were not set with an instance of `*`.
 
 **Build**

--- a/cmd/machines.go
+++ b/cmd/machines.go
@@ -203,7 +203,7 @@ func destroyMachineCmd(ctx *cli.Context) error {
 	}
 
 	preamble := "You are about to destroy a machine. This cannot be undone."
-	success, err := prompts.Confirm(nil, &preamble, true, true)
+	success, err := prompts.Confirm(nil, &preamble, true, false)
 	if err != nil {
 		return errs.NewErrorExitError("Failed to retrieve confirmation", err)
 	}

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -226,6 +226,15 @@ func orgsRemove(ctx *cli.Context) error {
 		return errs.NewExitError(userNotFound)
 	}
 
+	preamble := fmt.Sprintf("You are about to remove %s from the org %s.", ui.FaintString(profile.Body.Username), org.Body.Name)
+	success, err := prompts.Confirm(nil, &preamble, true, false)
+	if err != nil {
+		return errs.NewErrorExitError("Failed to retrieve confirmation", err)
+	}
+	if !success {
+		return errs.ErrAbort
+	}
+
 	err = client.Orgs.RemoveMember(c, *org.ID, *profile.ID)
 	if apitypes.IsNotFoundError(err) {
 		fmt.Println("User is not a member of the org.")

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -162,10 +162,3 @@ func createServiceCmd(ctx *cli.Context) error {
 	fmt.Printf("Service %s created.\n", serviceName)
 	return nil
 }
-
-func plural(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
-}

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -396,6 +396,16 @@ func teamsRemoveCmd(ctx *cli.Context) error {
 		)
 	}
 
+	preamble := fmt.Sprintf("You are about to remove %s from the %s team in the %s org.",
+		ui.FaintString(user.Body.Username), team.Body.Name, org.Body.Name)
+	success, err := prompts.Confirm(nil, &preamble, true, false)
+	if err != nil {
+		return errs.NewErrorExitError("Failed to retrieve confirmation", err)
+	}
+	if !success {
+		return errs.ErrAbort
+	}
+
 	// Lookup their membership row
 	memberships, mErr := client.Memberships.List(c, org.ID, team.ID, user.ID)
 	if mErr != nil || len(memberships) < 1 {

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -48,7 +48,7 @@ func unsetCmd(ctx *cli.Context) error {
 
 	preamble := fmt.Sprintf("You are about to unset \"%s/%s\". This cannot be undone.", displayPathExp(pe), name)
 
-	success, err := prompts.Confirm(nil, &preamble, true, true)
+	success, err := prompts.Confirm(nil, &preamble, true, false)
 	if err != nil {
 		return errs.NewErrorExitError("Failed to retrieve confirmation", err)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -288,3 +288,10 @@ func toTeamNameMap(teams []envelope.Team) map[string]envelope.Team {
 	}
 	return teamNamesToTeam
 }
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}


### PR DESCRIPTION
Org removal was missing a confirmation prompt while unset and machine
destroy were defaulting to "yes" instead of "no" when prompting the
user.