### PR TITLE
Spinners obey core.progress pref and unblock view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## Unreleased
+
+_YYYY-MM-DD_
+
+**Fixes**
+
+- The spinners released in `v0.30.0` can now be disabled by setting the
+  `core.progress` preference to false via `torus prefs set core.progress
+  false`.
+- Fixed a bug where the spinner during `torus run`, `torus view`, or `torus
+  export` would not be removed resulting in a stuck state for users.
+
 ## v0.30.0
 
 _2018-03-11_

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,12 +14,6 @@ import (
 // Cmds is the list of all cli commands
 var Cmds []cli.Command
 
-var progress api.ProgressFunc = func(evt *api.Event, err error) {
-	if evt != nil {
-		ui.Progress(evt.Message)
-	}
-}
-
 func spinner(text string) (*ui.Spinner, api.ProgressFunc) {
 	s := ui.NewSpinner(text)
 

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -106,7 +106,7 @@ func signup(ctx *cli.Context, subCommand bool) error {
 	c := context.Background()
 
 	fmt.Println("")
-	user, err := client.Users.Create(c, &signup, &progress)
+	user, err := client.Users.Create(c, &signup, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "resource exists") {
 			return errs.NewExitError("Username or email address in use.")
@@ -115,7 +115,7 @@ func signup(ctx *cli.Context, subCommand bool) error {
 	}
 
 	// Log the user in
-	err = performLogin(c, client, user.Email(), password, true)
+	err = performLogin(c, client, user.Email(), password, false)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func signup(ctx *cli.Context, subCommand bool) error {
 	}
 
 	fmt.Println("")
-	fmt.Println("Your account has been created!")
+	fmt.Println("Your account has been created, and you've been logged in!")
 
 	if !subCommand {
 		fmt.Println("")

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -105,8 +105,8 @@ func getSecrets(ctx *cli.Context) ([]apitypes.CredentialEnvelope, *pathexp.PathE
 
 	s, p := spinner("Decrypting credentials")
 	s.Start()
+	defer s.Stop()
 	secrets, err := client.Credentials.Get(c, path.String(), p)
-	s.Stop()
 	if err != nil {
 		return nil, nil, errs.NewErrorExitError("Error fetching secrets", err)
 	}

--- a/ui/spinner.go
+++ b/ui/spinner.go
@@ -10,25 +10,35 @@ import (
 type Spinner struct {
 	spinner *spinner.Spinner
 	text    string
+	enabled bool
 }
 
-// NewSpinner creates a new Spinner struct
-func NewSpinner(text string) *Spinner {
+// newSpinner creates a new Spinner struct
+func newSpinner(text string, enabled bool) *Spinner {
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	s.Suffix = " " + text
 	return &Spinner{
 		s,
 		text,
+		enabled,
 	}
 }
 
 // Start displays the Spinner and starts movement
 func (s *Spinner) Start() {
+	if !s.enabled {
+		return
+	}
+
 	s.spinner.Start()
 }
 
 // Stop halts the spiner movement and removes it from display
 func (s *Spinner) Stop() {
+	if !s.enabled {
+		return
+	}
+
 	s.spinner.Stop()
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -56,40 +56,14 @@ type UI struct {
 	EnableColors bool
 }
 
+// NewSpinner calls NewSpinner on the default UI
+func NewSpinner(text string) *Spinner {
+	return defUI.NewSpinner(text)
+}
+
 // NewSpinner creates a new ui.Spinner struct (spinner.go)
 func (u *UI) NewSpinner(text string) *Spinner {
-	return NewSpinner(text)
-}
-
-// StartSpinner checks to ensure progress is enabled and the output is a
-// terminal. After that, it starts the ui.Spinner spinning.
-func (u *UI) StartSpinner(s *Spinner) {
-	if !u.EnableProgress || !readline.IsTerminal(int(os.Stdout.Fd())) {
-		return
-	}
-
-	s.Start()
-}
-
-// StopSpinner checks to ensure progress is enabled and the output is a
-// terminal. After that, it stops the ui.Spinner spinning.
-func (u *UI) StopSpinner(s *Spinner) {
-	if !u.EnableProgress || !readline.IsTerminal(int(os.Stdout.Fd())) {
-		return
-	}
-
-	s.Stop()
-}
-
-// Progress calls Progress on the default UI
-func Progress(str string) { defUI.Progress(str) }
-
-// Progress handles the ui output for progress events, when enabled
-func (u *UI) Progress(str string) {
-	if !u.EnableProgress {
-		return
-	}
-	u.Line(str)
+	return newSpinner(text, u.EnableProgress && Attached())
 }
 
 // Line calls Line on the default UI


### PR DESCRIPTION
We had expoed spinners through a few different apis in the ui layer, as
a result some were obeying the `core.progress` preference while others
were not. I've fixed this by pushing the responsibility for checking
whether a spinner should/is displayed into the actual spinner itself.

At the sametime, I've fixed a bug where it was possible for a spinner to
never be removed due to a panic.

Closes #376 #377