### PR TITLE
Fix prefs set when not on darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ _YYYY-MM-DD_
 - The spinners released in `v0.30.0` can now be disabled by setting the
   `core.progress` preference to false via `torus prefs set core.progress
   false`.
+- Fixed a bug where spinners were enabled for sessions not attached to a
+  terminal such as in a CI environment or on a server.
 - Fixed a bug where the spinner during `torus run`, `torus view`, or `torus
   export` would not be removed resulting in a stuck state for users.
+- Fixed a bug preventing non-Mac OS X users from setting preferences via `torus
+  prefs set`.
 
 ## v0.30.0
 

--- a/cmd/prefs.go
+++ b/cmd/prefs.go
@@ -133,7 +133,11 @@ func setPrefByName(key, value string) error {
 	}
 
 	// Save updated ini to filePath
-	rcPath, _ := prefs.RcPath()
+	rcPath, err := prefs.RcPath()
+	if err != nil {
+		return errs.NewErrorExitError("Faled to save preferences.", err)
+	}
+
 	err = cfg.SaveTo(rcPath)
 	if err != nil {
 		return errs.NewErrorExitError("Failed to save preferences.", err)

--- a/prefs/prefs.go
+++ b/prefs/prefs.go
@@ -2,8 +2,6 @@ package prefs
 
 import (
 	"os"
-	"os/user"
-	"path"
 	"reflect"
 	"strings"
 
@@ -118,15 +116,6 @@ func findElemByName(values reflect.Value, iniField string) string {
 	return fieldName
 }
 
-// RcPath returns the torusrc filepath
-func RcPath() (string, error) {
-	u, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-	return path.Join(u.HomeDir, rcFilename), nil
-}
-
 // NewPreferences returns a new instance of preferences struct
 func NewPreferences() (*Preferences, error) {
 	prefs := &Preferences{
@@ -152,7 +141,6 @@ func NewPreferences() (*Preferences, error) {
 		return prefs, err
 	}
 
-	rcPath, _ := RcPath()
-	err = ini.MapTo(prefs, rcPath)
+	err = ini.MapTo(prefs, filePath)
 	return prefs, err
 }

--- a/prefs/rcpath.go
+++ b/prefs/rcpath.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package prefs
+
+import (
+	"errors"
+	"os"
+	"path"
+)
+
+// ErrMissingHome represents an error where the $HOME dir could not be found
+var ErrMissingHome = errors.New("Could not establish users home directory, is $HOME set?")
+
+// RcPath returns the torusrc filepath
+func RcPath() (string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", ErrMissingHome
+	}
+
+	return path.Join(home, rcFilename), nil
+}

--- a/prefs/rcpath_windows.go
+++ b/prefs/rcpath_windows.go
@@ -1,0 +1,25 @@
+package prefs
+
+import (
+	"errors"
+	"os"
+	"path"
+)
+
+// ErrMissingHome represents an error where the $HOMEDIR and/or $HOMEDRIVE
+var ErrMissingHome = errors.New("Could not establish users home directory, is %HOMEDRIVE and %HOME set?")
+
+// RcPath returns the torusrc filepath
+func RcPath() (string, error) {
+	homedrive := os.Getenv("HOMEDRIVE")
+	if homedrive == "" {
+		return "", ErrMissingHome
+	}
+
+	homedir := os.Getenv("HOMEDIR")
+	if homedir == "" {
+		return "", ErrMissingHome
+	}
+
+	return path.Join(homedrive, homedir, rcFilename), nil
+}


### PR DESCRIPTION
If a user attempted to set a preference on a non-darwin operating system
it would fail silently. This is because we were ignoring errors from
`user.Current()` which requires c-go to get the current user.

Since we're not building Torus with c-go (on purpose), we'd get an error
back when we called that method on linux or windows. I've worked around
this by writing a shim and no longer using `user.Current()`.

Closes #375