### PR TITLE
Automatically upload binaries to GitHub Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,11 @@ release-all: githubcheck envcheck tagcheck $(RELEASE_TARGETS) $(TOOLS)/cdn-index
 		--exclude "*/repomd.xml" \
 		$(foreach distro,debian ubuntu,$(foreach dir,conf db dists,--exclude "$(distro)/$(dir)/*"))
 	AWS_REGION=us-east-1 $(TOOLS)/cdn-indexer -bucket s3://$(TORUS_S3_BUCKET)
-	$(TOOLS)/gh-releaser
+	$(TOOLS)/gh-releaser reindex
+
+ifeq (prod,$(RELEASE_ENV))
+	$(TOOLS)/gh-releaser upload $(VERSION) builds/dist/$(VERSION)
+endif
 
 	@echo
 	@printf "=%.0s" {1..$(COLS)}


### PR DESCRIPTION
Starting with `v0.29.0` we began uplaoding the binaries to the GitHub
Release along with the Torus CDN at `get.torus.sh`.

To ensure these releases are always available, I've updated the
gh-releaser tool to support upload binaries from a folder which will
only be done for production releases.